### PR TITLE
去除 `Progress` 组件对 `ui` 值的依赖

### DIFF
--- a/packages/veui-theme-one/components/Progress.js
+++ b/packages/veui-theme-one/components/Progress.js
@@ -7,7 +7,15 @@ config.defaults({
   },
   ui: {
     size: {
-      values: ['tiny']
+      values: ['tiny'],
+      data: {
+        default: {
+          radius: 60
+        },
+        tiny: {
+          radius: 13
+        }
+      }
     }
   }
 }, 'progress')

--- a/packages/veui/src/components/Icon.vue
+++ b/packages/veui/src/components/Icon.vue
@@ -1,19 +1,19 @@
 <template>
-<icon class="veui-icon" v-bind="$props"><slot/></icon>
+<fa-icon class="veui-icon" v-bind="$props"><slot/></fa-icon>
 </template>
 <script>
-import Icon from 'vue-awesome/components/Icon'
+import FaIcon from 'vue-awesome/components/Icon'
 import ui from '../mixins/ui'
 
 export default {
   name: 'veui-icon',
   mixins: [ui],
   components: {
-    Icon
+    FaIcon
   },
-  props: Icon.props,
-  data: Icon.data,
-  computed: Icon.computed,
-  register: Icon.register
+  props: FaIcon.props,
+  data: FaIcon.data,
+  computed: FaIcon.computed,
+  register: FaIcon.register
 }
 </script>

--- a/packages/veui/src/components/Pagination.vue
+++ b/packages/veui/src/components/Pagination.vue
@@ -25,14 +25,14 @@
         :native="native"
         :disabled="page === 1"
         @click="handleRedirect(pageNavHref.previous.page, $event)">
-        <icon :name="icons.prev"></icon>
+        <veui-icon :name="icons.prev"/>
       </veui-link>
       <veui-link class="veui-pager-next"
         :to="page === pageCount ? '' : pageNavHref.next.href"
         :native="native"
         :disabled="page === pageCount || pageCount === 0"
         @click="handleRedirect(pageNavHref.next.page, $event)">
-        <icon :name="icons.next"></icon>
+        <veui-icon :name="icons.next"/>
       </veui-link>
     </div>
   </div>
@@ -78,7 +78,7 @@ export default {
   name: 'veui-pagination',
   mixins: [ui],
   components: {
-    Icon,
+    'veui-icon': Icon,
     'veui-link': Link,
     'veui-select': Select,
     'veui-option': Option

--- a/packages/veui/src/components/Progress.vue
+++ b/packages/veui/src/components/Progress.vue
@@ -6,9 +6,9 @@
     }"></div>
   </div>
   <svg v-else-if="type === 'circular'" class="veui-progress-circle"
-    :width="(radius + 1) * 2" :height="(radius + 1) * 2">
-    <circle class="veui-progress-rail" :cx="radius + 1" :cy="radius + 1" :r="radius" fill="none" stroke-width="2"></circle>
-    <circle class="veui-progress-meter" :cx="radius + 1" :cy="radius + 1" :r="radius" fill="none" stroke-width="2"
+    :width="(radius + halfStroke) * 2" :height="(radius + halfStroke) * 2">
+    <circle class="veui-progress-rail" :cx="radius + halfStroke" :cy="radius + halfStroke" :r="radius" fill="none" :stroke-width="stroke"></circle>
+    <circle class="veui-progress-meter" :cx="radius + halfStroke" :cy="radius + halfStroke" :r="radius" fill="none" :stroke-width="stroke"
       :stroke-dasharray="circumference" :stroke-dashoffset="circumference * (1 - ratio)"></circle>
   </svg>
   <div v-if="desc" class="veui-progress-desc">
@@ -28,8 +28,8 @@
 import ui from '../mixins/ui'
 import Icon from './Icon'
 
-const RADIUS_NORMAL = 60
-const RADIUS_TINY = 13
+const RADIUS_DEFAULT = 60
+const STROKE_DEFAULT = 2
 
 export default {
   name: 'veui-progress',
@@ -91,7 +91,13 @@ export default {
       return 2 * Math.PI * this.radius
     },
     radius () {
-      return this.uiProps.size === 'tiny' ? RADIUS_TINY : RADIUS_NORMAL
+      return this.uiData.radius || RADIUS_DEFAULT
+    },
+    stroke () {
+      return this.uiData.stroke || STROKE_DEFAULT
+    },
+    halfStroke () {
+      return this.stroke / 2
     }
   },
   watch: {

--- a/packages/veui/src/components/Searchbox.vue
+++ b/packages/veui/src/components/Searchbox.vue
@@ -33,7 +33,7 @@
         :disabled="realDisabled"
         v-if="localValue"
         @click.stop="clear">
-        <icon :name="icons.clear"></icon>
+        <veui-icon :name="icons.clear"/>
       </button>
       <button class="veui-searchbox-icon veui-searchbox-icon-search"
         ref="search"
@@ -41,7 +41,7 @@
         :readonly="realReadonly"
         :disabled="realDisabled"
         @click.stop="search">
-        <icon :name="icons.search"></icon>
+        <veui-icon :name="icons.search"/>
         <veui-button :ui="ui"
           :readonly="realReadonly"
           :disabled="realDisabled">搜索</veui-button>
@@ -89,7 +89,7 @@ export default {
   mixins: [ui, input, dropdown, overlay],
   components: {
     'veui-input': Input,
-    Icon,
+    'veui-icon': Icon,
     'veui-overlay': Overlay,
     'veui-button': Button
   },

--- a/packages/veui/src/components/Select/Option.vue
+++ b/packages/veui/src/components/Select/Option.vue
@@ -11,7 +11,7 @@
   @click.stop="selectOption">
   <slot>
     <span class="veui-option-label"><slot name="label">{{ label }}</slot></span>
-    <icon class="veui-option-checkmark" v-if="selected" :name="icons.checked"></icon>
+    <veui-icon class="veui-option-checkmark" v-if="selected" :name="icons.checked"/>
   </slot>
 </button>
 </template>
@@ -27,7 +27,7 @@ export default {
   name: 'veui-option',
   mixins: [ui, menu, select],
   components: {
-    Icon
+    'veui-icon': Icon
   },
   props: {
     label: {

--- a/packages/veui/src/components/Uploader.vue
+++ b/packages/veui/src/components/Uploader.vue
@@ -6,8 +6,8 @@
           (maxCount > 1 && fileList.length >= maxCount) ||
           (requestMode === 'iframe' && isSubmiting)}"
         @click="replacingFile = null" ref="label">
-        <slot name="button-label"><icon class="veui-uploader-input-label-icon"
-          :name="icons.upload"></icon>选择文件</slot>
+        <slot name="button-label"><veui-icon class="veui-uploader-input-label-icon"
+          :name="icons.upload"/>选择文件</slot>
         <input :id="inputId" hidden type="file" ref="input"
           @change="handleNewFiles"
           :name="name"
@@ -20,9 +20,9 @@
       </label>
       <span v-if="$slots.desc" class="veui-uploader-tip"><slot name="desc"/></span>
       <span class="veui-uploader-error">
-        <template v-if="error.typeInvalid"><slot name="type-invalid"><icon :name="icons.alert"></icon>文件的类型不符合要求</slot></template>
-        <template v-if="error.sizeInvalid"><slot name="size-invalid"><icon :name="icons.alert"></icon>文件的大小不符合要求</slot></template>
-        <template v-if="error.countOverflow"><slot name="count-overflow"><icon :name="icons.alert"></icon>文件的数量超过限制</slot></template>
+        <template v-if="error.typeInvalid"><slot name="type-invalid"><veui-icon :name="icons.alert"/>文件的类型不符合要求</slot></template>
+        <template v-if="error.sizeInvalid"><slot name="size-invalid"><veui-icon :name="icons.alert"/>文件的大小不符合要求</slot></template>
+        <template v-if="error.countOverflow"><slot name="count-overflow"><veui-icon :name="icons.alert"/>文件的数量超过限制</slot></template>
       </span>
     </div>
     <ul :class="listClass">
@@ -31,7 +31,7 @@
           || type === 'image' && (!file.status || file.status === 'success')">
           <slot name="file" :file="file">
             <template v-if="type === 'file'">
-              <icon :name="icons.file" class="veui-uploader-list-icon"></icon>
+              <veui-icon :name="icons.file" class="veui-uploader-list-icon"/>
               <span class="veui-uploader-list-name"
                 :class="{'veui-uploader-list-name-success': file.status === 'success',
                   'veui-uploader-list-name-failure': file.status === 'failure'
@@ -41,8 +41,8 @@
               <span v-if="file.status === 'failure'" class="veui-uploader-failure" :ref="`fileFailure${index}`">
                 <slot name="failure-label">上传失败</slot>
               </span>
-              <veui-button v-if="file.status === 'failure'" ui="link" @click="retry(file)" :class="listClass + '-retry'"><icon :name="icons.redo"></icon>重试</veui-button>
-              <veui-button class="veui-uploader-button-remove" ui="link" @click="removeFile(file)" :disabled="realUneditable"><icon :name="icons.clear"></icon></veui-button>
+              <veui-button v-if="file.status === 'failure'" ui="link" @click="retry(file)" :class="listClass + '-retry'"><veui-icon :name="icons.redo"/>重试</veui-button>
+              <veui-button class="veui-uploader-button-remove" ui="link" @click="removeFile(file)" :disabled="realUneditable"><veui-icon :name="icons.clear"/></veui-button>
               <veui-tooltip position='top' :target="`fileFailure${index}`">{{ file.failureReason }}</veui-tooltip>
             </template>
             <template v-else>
@@ -52,14 +52,14 @@
                   class="veui-button"
                   :class="{'veui-uploader-input-label-disabled': realUneditable}"
                   @click.stop="replaceFile(file)">重新上传</label>
-                <veui-button @click="removeFile(file)" :disabled="realUneditable" :class="`${listClass}-mask-remove`"><icon :name="icons.clear"></icon>移除</veui-button>
+                <veui-button @click="removeFile(file)" :disabled="realUneditable" :class="`${listClass}-mask-remove`"><veui-icon :name="icons.clear"/>移除</veui-button>
               </div>
             </template>
             <transition name="veui-uploader-fade">
               <div v-if="type === 'image' && file.status === 'success'"
                 :class="listClass + '-success'"
                 @click="updateFileList(file, {status: null})">
-                <span class="veui-uploader-success"><slot name="success-label"><icon :name="icons.success"></icon>完成</slot></span>
+                <span class="veui-uploader-success"><slot name="success-label"><veui-icon :name="icons.success"/>完成</slot></span>
               </div>
             </transition>
           </slot>
@@ -73,7 +73,7 @@
             </veui-uploader-progress>
             <veui-button v-if="type === 'file'" ui="link"
               class="veui-uploader-button-remove"
-              @click="cancelFile(file)"><icon :name="icons.clear"></icon></veui-button>
+              @click="cancelFile(file)"><veui-icon :name="icons.clear"/></veui-button>
             <veui-button v-else ui="aux operation"
               @click="cancelFile(file)">取消</veui-button>
           </slot>
@@ -85,7 +85,7 @@
             </div>
             <veui-button ui="aux operation" @click="retry(file)">重试</veui-button>
             <veui-button ui="link" @click="removeFile(file)"
-              :class="`${listClass}-mask-remove ${listClass}-mask-remove-failure`"><icon :name="icons.clear"></icon>移除</veui-button>
+              :class="`${listClass}-mask-remove ${listClass}-mask-remove-failure`"><veui-icon :name="icons.clear"/>移除</veui-button>
           </slot>
         </template>
       </li>
@@ -101,15 +101,15 @@
             :accept="accept"
             :multiple="requestMode !== 'iframe' && (maxCount > 1 || maxCount === undefined) && !isReplacing"
             @click.stop>
-            <icon :name="icons.add"></icon>
+            <veui-icon :name="icons.add"/>
         </label>
       </li>
     </ul>
     <span class="veui-uploader-tip" v-if="$slots.desc && type === 'image'"><slot name="desc"/></span>
     <span class="veui-uploader-error" v-if="type === 'image'">
-      <template v-if="error.typeInvalid"><slot name="type-invalid"><icon :name="icons.alert"></icon>文件的类型不符合要求</slot></template>
-      <template v-if="error.sizeInvalid"><slot name="size-invalid"><icon :name="icons.alert"></icon>文件的大小不符合要求</slot></template>
-      <template v-if="error.countOverflow"><slot name="count-overflow"><icon :name="icons.alert"></icon>文件的数量超过限制</slot></template>
+      <template v-if="error.typeInvalid"><slot name="type-invalid"><veui-icon :name="icons.alert"/>文件的类型不符合要求</slot></template>
+      <template v-if="error.sizeInvalid"><slot name="size-invalid"><veui-icon :name="icons.alert"/>文件的大小不符合要求</slot></template>
+      <template v-if="error.countOverflow"><slot name="count-overflow"><veui-icon :name="icons.alert"/>文件的数量超过限制</slot></template>
     </span>
     <iframe v-if="requestMode === 'iframe' && isSubmiting" ref="iframe"
      :id="iframeId" :name="iframeId" class="veui-uploader-hide"></iframe>
@@ -141,7 +141,7 @@ config.defaults({
 export default {
   name: 'veui-uploader',
   components: {
-    Icon,
+    'veui-icon': Icon,
     'veui-button': Button,
     'veui-tooltip': Tooltip,
     'veui-uploader-progress': getProgress()

--- a/packages/veui/src/mixins/ui.js
+++ b/packages/veui/src/mixins/ui.js
@@ -1,7 +1,7 @@
 import { getConfigKey } from '../utils/helper'
 import warn from '../utils/warn'
 import config from '../managers/config'
-import { compact, uniq, find, includes, get, assign, filter } from 'lodash'
+import { compact, uniq, find, includes, get, merge, filter } from 'lodash'
 
 export default {
   props: {
@@ -10,11 +10,6 @@ export default {
   computed: {
     uiProps () {
       let ui = (this.ui || '').trim()
-
-      if (!ui) {
-        return {}
-      }
-
       let tokens = compact(uniq(ui.split(/\s+/)))
       let { uiConfig = {} } = this
       return tokens.reduce((result, token) => {
@@ -29,20 +24,25 @@ export default {
           result[name] = token
         }
         return result
-      }, {})
+      }, Object.keys(uiConfig).reduce((result, prop) => {
+        result[prop] = 'default'
+        return result
+      }, {}))
     },
     uiConfig () {
       return this.getComponentConfig('ui')
     },
-    icons () {
-      let icons = this.getComponentConfig('icons')
+    uiData () {
       let { uiConfig = {}, uiProps } = this
-
-      let uiIcons = Object.keys(uiProps).reduce((result, name) => {
-        let icons = get(uiConfig[name], 'data.icons', {})
-        assign(result, icons[uiProps[name]])
+      return Object.keys(uiProps).reduce((result, name) => {
+        let data = get(uiConfig[name], ['data', uiProps[name]], {})
+        merge(result, data)
         return result
       }, {})
+    },
+    icons () {
+      let icons = this.getComponentConfig('icons')
+      let uiIcons = this.uiData.icons || {}
 
       return {
         ...icons,


### PR DESCRIPTION
在主题的 JS 文件中提供无法通过 CSS 定义的样式逻辑。

目前的逻辑是这样的：

```js
{
  icons: {
    success: 'check'
  },
  ui: {
    size: {
      values: ['tiny'],
      data: {
        default: {
          radius: 60
        },
        tiny: {
          radius: 13
        }
      }
    }
  }
}
```

组件代码中按如下方式调用：

```js
this.uiData.radius // 60 for `default`, 13 for `tiny`
```

这样就不需要在组件中感知主题提供哪些 `ui` 可选值了。当然，在组件逻辑中还是要提供默认值的，因为这些配置对于主题来说是可选的。

这个 PR 还有一些代码风格调整。