### PR TITLE
修改Option的value prop限制；增加slot与slot[name=label]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 ## 待定
 
 ### ⚠️ 非兼容性变更
-* [^] `select/Option`新增整个 OptionItem 级别的默认slot，原默认slot更改为`slot[name=label]`
-* [^] `select/Option`原`slot[name=option]`更新对齐到`select/Option#slot[name=default]`；新增`slot[name=option-label]`对齐到`select/Option#slot[name=label]`
+* [^] 为 `Select` 用名为 `option-label` 的 scoped slot 替代了原来的 `option`。原来的 `option` 现在为整个选项的内容，包括文本和图标等。
 
 ### 💡 主要变更
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 待定
 
+### ⚠️ 非兼容性变更
+* [^] `select/Option`新增整个 OptionItem 级别的默认slot，原默认slot更改为`slot[name=label]`
+* [^] `select/Option`原`slot[name=option]`更新对齐到`select/Option#slot[name=default]`；新增`slot[name=option-label]`对齐到`select/Option#slot[name=label]`
+
 ### 💡 主要变更
 
 * [+] 新增 `resize` 指令。

--- a/packages/veui/demo/cases/Select.vue
+++ b/packages/veui/demo/cases/Select.vue
@@ -59,7 +59,7 @@
       <veui-select v-bind="optGroupAttrs" v-model="defaultValue8" :overlay-options="{
           position: 'bottom right'
         }">
-        <template slot="option" scope="props">
+        <template slot="optionLabel" scope="props">
           <span class="veui-option-label-text">{{ props.label }}</span>
           <icon name="gift"></icon>
         </template>

--- a/packages/veui/demo/cases/Select.vue
+++ b/packages/veui/demo/cases/Select.vue
@@ -17,7 +17,7 @@
       <h2>Slot[name=option-label] 样式：</h2>
       <veui-select v-bind="attrs" v-model="defaultValue3" ui="alt">
         <template slot="option-label" scope="props">
-          <span class="veui-option-custom">{{ props.label }}</span>
+          <span class="veui-option-custom-label">{{ props.label }}</span>
         </template>
       </veui-select>
     </section>
@@ -55,7 +55,7 @@
       </veui-select>
     </section>
     <section>
-      <h2>Slot 分组样式 2：</h2>
+      <h2>Slot[name=option-label] 分组样式 2：</h2>
       <veui-select v-bind="optGroupAttrs" v-model="defaultValue8" :overlay-options="{
           position: 'bottom right'
         }">
@@ -239,6 +239,21 @@ export default {
 
   .veui-icon {
     margin-left: 5px;
+  }
+}
+.veui-option-custom {
+  position: relative;
+  padding-left: 10px;
+  &::after {
+    content: '❤️';
+    position: absolute;
+    top: 50%;
+    left: -10px;
+    transform: translateY(-50%);
+  }
+
+  &-label {
+    color: rgb(80, 170, 39);
   }
 }
 </style>

--- a/packages/veui/demo/cases/Select.vue
+++ b/packages/veui/demo/cases/Select.vue
@@ -59,7 +59,7 @@
       <veui-select v-bind="optGroupAttrs" v-model="defaultValue8" :overlay-options="{
           position: 'bottom right'
         }">
-        <template slot="optionLabel" scope="props">
+        <template slot="option-label" scope="props">
           <span class="veui-option-label-text">{{ props.label }}</span>
           <icon name="gift"></icon>
         </template>

--- a/packages/veui/demo/cases/Select.vue
+++ b/packages/veui/demo/cases/Select.vue
@@ -14,10 +14,10 @@
       <veui-select v-bind="attrs" v-model="defaultValue1" disabled></veui-select>
     </section>
     <section>
-      <h2>Slot 样式：</h2>
+      <h2>Slot[name=option-label] 样式：</h2>
       <veui-select v-bind="attrs" v-model="defaultValue3" ui="alt">
-        <template slot="option" scope="props">
-          {{ props.label }}
+        <template slot="option-label" scope="props">
+          <span class="veui-option-custom">{{ props.label }}</span>
         </template>
       </veui-select>
     </section>
@@ -50,7 +50,7 @@
       <h2>Slot 分组样式 1：</h2>
       <veui-select v-bind="optGroupAttrs" v-model="defaultValue7">
         <template slot="option" scope="props">
-          {{ props.label }}
+          <div class="veui-option-custom">{{ props.label }}</div>
         </template>
       </veui-select>
     </section>
@@ -60,7 +60,7 @@
           position: 'bottom right'
         }">
         <template slot="option-label" scope="props">
-          <span class="veui-option-label-text">{{ props.label }}</span>
+          <span class="veui-option-label-text veui-option-custom-label">{{ props.label }}</span>
           <icon name="gift"></icon>
         </template>
       </veui-select>

--- a/packages/veui/src/components/Select/Option.vue
+++ b/packages/veui/src/components/Select/Option.vue
@@ -6,8 +6,10 @@
     'veui-option-selected': selected
   }"
   @click.stop="select">
-  <span class="veui-option-label"><slot>{{ label }}</slot></span>
-  <icon class="veui-option-checkmark" v-if="selected" :name="icons.checked"></icon>
+  <slot>
+    <span class="veui-option-label"><slot name="label">{{ label }}</slot></span>
+    <icon class="veui-option-checkmark" v-if="selected" :name="icons.checked"></icon>
+  </slot>
 </div>
 </template>
 
@@ -23,7 +25,9 @@ export default {
   },
   props: {
     label: [String, Number],
-    value: [String, Number],
+    value: {
+      required: true
+    },
     disabled: {
       type: Boolean,
       default: false

--- a/packages/veui/src/components/Select/Select.vue
+++ b/packages/veui/src/components/Select/Select.vue
@@ -39,7 +39,9 @@
               :key="subOption.value"
               @select="handleSelect(subOption)">
               <slot v-if="$scopedSlots.option" name="option" v-bind="subOption" :selected="option.value === value"></slot>
-              <slot v-if="$scopedSlots.optionLabel" name="option-label" v-bind="subOption" :selected="option.value === value"></slot>
+              <template v-if="$scopedSlots['option-label']" slot="label">
+                <slot name="option-label" v-bind="subOption" :selected="option.value === value"></slot>
+              </template>
             </veui-option>
           </div>
           <veui-option
@@ -50,7 +52,9 @@
             :key="option.value"
             @select="handleSelect(option)">
             <slot v-if="$scopedSlots.option" name="option" v-bind="option" :selected="option.value === value"></slot>
-            <slot v-if="$scopedSlots.optionLabel" name="option-label"  v-bind="option" :selected="option.value === value"></slot>
+            <template v-if="$scopedSlots['option-label']" slot="label">
+              <slot name="option-label" v-bind="option" :selected="option.value === value"></slot>
+            </template>
           </veui-option>
         </template>
       </slot>

--- a/packages/veui/src/components/Select/Select.vue
+++ b/packages/veui/src/components/Select/Select.vue
@@ -39,7 +39,7 @@
               :key="subOption.value"
               @select="handleSelect(subOption)">
               <slot v-if="$scopedSlots.option" name="option" v-bind="subOption" :selected="option.value === value"></slot>
-              <slot v-if="$scopedSlots.option-label" name="optionLabel" v-bind="subOption" :selected="option.value === value"></slot>
+              <slot v-if="$scopedSlots.optionLabel" name="option-label" v-bind="subOption" :selected="option.value === value"></slot>
             </veui-option>
           </div>
           <veui-option

--- a/packages/veui/src/components/Select/Select.vue
+++ b/packages/veui/src/components/Select/Select.vue
@@ -50,7 +50,7 @@
             :key="option.value"
             @select="handleSelect(option)">
             <slot v-if="$scopedSlots.option" name="option" v-bind="option" :selected="option.value === value"></slot>
-            <slot v-if="$scopedSlots.option-label" name="optionLabel"  v-bind="option" :selected="option.value === value"></slot>
+            <slot v-if="$scopedSlots.optionLabel" name="option-label"  v-bind="option" :selected="option.value === value"></slot>
           </veui-option>
         </template>
       </slot>

--- a/packages/veui/src/components/Select/Select.vue
+++ b/packages/veui/src/components/Select/Select.vue
@@ -38,7 +38,8 @@
               :selected="subOption.value === value"
               :key="subOption.value"
               @select="handleSelect(subOption)">
-              <slot name="option" v-bind="subOption" :selected="option.value === value"></slot>
+              <slot v-if="$scopedSlots.option" name="option" v-bind="subOption" :selected="option.value === value"></slot>
+              <slot v-if="$scopedSlots.optionLabel" name="optionLabel" v-bind="subOption" :selected="option.value === value"></slot>
             </veui-option>
           </div>
           <veui-option
@@ -48,7 +49,8 @@
             :selected="option.value === value"
             :key="option.value"
             @select="handleSelect(option)">
-            <slot name="option" v-bind="option" :selected="option.value === value"></slot>
+            <slot v-if="$scopedSlots.option" name="option" v-bind="option" :selected="option.value === value"></slot>
+            <slot v-if="$scopedSlots.optionLabel" name="optionLabel"  v-bind="option" :selected="option.value === value"></slot>
           </veui-option>
         </template>
       </slot>

--- a/packages/veui/src/components/Select/Select.vue
+++ b/packages/veui/src/components/Select/Select.vue
@@ -39,7 +39,7 @@
               :key="subOption.value"
               @select="handleSelect(subOption)">
               <slot v-if="$scopedSlots.option" name="option" v-bind="subOption" :selected="option.value === value"></slot>
-              <slot v-if="$scopedSlots.optionLabel" name="optionLabel" v-bind="subOption" :selected="option.value === value"></slot>
+              <slot v-if="$scopedSlots.option-label" name="optionLabel" v-bind="subOption" :selected="option.value === value"></slot>
             </veui-option>
           </div>
           <veui-option
@@ -50,7 +50,7 @@
             :key="option.value"
             @select="handleSelect(option)">
             <slot v-if="$scopedSlots.option" name="option" v-bind="option" :selected="option.value === value"></slot>
-            <slot v-if="$scopedSlots.optionLabel" name="optionLabel"  v-bind="option" :selected="option.value === value"></slot>
+            <slot v-if="$scopedSlots.option-label" name="optionLabel"  v-bind="option" :selected="option.value === value"></slot>
           </veui-option>
         </template>
       </slot>


### PR DESCRIPTION
本次修改如下：
1. 修改select/Option的props#value的要求，可以使任何值
2. 更新select/Option成两个slot. slot[name=default]和slot[name=label]

对这demo对比了一下，正常来说并无影响