### PR TITLE
bugfix: init prevNode with parentNode

### DIFF
--- a/packages/veui/src/managers/overlay.js
+++ b/packages/veui/src/managers/overlay.js
@@ -194,7 +194,7 @@ export class Tree {
     const node = this.nodeMap[startNodeId].node
     const parentNode = node.parent
 
-    let prevNode
+    let prevNode = parentNode
     let isEncountered = false
     let baseZIndex
     parentNode.iterateChildren((child) => {


### PR DESCRIPTION
直接遍历 parentNode 的 children 的时候，判断的是未初始化的 prevNode，这个逻辑永远是设置不了 parentNode 的一级 child 的zIndex