### PR TITLE
Fix input component lookup in Label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@
 ### 💡 主要变更
 
 * [^] `RegionPicker` 组件的 `datasource` prop 中的 `id` 字段重命名为 `value`，但 `id` 依然保留，优先使用 `value`。
-* [^] 优化 `Switch` 组件的可访问性。
+* [^] 优化了 `outside` 指令解析数字值的逻辑。
+* [^] 为 `Pagination` 组件内的 `Select` 组件新增了 `overlay-class` 定义，方便自定义样式。
+* [^] 优化了 `Switch`、`Steps`、`Schedule`、`Table`、`Fieldset` 等组件的可访问性，实现了键盘交互。
 
 ### 🐞 问题修复
 
@@ -17,6 +19,7 @@
 * [^] 去除了 `dropdown` mixin 中 多余的默认 `overlay-options` 约束条件，修正某些场景下的浮层展开的默认方向。
 * [^] 修复了 `Input` 组件初始值为 `null` 时使用输入法会失效的问题。
 * [^] 现在 `Searchbox` 组件在 `suggestions` 变化时会自动更新浮层位置。
+* [^] 修复了点击 `Label` 组件激活同 `Field` 下的输入组件时，没有考虑组件禁用/只读状态的问题。
 
 ## 1.0.0-alpha.13
 

--- a/packages/veui/src/components/Checkbox.vue
+++ b/packages/veui/src/components/Checkbox.vue
@@ -106,6 +106,9 @@ export default {
   },
   methods: {
     activate () {
+      if (this.realDisabled || this.realReadonly) {
+        return
+      }
       this.toggleChecked()
     },
     handleChange () {

--- a/packages/veui/src/components/Input.vue
+++ b/packages/veui/src/components/Input.vue
@@ -153,6 +153,9 @@ export default {
       this.$refs.input.focus()
     },
     activate () {
+      if (this.realDisabled || this.realReadonly) {
+        return
+      }
       this.$refs.input.focus()
     },
     clear () {

--- a/packages/veui/src/components/Label.vue
+++ b/packages/veui/src/components/Label.vue
@@ -1,5 +1,5 @@
 <template>
-<label class="veui-label" :ui="ui" @click="findLabeledInput"><slot/></label>
+<label class="veui-label" :ui="ui" @click="activateInput"><slot/></label>
 </template>
 
 <script>
@@ -11,7 +11,14 @@ export default {
   name: 'veui-label',
   mixins: [ui],
   methods: {
-    findLabeledInput () {
+    /**
+     * Why not implement this in the `Field` component?
+     *
+     * Basically it should, but this make it hard if we overwrite `label` slot
+     * when we are using a `Field` that we have to manually handle `click` events
+     * and then call `activate` method for the `Field`.
+     */
+    activateInput () {
       if (window.getSelection().toString().length) {
         return
       }

--- a/packages/veui/src/components/Label.vue
+++ b/packages/veui/src/components/Label.vue
@@ -3,7 +3,7 @@
 </template>
 
 <script>
-import { isFunction, get } from 'lodash'
+import { isFunction } from 'lodash'
 import { getTypedAncestor, isType } from '../utils/helper'
 import ui from '../mixins/ui'
 
@@ -15,17 +15,32 @@ export default {
       if (window.getSelection().toString().length) {
         return
       }
-      let ancestor = getTypedAncestor(this, 'field')
-      if (ancestor) {
-        let target = ancestor.$children.filter(child => child !== this)[0]
-        while (target && !isType(target, 'input')) {
-          target = get(target, '$children[0]')
-        }
 
-        if (target && isFunction(target.activate)) {
-          target.activate()
-        }
+      let field = getTypedAncestor(this, 'field')
+      let target = this.findInput(field)
+      if (target && isFunction(target.activate)) {
+        target.activate()
       }
+    },
+    findInput (component) {
+      if (component === this) {
+        return null
+      }
+      if (isType(component, 'input')) {
+        return component
+      }
+
+      let children = component.$children || []
+      if (!children.length) {
+        return null
+      }
+
+      let result
+      children.some(c => {
+        result = this.findInput(c)
+        return result
+      })
+      return result
     }
   }
 }

--- a/packages/veui/src/components/NumberInput.vue
+++ b/packages/veui/src/components/NumberInput.vue
@@ -307,6 +307,9 @@ export default {
         return val.toString()
       }
       return round(this.filterLimitValue(val), this.decimalPlace).toFixed(this.decimalPlace)
+    },
+    activate () {
+      this.$ref.input.activate()
     }
   }
 }

--- a/packages/veui/src/components/Radio.vue
+++ b/packages/veui/src/components/Radio.vue
@@ -96,6 +96,12 @@ export default {
       } else {
         this.$refs.box.focus()
       }
+    },
+    activate () {
+      if (this.realDisabled || this.realReadonly) {
+        return
+      }
+      this.localChecked = true
     }
   }
 }

--- a/packages/veui/src/components/Searchbox.vue
+++ b/packages/veui/src/components/Searchbox.vue
@@ -237,6 +237,9 @@ export default {
       }
     },
     activate () { // for label activation
+      if (this.realDisabled || this.realReadonly) {
+        return
+      }
       this.focus()
     },
     disallowSuggest () {

--- a/packages/veui/src/components/Switch.vue
+++ b/packages/veui/src/components/Switch.vue
@@ -86,6 +86,12 @@ export default {
     handleChange (checked) {
       this.localChecked = checked
       this.$emit('change', checked)
+    },
+    activate () {
+      if (this.realDisabled || this.realReadonly) {
+        return
+      }
+      this.localChecked = !this.localChecked
     }
   }
 }

--- a/packages/veui/src/components/Textarea.vue
+++ b/packages/veui/src/components/Textarea.vue
@@ -162,6 +162,9 @@ export default {
       this.$refs.input.focus()
     },
     activate () {
+      if (this.realDisabled || this.realReadonly) {
+        return
+      }
       this.$refs.input.focus()
     },
     getMeasurersHeight () {

--- a/packages/veui/src/mixins/dropdown.js
+++ b/packages/veui/src/mixins/dropdown.js
@@ -22,6 +22,9 @@ export default {
       this.expanded = false
     },
     activate () {
+      if (this.realDisabled || this.realReadonly) {
+        return
+      }
       this.expanded = true
     }
   },


### PR DESCRIPTION
Should look for the first component with `uiType` value `input` among all descendants of the closest `field` instead of only searching first child component of each level.