### PR TITLE
为 RegionPicker 添加键盘导航 & WAI-ARIA 支持

### DIFF
--- a/packages/veui-theme-one/components/region-picker.less
+++ b/packages/veui-theme-one/components/region-picker.less
@@ -6,12 +6,13 @@
   @padding-x: 20px;
   width: @item-width * @row-size + @padding-x * 2 + 2px;
   border: 1px solid @veui-gray-color-5;
+  outline: none;
 
   &-section {
-    border-top: 1px solid @veui-gray-color-5;
+    border-bottom: 1px solid @veui-gray-color-5;
 
-    &:first-child {
-      border-top: none;
+    &:last-child {
+      border-bottom: none;
     }
 
     &-title {

--- a/packages/veui-theme-one/components/region-picker.less
+++ b/packages/veui-theme-one/components/region-picker.less
@@ -6,7 +6,6 @@
   @padding-x: 20px;
   width: @item-width * @row-size + @padding-x * 2 + 2px;
   border: 1px solid @veui-gray-color-5;
-  outline: none;
 
   &-section {
     border-bottom: 1px solid @veui-gray-color-5;

--- a/packages/veui/src/components/Carousel.vue
+++ b/packages/veui/src/components/Carousel.vue
@@ -133,7 +133,7 @@ export default {
       if (event === 'click') {
         setTimeout(() => {
           this.$refs.item[this.localIndex].focus()
-        }, 0)
+        })
       }
 
       this.localIndex = index

--- a/packages/veui/src/components/Checkbox.vue
+++ b/packages/veui/src/components/Checkbox.vue
@@ -93,6 +93,9 @@ export default {
     },
     toggleChecked () {
       this.localChecked = this.isChecked ? this.falseValue : this.trueValue
+    },
+    focus () {
+      this.$refs.box.focus()
     }
   },
   watch: {

--- a/packages/veui/src/components/Checkbox.vue
+++ b/packages/veui/src/components/Checkbox.vue
@@ -27,7 +27,7 @@ import Icon from './Icon'
 import input from '../mixins/input'
 import ui from '../mixins/ui'
 import { getListeners } from '../utils/helper'
-import { patchIndeterminate } from '../utils/dom'
+import { patchIndeterminate, focus } from '../utils/dom'
 
 const EVENTS = ['keyup', 'keydown', 'keypress', 'focus', 'blur']
 
@@ -94,8 +94,12 @@ export default {
     toggleChecked () {
       this.localChecked = this.isChecked ? this.falseValue : this.trueValue
     },
-    focus () {
-      this.$refs.box.focus()
+    focus ({ visible = false }) {
+      if (visible) {
+        focus(this.$refs.box)
+      } else {
+        this.$refs.box.focus()
+      }
     }
   },
   watch: {

--- a/packages/veui/src/components/Radio.vue
+++ b/packages/veui/src/components/Radio.vue
@@ -20,6 +20,7 @@
 import ui from '../mixins/ui'
 import input from '../mixins/input'
 import { getListeners } from '../utils/helper'
+import { focus } from '../utils/dom'
 
 const EVENTS = ['keyup', 'keydown', 'keypress', 'focus', 'blur']
 
@@ -86,8 +87,12 @@ export default {
     }
   },
   methods: {
-    focus () {
-      this.$refs.box.focus()
+    focus ({ visible = false }) {
+      if (visible) {
+        focus(this.$refs.box)
+      } else {
+        this.$refs.box.focus()
+      }
     }
   }
 }

--- a/packages/veui/src/components/Radio.vue
+++ b/packages/veui/src/components/Radio.vue
@@ -6,6 +6,7 @@
   }"
   :ui="ui">
   <input
+    ref="box"
     type="radio"
     v-bind="attrs"
     @change="localChecked = $event.target.checked"
@@ -82,6 +83,11 @@ export default {
         }
       },
       immediate: true
+    }
+  },
+  methods: {
+    focus () {
+      this.$refs.box.focus()
     }
   }
 }

--- a/packages/veui/src/components/RegionPicker.vue
+++ b/packages/veui/src/components/RegionPicker.vue
@@ -329,7 +329,7 @@ export default {
       if (contains(this.$el, relatedTarget)) {
         setTimeout(() => {
           focusBefore(target)
-        }, 0)
+        })
         return
       }
 
@@ -341,7 +341,7 @@ export default {
       let last = this.focusPath.pop()
       setTimeout(() => {
         this.focusPath.push(last)
-      }, 0)
+      })
     },
     focusDown () {
       let { children } = this.focusNode
@@ -360,7 +360,7 @@ export default {
         this.toggleActive(this.focusNode, false)
       }
 
-      this.focusPath = [...focusPath].slice(0, -1)
+      this.focusPath = focusPath.slice(0, -1)
     },
     focusStep (forward = true) {
       if (this.focusPath.length === 3) {
@@ -377,7 +377,7 @@ export default {
         if (box && typeof box.focus === 'function') {
           box.focus({ visible: true })
         }
-      }, 0)
+      })
     },
     focusGroup (group, shadow = false) {
       this.toggleActive(group, shadow)

--- a/packages/veui/src/components/RegionPicker.vue
+++ b/packages/veui/src/components/RegionPicker.vue
@@ -1,34 +1,64 @@
 <template>
-<div class="veui-region-picker" :ui="ui">
-  <div v-for="(section, si) in localDatasource" class="veui-region-picker-section" :key="si">
+<div
+  class="veui-region-picker"
+  :ui="ui"
+  role="application"
+  aria-label="地域选择，按 Tab 键在同一层级内导航，按左右箭头键切换层级">
+  <div
+    v-for="(section, si) in localDatasource"
+    class="veui-region-picker-section"
+    :key="si">
     <div class="veui-region-picker-section-title">
-      <veui-checkbox :checked="section.selected" :indeterminate="section.indeterminate"
-        :readonly="realReadonly" :disabled="realDisabled || section.disabled"
+      <veui-checkbox
+        :checked="section.selected"
+        :indeterminate="section.indeterminate"
+        :readonly="realReadonly"
+        :disabled="realDisabled || section.disabled"
         @change="checked => toggleNode(section, checked)">
         <slot name="label" v-bind="section" :level="0">{{ section.label }}</slot>
       </veui-checkbox>
     </div>
-    <div v-if="section.children" class="veui-region-picker-section-content">
-      <div v-for="(branch, bi) in section.children" class="veui-region-picker-branch" :key="bi">
+    <div
+      v-if="section.children"
+      class="veui-region-picker-section-content">
+      <div
+        v-for="(branch, bi) in section.children"
+        class="veui-region-picker-branch"
+        :key="bi">
         <div class="veui-region-picker-branch-title">
-          <veui-checkbox :checked="branch.selected" :indeterminate="branch.indeterminate"
-            :readonly="realReadonly" :disabled="realDisabled || branch.disabled"
+          <veui-checkbox
+            :checked="branch.selected"
+            :indeterminate="branch.indeterminate"
+            :readonly="realReadonly"
+            :disabled="realDisabled || branch.disabled"
             @change="checked => toggleNode(branch, checked)">
             <slot name="label" v-bind="branch" :level="1">{{ branch.label }}</slot>
           </veui-checkbox>
         </div>
-        <div v-if="branch.children" class="veui-region-picker-branch-content">
-          <div v-for="(group, gi) in branch.children" class="veui-region-picker-group" :key="gi">
+        <div
+          v-if="branch.children"
+          class="veui-region-picker-branch-content">
+          <div
+            v-for="(group, gi) in branch.children"
+            class="veui-region-picker-group"
+            :key="gi">
             <div class="veui-region-picker-group-title">
-              <veui-checkbox :ref="`group-${si}-${bi}-${gi}`" :checked="group.selected"
-                :readonly="realReadonly" :disabled="realDisabled || group.disabled"
-                :indeterminate="group.indeterminate" @change="checked => toggleNode(group, checked)"
+              <veui-checkbox
+                :ref="`group-${si}-${bi}-${gi}`"
+                :checked="group.selected"
+                :readonly="realReadonly"
+                :disabled="realDisabled || group.disabled"
+                :indeterminate="group.indeterminate"
+                @change="checked => toggleNode(group, checked)"
                 @mouseenter.native="toggleActive(group, true)">
                 <slot name="label" v-bind="group" :level="2">{{ group.label }}</slot>
               </veui-checkbox>
-              <veui-overlay v-if="group.children && group.active" :open.sync="group.active"
+              <veui-overlay
+                v-if="group.children && group.active"
+                :open.sync="group.active"
                 :overlay-class="overlayClass"
-                :target="`group-${si}-${bi}-${gi}`" :options="{
+                :target="`group-${si}-${bi}-${gi}`"
+                :options="{
                   attachment: 'top left',
                   targetAttachment: 'bottom left',
                   constraints
@@ -43,9 +73,15 @@
                   }">
                   <template v-for="ri in Math.ceil(group.children.length / 3)">
                     <div class="veui-region-picker-unit-row" :key="ri">
-                      <div v-for="(unit, ui) in group.children.slice(ri * 3 - 3, ri * 3)" class="veui-region-picker-unit" :key="ui">
-                        <veui-checkbox :checked="unit.selected" :indeterminate="unit.indeterminate"
-                          :readonly="realReadonly" :disabled="realDisabled || unit.disabled"
+                      <div
+                        v-for="(unit, ui) in group.children.slice(ri * 3 - 3, ri * 3)"
+                        class="veui-region-picker-unit"
+                        :key="ui">
+                        <veui-checkbox
+                          :checked="unit.selected"
+                          :indeterminate="unit.indeterminate"
+                          :readonly="realReadonly"
+                          :disabled="realDisabled || unit.disabled"
                           @change="checked => toggleNode(unit, checked)">
                           <slot name="label" v-bind="unit" :level="3">{{ unit.label }}</slot>
                         </veui-checkbox>
@@ -54,9 +90,12 @@
                   </template>
                 </div>
               </veui-overlay>
-              <veui-overlay v-if="group.children && group.active" :open.sync="group.active"
+              <veui-overlay
+                v-if="group.children && group.active"
+                :open.sync="group.active"
                 :overlayClass="mergeOverlayClass('veui-region-picker-group-shadow-overlay')"
-                :target="`group-${si}-${bi}-${gi}`" :options="{
+                :target="`group-${si}-${bi}-${gi}`"
+                :options="{
                   attachment: 'top left',
                   targetAttachment: 'top left'
                 }">
@@ -68,8 +107,12 @@
                     trigger: 'hover',
                     delay: 200
                   }">
-                  <veui-checkbox :checked="group.selected" :indeterminate="group.indeterminate"
-                    :readonly="realReadonly" :disabled="realDisabled || group.disabled"
+                  <veui-checkbox
+                    :ref="`shadow-checker-${si}-${bi}-${gi}`"
+                    :checked="group.selected"
+                    :indeterminate="group.indeterminate"
+                    :readonly="realReadonly"
+                    :tabindex="focusLevel === 2 ? null : '-1'"
                     @change="checked => toggleNode(group, checked)">
                     <slot name="label" v-bind="group" :overlay="true" :level="2">
                       {{ group.label }}

--- a/packages/veui/src/components/RegionPicker.vue
+++ b/packages/veui/src/components/RegionPicker.vue
@@ -2,18 +2,36 @@
 <div
   class="veui-region-picker"
   :ui="ui"
-  role="application"
+  role="tree"
+  aria-multiselectable="true"
   aria-label="地域选择，按 Tab 键在同一层级内导航，按左右箭头键切换层级">
+  <div
+    data-id="x"
+    class="veui-sr-only"
+    tabindex="0"
+    @focus="initFocus"></div>
   <div
     v-for="(section, si) in localDatasource"
     class="veui-region-picker-section"
+    role="treeitem"
+    aria-level="1"
+    :aria-expanded="String(localDatasource.length > 0)"
+    :aria-setsize="localDatasource.length"
+    :aria-posinset="si + 1"
+    :aria-checked="section.indeterminate ? 'mixed' : String(section.selected)"
+    :aria-selected="section.id != null && section.selected && (includeIndeterminate || !section.indeterminate)"
     :key="si">
     <div class="veui-region-picker-section-title">
       <veui-checkbox
+        :ref="`node-${si}`"
         :checked="section.selected"
         :indeterminate="section.indeterminate"
         :readonly="realReadonly"
         :disabled="realDisabled || section.disabled"
+        tabindex="-1"
+        @keydown.right.prevent="focusDown"
+        @keydown.down.prevent="focusStep()"
+        @keydown.up.prevent="focusStep(false)"
         @change="checked => toggleNode(section, checked)">
         <slot name="label" v-bind="section" :level="0">{{ section.label }}</slot>
       </veui-checkbox>
@@ -24,13 +42,26 @@
       <div
         v-for="(branch, bi) in section.children"
         class="veui-region-picker-branch"
+        role="treeitem"
+        aria-level="2"
+        :aria-expanded="String(section.children.length > 0)"
+        :aria-setsize="section.children.length"
+        :aria-posinset="bi + 1"
+        :aria-checked="branch.indeterminate ? 'mixed' : String(branch.selected)"
+        :aria-selected="branch.id != null && branch.selected && (includeIndeterminate || !branch.indeterminate)"
         :key="bi">
         <div class="veui-region-picker-branch-title">
           <veui-checkbox
+            :ref="`node-${si}-${bi}`"
             :checked="branch.selected"
             :indeterminate="branch.indeterminate"
             :readonly="realReadonly"
             :disabled="realDisabled || branch.disabled"
+            tabindex="-1"
+            @keydown.left.prevent="focusUp"
+            @keydown.right.prevent="focusDown"
+            @keydown.down.prevent="focusStep"
+            @keydown.up.prevent="focusStep(false)"
             @change="checked => toggleNode(branch, checked)">
             <slot name="label" v-bind="branch" :level="1">{{ branch.label }}</slot>
           </veui-checkbox>
@@ -41,33 +72,47 @@
           <div
             v-for="(group, gi) in branch.children"
             class="veui-region-picker-group"
+            role="treeitem"
+            aria-level="3"
+            :aria-expanded="String(branch.children.length > 0)"
+            :aria-setsize="branch.children.length"
+            :aria-posinset="gi + 1"
+            :aria-checked="group.indeterminate ? 'mixed' : String(group.selected)"
+            :aria-selected="group.id != null && group.selected && (includeIndeterminate || !group.indeterminate)"
+            :aria-owns="`${id}-shadow ${id}-units`"
             :key="gi">
             <div class="veui-region-picker-group-title">
               <veui-checkbox
-                :ref="`group-${si}-${bi}-${gi}`"
+                :ref="`node-${si}-${bi}-${gi}`"
                 :checked="group.selected"
                 :readonly="realReadonly"
                 :disabled="realDisabled || group.disabled"
                 :indeterminate="group.indeterminate"
+                tabindex="-1"
                 @change="checked => toggleNode(group, checked)"
-                @mouseenter.native="toggleActive(group, true)">
+                @mouseenter.native="toggleActive(group, true)"
+                @keydown.left.prevent="focusUp"
+                @keydown.right.prevent="focusGroup(group, true)"
+                @keydown.down.prevent="focusStep"
+                @keydown.up.prevent="focusStep(false)">
                 <slot name="label" v-bind="group" :level="2">{{ group.label }}</slot>
               </veui-checkbox>
               <veui-overlay
                 v-if="group.children && group.active"
                 :open.sync="group.active"
                 :overlay-class="overlayClass"
-                :target="`group-${si}-${bi}-${gi}`"
+                :target="`node-${si}-${bi}-${gi}`"
                 :options="{
                   attachment: 'top left',
                   targetAttachment: 'bottom left',
                   constraints
                 }">
                 <div class="veui-region-picker-units"
+                  :id="`${id}-units`"
                   :ref="`layer-${si}-${bi}-${gi}`"
                   v-outside="{
                     handler: () => { toggleActive(group, false) },
-                    refs: [`group-${si}-${bi}-${gi}`, `shadow-${si}-${bi}-${gi}`],
+                    refs: [`node-${si}-${bi}-${gi}`, `shadow-${si}-${bi}-${gi}`],
                     trigger: 'hover',
                     delay: 200
                   }">
@@ -76,12 +121,25 @@
                       <div
                         v-for="(unit, ui) in group.children.slice(ri * 3 - 3, ri * 3)"
                         class="veui-region-picker-unit"
+                        role="treeitem"
+                        aria-level="4"
+                        :aria-expanded="String(group.children.length > 0)"
+                        :aria-setsize="group.children.length"
+                        :aria-posinset="ri * 3 + ui - 2"
+                        :aria-checked="String(unit.selected)"
+                        :aria-selected="unit.id != null && unit.selected"
                         :key="ui">
                         <veui-checkbox
+                          :ref="`node-${si}-${bi}-${gi}-${ri * 3 - 3 + ui}`"
                           :checked="unit.selected"
                           :indeterminate="unit.indeterminate"
                           :readonly="realReadonly"
                           :disabled="realDisabled || unit.disabled"
+                          tabindex="-1"
+                          aria-haspopup="tree"
+                          @keydown.left.prevent="focusUp"
+                          @keydown.down.prevent="focusStep"
+                          @keydown.up.prevent="focusStep(false)"
                           @change="checked => toggleNode(unit, checked)">
                           <slot name="label" v-bind="unit" :level="3">{{ unit.label }}</slot>
                         </veui-checkbox>
@@ -94,16 +152,25 @@
                 v-if="group.children && group.active"
                 :open.sync="group.active"
                 :overlayClass="mergeOverlayClass('veui-region-picker-group-shadow-overlay')"
-                :target="`group-${si}-${bi}-${gi}`"
+                :target="`node-${si}-${bi}-${gi}`"
                 :options="{
                   attachment: 'top left',
                   targetAttachment: 'top left'
                 }">
                 <div class="veui-region-picker-group-shadow"
+                  :id="`${id}-shadow`"
                   :ref="`shadow-${si}-${bi}-${gi}`"
+                  role="treeitem"
+                  aria-level="3"
+                  :aria-expanded="String(branch.children.length > 0)"
+                  :aria-setsize="branch.children.length"
+                  :aria-posinset="gi + 1"
+                  :aria-checked="group.indeterminate ? 'mixed' : String(group.selected)"
+                  :aria-selected="group.id != null && group.selected && (includeIndeterminate || !group.indeterminate)"
+                  :aria-owns="`${id}-units`"
                   v-outside="{
                     handler: () => { toggleActive(group, false) },
-                    refs: [`group-${si}-${bi}-${gi}`, `layer-${si}-${bi}-${gi}`],
+                    refs: [`node-${si}-${bi}-${gi}`, `layer-${si}-${bi}-${gi}`],
                     trigger: 'hover',
                     delay: 200
                   }">
@@ -112,7 +179,11 @@
                     :checked="group.selected"
                     :indeterminate="group.indeterminate"
                     :readonly="realReadonly"
-                    :tabindex="focusLevel === 2 ? null : '-1'"
+                    tabindex="-1"
+                    @keydown.left.prevent="focusGroup(group)"
+                    @keydown.right.prevent="focusDown"
+                    @keydown.down.prevent="focusStep"
+                    @keydown.up.prevent="focusStep(false)"
                     @change="checked => toggleNode(group, checked)">
                     <slot name="label" v-bind="group" :overlay="true" :level="2">
                       {{ group.label }}
@@ -139,9 +210,10 @@ import ui from '../mixins/ui'
 import input from '../mixins/input'
 import overlay from '../mixins/overlay'
 import outside from '../directives/outside'
-import { cloneDeep, pick } from 'lodash'
-import Vue from 'vue'
 import warn from '../utils/warn'
+import { contains, focusBefore } from '../utils/dom'
+import { uniqueId, get, cloneDeep, pick } from 'lodash'
+import Vue from 'vue'
 
 export default {
   name: 'veui-region-picker',
@@ -169,7 +241,9 @@ export default {
           to: 'window',
           attachment: 'together'
         }
-      ]
+      ],
+      focusPath: [0],
+      id: uniqueId('veui-region-picker-')
     }
   },
   computed: {
@@ -178,6 +252,19 @@ export default {
         result[current] = true
         return result
       }, {})
+    },
+    nodePath () {
+      return this.focusPath.join(',children,').split(',')
+    },
+    focusNode () {
+      return get(this.localDatasource, this.nodePath)
+    },
+    focusSiblings () {
+      let { nodePath } = this
+      if (nodePath.length <= 1) {
+        return this.localDatasource
+      }
+      return get(this.localDatasource, this.nodePath.slice(0, -1))
     }
   },
   watch: {
@@ -193,6 +280,11 @@ export default {
     },
     datasource () {
       this.init()
+    },
+    focusPath (val, oldVal) {
+      let prefix = oldVal.length === 4 && val.length === 3
+        ? 'shadow-checker' : 'node'
+      this.focusByPath(prefix)
     }
   },
   created () {
@@ -232,6 +324,64 @@ export default {
         }
       })
       this.localDatasource = localDatasource
+    },
+    initFocus ({ target, relatedTarget }) {
+      if (contains(this.$el, relatedTarget)) {
+        setTimeout(() => {
+          focusBefore(target)
+        }, 0)
+        return
+      }
+
+      if (this.focusPath.length < 4) {
+        this.focusByPath()
+        return
+      }
+
+      let last = this.focusPath.pop()
+      setTimeout(() => {
+        this.focusPath.push(last)
+      }, 0)
+    },
+    focusDown () {
+      let { children } = this.focusNode
+      if (!children || !children.length) {
+        return
+      }
+      this.focusPath.push(0)
+    },
+    focusUp () {
+      let { focusPath } = this
+      if (focusPath.length <= 1) {
+        return
+      }
+
+      if (focusPath.length === 3) {
+        this.toggleActive(this.focusNode, false)
+      }
+
+      this.focusPath = [...focusPath].slice(0, -1)
+    },
+    focusStep (forward = true) {
+      if (this.focusPath.length === 3) {
+        this.toggleActive(this.focusNode, false)
+      }
+      let count = this.focusSiblings.length
+      let index = this.focusPath[this.focusPath.length - 1]
+      this.$set(this.focusPath, this.focusPath.length - 1, (count + index + (forward ? 1 : -1)) % count)
+    },
+    focusByPath (prefix = 'node') {
+      setTimeout(() => {
+        let box = this.$refs[`${prefix}-${this.focusPath.join('-')}`]
+        box = Array.isArray(box) ? box[0] : box
+        if (box && typeof box.focus === 'function') {
+          box.focus({ visible: true })
+        }
+      }, 0)
+    },
+    focusGroup (group, shadow = false) {
+      this.toggleActive(group, shadow)
+      this.focusByPath(shadow ? 'shadow-checker' : 'node')
     },
     toggleActive (node, show) {
       if (node.disabled) {

--- a/packages/veui/src/components/Textarea.vue
+++ b/packages/veui/src/components/Textarea.vue
@@ -40,6 +40,7 @@ import { pick } from 'lodash'
 import ui from '../mixins/ui'
 import input from '../mixins/input'
 import { getListeners } from '../utils/helper'
+import { log10 } from '../utils/math'
 
 const EVENTS = ['click', 'keyup', 'keydown', 'keypress']
 
@@ -89,9 +90,6 @@ export default {
       return this.localValue.split('\n').map(line => line || `\u200b${line}`)
     },
     digits () {
-      const log10 = Math.log10 || function (x) {
-        return Math.log(x) * Math.LOG10E
-      }
       return Math.floor(log10(this.lines.length)) + 1
     },
     lineNumberWidth () {

--- a/packages/veui/src/managers/focus.js
+++ b/packages/veui/src/managers/focus.js
@@ -1,6 +1,5 @@
 import { remove, findIndex, keys } from 'lodash'
 import { focusIn } from '../utils/dom'
-import Vue from 'vue'
 
 class FocusContext {
   /**
@@ -60,11 +59,11 @@ class FocusContext {
   }
 
   focusAt (index = 0, ignoreAutofocus) {
-    Vue.nextTick(() => {
+    setTimeout(() => {
       if (!focusIn(this.preferred || this.root, index, ignoreAutofocus)) {
         this.root.focus()
       }
-    })
+    }, 0)
   }
 
   destroy () {
@@ -77,8 +76,7 @@ class FocusContext {
     }
     if (source) {
       this.source = null
-      // restore focus in a macro task to prevent
-      // triggering events on the original focus
+
       if (typeof source.focus === 'function' && this.env.trigger !== 'pointer') {
         setTimeout(() => {
           source.focus()

--- a/packages/veui/src/managers/focus.js
+++ b/packages/veui/src/managers/focus.js
@@ -63,7 +63,7 @@ class FocusContext {
       if (!focusIn(this.preferred || this.root, index, ignoreAutofocus)) {
         this.root.focus()
       }
-    }, 0)
+    })
   }
 
   destroy () {
@@ -80,7 +80,7 @@ class FocusContext {
       if (typeof source.focus === 'function' && this.env.trigger !== 'pointer') {
         setTimeout(() => {
           source.focus()
-        }, 0)
+        })
       }
     }
     this.preferred = null

--- a/packages/veui/src/utils/dom.js
+++ b/packages/veui/src/utils/dom.js
@@ -1,3 +1,5 @@
+import { findIndex } from 'lodash'
+
 export function closest (element, selectors) {
   if (element.closest) {
     return element.closest(selectors)
@@ -174,6 +176,40 @@ export function focusIn (elem, index = 0, ignoreAutofocus) {
 }
 
 /**
+ * 聚焦到前/后第指定个可聚焦元素
+ *
+ * @param {HTMLElement} elem 起始元素
+ * @param {number} step 偏移量
+ */
+function focusNav (elem, step) {
+  let focusable = getFocusable(document.body)
+  let index = findIndex(focusable, el => el === elem)
+  if (index !== -1) {
+    let next = focusable[index + step]
+    if (next) {
+      next.focus()
+    }
+  }
+}
+
+/**
+ * 聚焦到上一个可聚焦元素
+ *
+ * @param {HTMLElement} elem 起始元素
+ */
+export function focusBefore (elem) {
+  return focusNav(elem, -1)
+}
+
+/**
+ * 聚焦到下一个可聚焦元素
+ *
+ * @param {HTMLElement} elem 起始元素
+ */
+export function focusAfter (elem) {
+  return focusNav(elem, 1)
+}
+/**
  * 通过程序 focus 时手动添加 `.focus-visible` 类，弥补当前 polyfill 的不足。
  * 在不支持 `classList` 的浏览器下啥都不做，因为 polyfill 依赖了 `classList` polyfill。
  * 如果不引 `classList`，本来就不能工作，也就无需添加类。
@@ -181,7 +217,7 @@ export function focusIn (elem, index = 0, ignoreAutofocus) {
  *
  * @param {HTMLElement} elem
  */
-function focus (elem) {
+export function focus (elem) {
   if (!elem) {
     return
   }

--- a/packages/veui/src/utils/math.js
+++ b/packages/veui/src/utils/math.js
@@ -59,3 +59,13 @@ export function add (a, b, decimals = 0) {
 export function round (num, decimals = 0) {
   return Number(Math.round(num + 'e' + decimals) + 'e-' + decimals)
 }
+
+/**
+ * 以 10 为底数取对数
+ *
+ * @param {number} num 真数
+ * @returns {number} 对数
+ */
+export function log10 (num) {
+  return Math.log10 ? Math.log10(num) : Math.log(num) * Math.LOG10E
+}


### PR DESCRIPTION
#234.

* keyboard nav & WAI-ARIA support for `RegionPicker`
* `log10` in `utils/math`
* `focusBefore` & `focusAfter` in `utils/dom`
* `focus({ visible })` for `Radio` & `Checkbox`