### PR TITLE
ui 机制调整

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@
 * `Breadcrumb` 组件的 `default` 作用域插槽重命名为 `item`，因为 Vue 实际的 fallback 逻辑，所以避免使用同名的 slot 和 scoped slot。
 * `Tooltip` 组件的 `custom` prop 被废弃，将在 `1.0.0` 移除。替代方式为：将 `trigger` prop 指定为 `custom` 来使用自定义逻辑控制打开及关闭。
 * `Pagination` 组件内部所有的 `class` 中的 `pager` 被更名为 `pagination`。如果在样式代码中进行过定制，请进行全局替换。
+* `Uploader` 组件的 `progress` prop 的 `'number'` 取值被替换为 `'percent'` 及 `'detail'`，分别表示显示百分比及显示进度详情。进度详情将以 <code>\`${loaded}KB/${total}KB\`</code> 的形式输出。
 
 ### 💡 主要变更
 
-* 增加主题包为组件部件指定 `ui` 的功能。
+* 增加主题包为组件部件指定 `ui` 的功能，同时组件现在将自动继承父组件中可继承的 `ui` 字段，并更新了 `veui-theme-one` 中所有相应的部分。
 * `Breadcrumb` 组件的 scoped slot `item`（原 `default`）新增参数 `index`。
+* `Button` 组件增加 `ui` 选项 `dark`。
 
 ### 🐞 问题修复
 

--- a/packages/veui-theme-one/components/Button.js
+++ b/packages/veui-theme-one/components/Button.js
@@ -7,7 +7,7 @@ config.defaults({
   },
   ui: {
     style: {
-      values: ['alt', 'primary']
+      values: ['alt', 'primary', 'dark']
     },
     role: {
       values: ['link']

--- a/packages/veui-theme-one/components/ButtonGroup.js
+++ b/packages/veui-theme-one/components/ButtonGroup.js
@@ -3,10 +3,12 @@ import config from 'veui/managers/config'
 config.defaults({
   ui: {
     style: {
-      values: ['alt', 'primary']
+      values: ['alt', 'primary'],
+      inherit: true
     },
     size: {
-      values: ['large', 'small', 'tiny', 'micro']
+      values: ['large', 'small', 'tiny', 'micro'],
+      inherit: true
     }
   }
 }, 'buttongroup')

--- a/packages/veui-theme-one/components/CheckButtonGroup.js
+++ b/packages/veui-theme-one/components/CheckButtonGroup.js
@@ -3,10 +3,12 @@ import config from 'veui/managers/config'
 config.defaults({
   ui: {
     style: {
-      values: ['alt']
+      values: ['alt'],
+      inherit: true
     },
     size: {
-      values: ['large', 'small', 'tiny', 'micro']
+      values: ['large', 'small', 'tiny', 'micro'],
+      inherit: true
     }
   }
 }, 'checkbuttongroup')

--- a/packages/veui-theme-one/components/CheckboxGroup.js
+++ b/packages/veui-theme-one/components/CheckboxGroup.js
@@ -3,7 +3,8 @@ import config from 'veui/managers/config'
 config.defaults({
   ui: {
     size: {
-      values: ['small']
+      values: ['small'],
+      inherit: true
     }
   }
 }, 'checkboxgroup')

--- a/packages/veui-theme-one/components/DatePicker.js
+++ b/packages/veui-theme-one/components/DatePicker.js
@@ -14,7 +14,8 @@ config.defaults({
       values: ['alt']
     },
     size: {
-      values: ['large', 'small', 'tiny', 'micro']
+      values: ['large', 'small', 'tiny', 'micro'],
+      inherit: true
     }
   }
 }, 'datepicker')

--- a/packages/veui-theme-one/components/Dropdown.js
+++ b/packages/veui-theme-one/components/Dropdown.js
@@ -9,10 +9,12 @@ config.defaults({
   },
   ui: {
     style: {
-      values: ['primary']
+      values: ['primary'],
+      inherit: true
     },
     role: {
-      values: ['link']
+      values: ['link'],
+      inherit: true
     }
   }
 }, 'dropdown')

--- a/packages/veui-theme-one/components/Field.js
+++ b/packages/veui-theme-one/components/Field.js
@@ -7,7 +7,8 @@ config.defaults({
   },
   ui: {
     size: {
-      values: ['large', 'small', 'tiny', 'micro']
+      values: ['large', 'small', 'tiny', 'micro'],
+      inherit: true
     }
   }
 }, 'field')

--- a/packages/veui-theme-one/components/FilterPanel.js
+++ b/packages/veui-theme-one/components/FilterPanel.js
@@ -1,0 +1,7 @@
+import config from 'veui/managers/config'
+
+config.defaults({
+  parts: {
+    search: 'small'
+  }
+}, 'filterpanel')

--- a/packages/veui-theme-one/components/RadioButtonGroup.js
+++ b/packages/veui-theme-one/components/RadioButtonGroup.js
@@ -3,10 +3,12 @@ import config from 'veui/managers/config'
 config.defaults({
   ui: {
     style: {
-      values: ['alt']
+      values: ['alt'],
+      inherit: true
     },
     size: {
-      values: ['large', 'small', 'tiny', 'micro']
+      values: ['large', 'small', 'tiny', 'micro'],
+      inherit: true
     }
   }
 }, 'radiobuttongroup')

--- a/packages/veui-theme-one/components/RadioGroup.js
+++ b/packages/veui-theme-one/components/RadioGroup.js
@@ -3,7 +3,8 @@ import config from 'veui/managers/config'
 config.defaults({
   ui: {
     size: {
-      values: ['small']
+      values: ['small'],
+      inherit: true
     }
   }
 }, 'radiogroup')

--- a/packages/veui-theme-one/components/Schedule.js
+++ b/packages/veui-theme-one/components/Schedule.js
@@ -4,5 +4,10 @@ config.defaults({
   statuses: [
     { name: 'selected', label: '已选时段' },
     { name: 'available', label: '未选时段' }
-  ]
+  ],
+  parts: {
+    shortcuts: 'link',
+    dayPicker: 'small',
+    tooltip: 'small'
+  }
 }, 'schedule')

--- a/packages/veui-theme-one/components/Searchbox.js
+++ b/packages/veui-theme-one/components/Searchbox.js
@@ -7,7 +7,8 @@ config.defaults({
   },
   ui: {
     size: {
-      values: ['large', 'small']
+      values: ['large', 'small'],
+      inherit: true
     }
   }
 }, 'searchbox')

--- a/packages/veui-theme-one/components/Select.js
+++ b/packages/veui-theme-one/components/Select.js
@@ -9,7 +9,8 @@ config.defaults({
   },
   ui: {
     size: {
-      values: ['large', 'small', 'tiny', 'micro']
+      values: ['large', 'small', 'tiny', 'micro'],
+      inherit: true
     },
     style: {
       values: ['alt']

--- a/packages/veui-theme-one/components/Uploader.js
+++ b/packages/veui-theme-one/components/Uploader.js
@@ -21,5 +21,15 @@ config.defaults({
     direction: {
       values: ['horizontal']
     }
+  },
+  parts: {
+    retryFileDone: 'link micro',
+    clearFileDone: 'link square micro',
+    cancelFile: 'link square micro',
+    cancelImage: 'small',
+    retryImageSuccess: 'dark',
+    clearImageSuccess: 'dark square micro',
+    retryImageFailure: 'small',
+    clearImageFailure: 'link square micro'
   }
 }, 'uploader')

--- a/packages/veui-theme-one/components/button.less
+++ b/packages/veui-theme-one/components/button.less
@@ -62,6 +62,20 @@
     }
   }
 
+  @dark-color: #000;
+
+  &[ui~="dark"] {
+    border-color: transparent;
+    background-color: fadeout(@dark-color, 30%);
+    color: #fff;
+
+    &:hover,
+    &:active,
+    &.focus-visible {
+      background-color: fadeout(@dark-color, 20%);
+    }
+  }
+
   &[ui~="large"] {
     .centered-line(@veui-height-large);
     font-size: @veui-font-size-large;

--- a/packages/veui-theme-one/components/uploader.less
+++ b/packages/veui-theme-one/components/uploader.less
@@ -74,7 +74,6 @@
     padding: 0;
     margin: 0;
     list-style: none;
-    overflow: hidden;
 
     li {
       margin: 0 10px 5px 0;
@@ -108,31 +107,30 @@
     }
 
     &-success {
-      .absolute(0);
+      .absolute(-1px);
       padding: 9px 4px;
       background-color: #fff;
+      border: 1px solid @veui-gray-color-5;
       color: @veui-success-color;
       cursor: pointer;
     }
   }
 
   &-list {
-    width: @width;
-
     &-container {
       position: relative;
-      padding: 4px;
       width: @width;
+      padding: 3px 4px;
+      max-width: @width;
       color: @veui-gray-color-2;
       transition: background-color @veui-transition-duration;
+      text-align: right;
+      overflow: hidden;
+      white-space: nowrap;
     }
 
     &-container:hover {
       background-color: @veui-gray-color-8;
-
-      .veui-button[ui~="link"] {
-        background-color: @veui-gray-color-8;
-      }
 
       .veui-uploader-button-remove {
         opacity: 1;
@@ -140,13 +138,12 @@
     }
 
     &-name {
-      display: inline-block;
-      vertical-align: top;
-      overflow: hidden;
-      width: ~"calc(100% - 3em)";
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      line-height: 20px;
+      .ellipsis();
+      float: left;
+      max-width: ~"calc(100% - 3em)";
+      line-height: 22px;
+      text-align: left;
+      vertical-align: middle;
     }
 
     &-name-success {
@@ -154,12 +151,12 @@
     }
 
     &-name-failure {
-      width: ~"calc(100% - 11em)";
+      width: ~"calc(100% - 12em)";
     }
 
     &-status {
       display: inline-block;
-      width: ~"calc(100% - 3em)";
+      max-width: ~"calc(100% - 3em)";
       height: 100%;
     }
 
@@ -171,33 +168,30 @@
     }
 
     &-icon {
-      .size(12px);
-      margin: 4px 5px 0 0;
-      vertical-align: top;
+      font-size: 12px;
+      margin: 5px 8px 0 0;
+      float: left;
     }
 
-    .veui-button {
-      float: right;
-      .centered-line(20px);
-      vertical-align: top;
+    &-retry {
+      margin-right: 6px;
+      margin-left: 10px;
 
-      &.veui-uploader-list-retry {
-        float: none;
-        margin-left: 10px;
-        color: @veui-gray-color-1;
+      &.veui-button[ui~="micro"] {
+        font-size: @veui-font-size-normal;
+      }
 
-        .veui-icon {
-          margin: 4px 6px 0 0;
-          font-size: 12px;
-        }
+      .veui-icon {
+        margin: 4px 6px 0 0;
+        font-size: 12px;
       }
     }
 
     .veui-uploader-progress {
-      display: inline-block;
-      width: ~"calc(100% - 6em)";
-      height: 20px;
-      vertical-align: middle;
+      float: left;
+      text-align: left;
+      line-height: 22px;
+      margin-right: 10px;
     }
   }
 
@@ -205,19 +199,12 @@
     float: left;
 
     &-container {
-      overflow: hidden;
+      .clearfix();
       .size(@image-size);
       padding: 0;
       border: 1px solid @veui-gray-color-5;
       text-align: center;
       position: relative;
-
-      .veui-button[ui~="operation"] {
-        .absolute(~"calc(50% + 10px)", _, _, ~"calc(50% - 35px)");
-        width: 70px;
-        .centered-line(28px);
-        font-size: @veui-font-size-small;
-      }
 
       label.veui-button {
         cursor: pointer;
@@ -243,35 +230,8 @@
         background-color: none;
       }
 
-      .veui-button {
-        padding: 0;
-        position: absolute;
-        background-color: fadeout(#000, 20%);
-        border: 1px solid fadeout(#fff, 80%);
-        color: #fff;
-        font-size: @veui-font-size-normal;
-
-        &:hover {
-          background-color: fadeout(#000, 20%);
-        }
-
-        &:hover,
-        &.active {
-          color: #fff;
-        }
-      }
-
       .veui-button&-remove {
-        .size(24px);
-        line-height: 24px;
-        top: 0;
-        right: 0;
-        left: auto;
-        overflow: hidden;
-
-        .veui-icon {
-          margin-top: 4px;
-        }
+        .absolute(-1px, -1px, _, _);
       }
 
       .veui-button.veui-uploader-input-label-disabled {
@@ -348,10 +308,13 @@
   &-error,
   &-failure {
     color: @veui-alert-color;
+    vertical-align: middle;
+    cursor: help;
   }
 
   &-success {
     color: @veui-success-color;
+    vertical-align: middle;
   }
 
   &-hide {
@@ -363,25 +326,25 @@
 
     .veui-uploader-list,
     .veui-uploader-list-image {
+      .clearfix();
+
       li {
-        display: inline-block;
+        float: left;
         margin-right: 10px;
       }
+    }
+
+    .veui-uploader-list-container {
+      width: auto;
     }
   }
 
   & &-button-remove {
-    float: right;
-    margin-right: 4px;
+    margin-right: -1px;
     color: @veui-gray-color-2;
     opacity: 0;
-    .centered-line(20px);
+    vertical-align: middle;
     transition: opacity @veui-transition-duration;
-
-    .veui-icon {
-      font-size: 10px;
-      margin-top: 5px;
-    }
   }
 
   &-list-enter,

--- a/packages/veui/build/dev-server.js
+++ b/packages/veui/build/dev-server.js
@@ -102,7 +102,7 @@ app.use('/upload', function (req, res) {
       result.reason = '图片尺寸不对'
     }
     res.json(result)
-  }, 1500)
+  }, 5000)
 })
 
 module.exports = app.listen(port, function (err) {

--- a/packages/veui/demo/cases/Button.vue
+++ b/packages/veui/demo/cases/Button.vue
@@ -91,6 +91,24 @@
       <veui-button ui="alt square" disabled><icon name="cross"></icon></veui-button>
       <veui-button ui="alt square" loading><icon name="cross"></icon></veui-button>
     </p>
+    <p>
+      <veui-button ui="dark micro">取消</veui-button>
+      <veui-button ui="dark tiny">取消</veui-button>
+      <veui-button ui="dark small">取消</veui-button>
+      <veui-button ui="dark">取消</veui-button>
+      <veui-button ui="dark large">取消</veui-button>
+      <veui-button ui="dark" disabled>取消</veui-button>
+      <veui-button ui="dark" loading>取消</veui-button>
+    </p>
+    <p>
+      <veui-button ui="dark square micro"><icon name="search"></icon></veui-button>
+      <veui-button ui="dark square tiny"><icon name="search"></icon></veui-button>
+      <veui-button ui="dark square small"><icon name="search"></icon></veui-button>
+      <veui-button ui="dark square"><icon name="search"></icon></veui-button>
+      <veui-button ui="dark square large"><icon name="search"></icon></veui-button>
+      <veui-button ui="dark square" disabled><icon name="search"></icon></veui-button>
+      <veui-button ui="dark square" loading><icon name="search"></icon></veui-button>
+    </p>
   </article>
 </template>
 

--- a/packages/veui/demo/cases/Uploader.vue
+++ b/packages/veui/demo/cases/Uploader.vue
@@ -11,7 +11,7 @@
       accept=".jpg,.jpeg,.gif"
       ui="horizontal"
       :payload="payload"
-      progress="number"
+      progress="percent"
       @success="onSuccess"
       @failure="onFailure"
       @change="handleChange('files')"
@@ -54,7 +54,9 @@
       class="extra-operation">
       <template slot="desc">请选择jpg,jpeg,gif图片，大小在10M以内，最多上传3张图</template>
       <template slot="extra-operation" slot-scope="file">
-        <veui-button class="extra-operation-button"
+        <veui-button
+          :ui="file.src ? 'dark' : null"
+          class="extra-operation-button"
           @click="openTooltip(file)"
           :ref="`add-image${file.index !== undefined ? '-' + file.index : ''}`">输入图片地址</veui-button>
       </template>
@@ -75,7 +77,7 @@
       accept=".jpg,.jpeg,.gif"
       :payload="payload"
       ui="horizontal"
-      progress="number"
+      progress="detail"
       @success="onSuccess"
       @failure="onFailure"
       @change="handleChange('files2')"

--- a/packages/veui/src/components/Alert.vue
+++ b/packages/veui/src/components/Alert.vue
@@ -2,7 +2,7 @@
 <div
   v-if="localOpen"
   class="veui-alert"
-  :ui="ui"
+  :ui="realUi"
   :class="`veui-alert-${type}`"
   role="alert" aria-expanded="true"
 >
@@ -20,7 +20,7 @@
 
     <div class="veui-alert-nav" v-if="isMultiple">
       <veui-button
-        ui="link"
+        :ui="uiParts.prev || 'link'"
         :disabled="isFirst"
         @click="switchMessage(-1)"
         aria-label="上一条"
@@ -32,7 +32,7 @@
         :aria-label="`第 ${localIndex + 1} 条，共 ${message.length} 条`"
       >{{ localIndex + 1 }}/{{ message.length }}</span>
       <veui-button
-        ui="link"
+        :ui="uiParts.next || 'link'"
         :disabled="isLast"
         @click="switchMessage(1)"
         aria-label="下一条"
@@ -45,12 +45,12 @@
       <veui-button
         v-if="realCloseLabel"
         class="veui-alert-close-text"
-        ui="link primary"
+        :ui="uiParts.close || 'link primary'"
         @click="close"
       >{{ realCloseLabel }}</veui-button>
       <veui-button
         v-else
-        ui="link"
+        :ui="uiParts.closeLabel || 'link'"
         @click="close"
         aria-label="关闭"
       >

--- a/packages/veui/src/components/AlertBox.vue
+++ b/packages/veui/src/components/AlertBox.vue
@@ -1,6 +1,6 @@
 <template>
 <veui-dialog
-  :ui="ui"
+  :ui="realUi"
   :overlay-class="mergeOverlayClass({
     'veui-alert-box': true,
     [`veui-alert-box-${type}`]: true

--- a/packages/veui/src/components/BreadcrumbItem.vue
+++ b/packages/veui/src/components/BreadcrumbItem.vue
@@ -1,7 +1,7 @@
 <template>
 <li class="veui-breadcrumb-item">
   <veui-link v-if="type === 'link'"
-    ui="link primary"
+    :ui="uiParts.link || 'link primary'"
     @click="$emit('redirect', $event)"
     :to="to"
     :replace="replace"

--- a/packages/veui/src/components/Button.vue
+++ b/packages/veui/src/components/Button.vue
@@ -1,8 +1,13 @@
 <template>
-<button class="veui-button" :class="{
+<button
+  :class="{
+    'veui-button': true,
     'veui-button-loading': loading,
     'veui-disabled': disabled
-  }" v-bind="attrs" v-on="listeners">
+  }"
+  :ui="realUi"
+  v-bind="attrs"
+  v-on="listeners">
   <template v-if="!loading"><slot/></template>
   <template v-else>
     <slot name="loading">

--- a/packages/veui/src/components/ButtonGroup.vue
+++ b/packages/veui/src/components/ButtonGroup.vue
@@ -4,14 +4,13 @@
     'veui-button-group': true,
     'veui-button-group-disabled': disabled
   }"
-  :ui="ui"
+  :ui="realUi"
   role="group"
   :aria-disabled="disabled">
   <slot>
     <veui-button
       v-for="(item, index) in items"
       :key="index"
-      :ui="inheritedUi"
       :disabled="disabled || item.disabled"
       @click="handleClick(item, index)"
       :aria-posinset="index + 1"

--- a/packages/veui/src/components/Calendar.vue
+++ b/packages/veui/src/components/Calendar.vue
@@ -1,7 +1,7 @@
 <template>
 <div
   class="veui-calendar"
-  :ui="ui"
+  :ui="realUi"
   role="application"
   aria-label="日历"
   :aria-disabled="realDisabled"

--- a/packages/veui/src/components/Carousel.vue
+++ b/packages/veui/src/components/Carousel.vue
@@ -1,5 +1,5 @@
 <template>
-<div class="veui-carousel" :ui="ui">
+<div class="veui-carousel" :ui="realUi">
   <div class="veui-carousel-viewport" @mouseenter="handleEnter" @mouseleave="handleLeave">
     <transition-group name="veui-carousel-item" class="veui-carousel-items" tag="ol">
       <li

--- a/packages/veui/src/components/CheckButtonGroup.vue
+++ b/packages/veui/src/components/CheckButtonGroup.vue
@@ -1,6 +1,6 @@
 <template>
 <div class="veui-check-button-group veui-button-group"
-  :ui="ui"
+  :ui="realUi"
   role="listbox"
   aria-multiselectable="true"
   :aria-readonly="String(realReadonly)"
@@ -9,7 +9,6 @@
     :class="{
       'veui-button-selected': localValue.indexOf(item.value) !== -1
     }"
-    :ui="inheritedUi"
     v-for="(item, index) in items"
     :key="index"
     :disabled="item.disabled || realDisabled || realReadonly"

--- a/packages/veui/src/components/Checkbox.vue
+++ b/packages/veui/src/components/Checkbox.vue
@@ -4,7 +4,7 @@
     'veui-checkbox': true,
     'veui-disabled': realReadonly || realDisabled
   }"
-  :ui="ui">
+  :ui="realUi">
   <input
     ref="box"
     type="checkbox"

--- a/packages/veui/src/components/CheckboxGroup.vue
+++ b/packages/veui/src/components/CheckboxGroup.vue
@@ -1,13 +1,12 @@
 <template>
 <div
   class="veui-checkbox-group"
-  :ui="ui"
+  :ui="realUi"
   role="listbox"
   aria-multiselectable="true"
   :aria-readonly="String(realReadonly)"
   :aria-disabled="String(realDisabled)">
-  <checkbox
-    :ui="ui"
+  <veui-checkbox
     :name="localName"
     v-for="(item, index) in items"
     :key="index"
@@ -19,7 +18,7 @@
     :aria-posinset="index + 1"
     :aria-setsize="items.length">
     <slot v-bind="item" :index="index">{{ item.label }}</slot>
-  </checkbox>
+  </veui-checkbox>
 </div>
 </template>
 
@@ -32,7 +31,7 @@ import Checkbox from './Checkbox'
 export default {
   name: 'veui-checkbox-group',
   components: {
-    'checkbox': Checkbox
+    'veui-checkbox': Checkbox
   },
   mixins: [ui, input],
   model: {

--- a/packages/veui/src/components/ConfirmBox.vue
+++ b/packages/veui/src/components/ConfirmBox.vue
@@ -1,6 +1,6 @@
 <template>
 <veui-dialog
-  :ui="ui"
+  :ui="realUi"
   :overlay-class="mergeOverlayClass('veui-confirm-box')"
   :open.sync="localOpen"
   :priority="priority"

--- a/packages/veui/src/components/DatePicker.vue
+++ b/packages/veui/src/components/DatePicker.vue
@@ -1,5 +1,5 @@
 <template>
-<div class="veui-date-picker" :ui="ui"
+<div class="veui-date-picker" :ui="realUi"
   :class="{
     'veui-input-invalid': realInvalid,
     'veui-date-picker-empty': !selected,
@@ -9,7 +9,6 @@
   <veui-button
     ref="button"
     class="veui-date-picker-button"
-    :ui="ui"
     :disabled="realDisabled || realReadonly"
     :aria-disabled="realDisabled"
     :aria-readonly="realReadonly"
@@ -64,7 +63,7 @@
       v-model="localSelected"
       v-bind="calendarProps"
       ref="cal"
-      :ui="inheritedUi"
+      :ui="uiParts.calendar"
       v-outside:button="close"
       @select="handleSelect"
       @selectstart="handleProgress"

--- a/packages/veui/src/components/Dialog.vue
+++ b/packages/veui/src/components/Dialog.vue
@@ -7,7 +7,7 @@
       'veui-dialog-box': true,
       'veui-dialog-box-mask': modal
     })"
-    :ui="ui"
+    :ui="realUi"
     autofocus
     :modal="modal"
     :priority="priority"

--- a/packages/veui/src/components/Dropdown.vue
+++ b/packages/veui/src/components/Dropdown.vue
@@ -1,7 +1,7 @@
 <template>
 <div
   ref="main"
-  :ui="ui"
+  :ui="realUi"
   :class="{
     'veui-dropdown': true,
     'veui-dropdown-expanded': expanded,
@@ -10,15 +10,13 @@
   <veui-button
     v-if="split"
     class="veui-dropdown-command"
-    @click="$emit('click')"
-    :ui="ui">
+    @click="$emit('click')">
     <span class="veui-dropdown-label">
       <slot name="label" :label="label">{{ label }}</slot>
     </span>
   </veui-button>
   <veui-button
     class="veui-dropdown-button"
-    :ui="ui"
     :disabled="disabled"
     aria-haspopup="menu"
     :aria-disabled="String(this.disabled)"
@@ -48,7 +46,6 @@
       }"
       tabindex="-1"
       role="menu"
-      :ui="ui"
       :aria-expanded="String(expanded)"
       @keydown.esc.stop="close"
       @keydown.down.prevent="navigate()"

--- a/packages/veui/src/components/FilterPanel.vue
+++ b/packages/veui/src/components/FilterPanel.vue
@@ -1,12 +1,12 @@
 <template>
-  <div class="veui-filter-panel" :ui="ui">
+  <div class="veui-filter-panel" :ui="realUi">
     <h3 class="veui-filter-panel-title">
       <slot name="head">标题</slot>
     </h3>
     <div class="veui-filter-panel-content">
       <veui-searchbox v-model="keyword"
         v-if="searchable"
-        ui="small"
+        :ui="uiParts.search"
         :placeholder="placeholder"
         @search="debounceSearch"
         @input="searchOnInput && debounceSearch()"></veui-searchbox>

--- a/packages/veui/src/components/Form/Field.vue
+++ b/packages/veui/src/components/Form/Field.vue
@@ -1,6 +1,6 @@
 <template>
 <div
-  :ui="ui"
+  :ui="realUi"
   :class="{
     'veui-field': true,
     'veui-field-invalid': !validity.valid,

--- a/packages/veui/src/components/Form/Fieldset.vue
+++ b/packages/veui/src/components/Form/Fieldset.vue
@@ -1,6 +1,6 @@
 <template>
 <veui-field
-  :ui="ui"
+  :ui="realUi"
   ref="field"
   class="veui-fieldset"
   :class="{

--- a/packages/veui/src/components/Form/Form.vue
+++ b/packages/veui/src/components/Form/Form.vue
@@ -1,6 +1,6 @@
 <template>
 <form
-  :ui="ui"
+  :ui="realUi"
   class="veui-form"
   @submit.prevent="handleSubmit"
   @reset.prevent="reset(null)">

--- a/packages/veui/src/components/Input.vue
+++ b/packages/veui/src/components/Input.vue
@@ -9,7 +9,7 @@
     'veui-readonly': realReadonly,
     'veui-disabled': realDisabled
   }"
-  :ui="ui"
+  :ui="realUi"
 >
   <template v-if="$slots.before">
     <div class="veui-input-before"><slot name="before"/></div>

--- a/packages/veui/src/components/Label.vue
+++ b/packages/veui/src/components/Label.vue
@@ -1,5 +1,5 @@
 <template>
-<label class="veui-label" :ui="ui" @click="activateInput"><slot/></label>
+<label class="veui-label" :ui="realUi" @click="activateInput"><slot/></label>
 </template>
 
 <script>

--- a/packages/veui/src/components/Link.vue
+++ b/packages/veui/src/components/Link.vue
@@ -2,13 +2,13 @@
 <component v-if="!to"
   :class="klass"
   :is="fallback"
-  :ui="ui"
+  :ui="realUi"
   :aria-disabled="String(disabled)"
   @click="handleRedirect"><slot/></component>
 <router-link v-else-if="$router && !native"
   :class="klass"
   :to="to"
-  :ui="ui"
+  :ui="realUi"
   :aria-disabled="String(disabled)"
   :replace="replace">
   <slot/>
@@ -16,7 +16,7 @@
 <a v-else
   :class="klass"
   :href="to"
-  :ui="ui"
+  :ui="realUi"
   :aria-disabled="String(disabled)"
   @click="handleRedirect">
   <slot/>

--- a/packages/veui/src/components/NumberInput.vue
+++ b/packages/veui/src/components/NumberInput.vue
@@ -3,7 +3,7 @@
       step,
       update: handleThumbNudgeUpdate
     }"
-    :ui="ui"
+    :ui="realUi"
     type="text"
     inputmode="numeric"
     ref="input"

--- a/packages/veui/src/components/Overlay.vue
+++ b/packages/veui/src/components/Overlay.vue
@@ -6,7 +6,7 @@
     <div
       class="veui-overlay-box"
       :class="realOverlayClass"
-      :ui="ui"
+      :ui="realUi"
       ref="box"
       :style="{zIndex}"
       v-show="realOpen">

--- a/packages/veui/src/components/Pagination.vue
+++ b/packages/veui/src/components/Pagination.vue
@@ -3,7 +3,7 @@
   class="veui-pagination"
   role="navigation"
   :aria-label="`选择分页，当前为第 ${page} 页，共 ${pageCount} 页`"
-  :ui="ui">
+  :ui="realUi">
   <div class="veui-pagination-info">
     <div class="veui-pagination-total">共 {{ realTotal }} 条</div>
     <div class="veui-pagination-size">

--- a/packages/veui/src/components/Progress.vue
+++ b/packages/veui/src/components/Progress.vue
@@ -7,7 +7,7 @@
   :aria-valuenow="realValue"
   :aria-valuetext="desc ? valueText : null"
   :class="klass"
-  :ui="ui">
+  :ui="realUi">
   <div v-if="desc" class="veui-progress-desc">
     <slot v-bind="{ percent, value: realValue, status }">
       <veui-icon :name="icons.success" v-if="type === 'circular' && localStatus === 'success'"/>

--- a/packages/veui/src/components/PromptBox.vue
+++ b/packages/veui/src/components/PromptBox.vue
@@ -1,6 +1,6 @@
 <template>
 <veui-dialog
-  :ui="ui"
+  :ui="realUi"
   :overlay-class="mergeOverlayClass('veui-prompt-box')"
   :open.sync="localOpen"
   :priority="priority"

--- a/packages/veui/src/components/Radio.vue
+++ b/packages/veui/src/components/Radio.vue
@@ -4,7 +4,7 @@
     'veui-radio': true,
     'veui-disabled': realReadonly || realDisabled
   }"
-  :ui="ui">
+  :ui="realUi">
   <input
     ref="box"
     type="radio"

--- a/packages/veui/src/components/RadioButtonGroup.vue
+++ b/packages/veui/src/components/RadioButtonGroup.vue
@@ -1,7 +1,7 @@
 <template>
 <div
   class="veui-radio-button-group veui-button-group"
-  :ui="ui"
+  :ui="realUi"
   role="radiogroup"
   :aria-readonly="String(realReadonly)"
   :aria-disabled="String(realDisabled)">
@@ -9,7 +9,6 @@
     :class="{
       'veui-button-selected': item.value === localValue
     }"
-    :ui="inheritedUi"
     v-for="(item, index) in items"
     :key="index"
     :disabled="item.disabled || realDisabled || realReadonly"

--- a/packages/veui/src/components/RadioGroup.vue
+++ b/packages/veui/src/components/RadioGroup.vue
@@ -1,12 +1,11 @@
 <template>
 <div
   class="veui-radio-group"
-  :ui="ui"
+  :ui="realUi"
   role="radiogroup"
   :aria-readonly="String(realReadonly)"
   :aria-disabled="String(realDisabled)">
   <veui-radio
-    :ui="ui"
     :name="localName"
     v-for="(item, index) in items"
     :key="index"

--- a/packages/veui/src/components/RegionPicker.vue
+++ b/packages/veui/src/components/RegionPicker.vue
@@ -1,7 +1,7 @@
 <template>
 <div
   class="veui-region-picker"
-  :ui="ui"
+  :ui="realUi"
   role="tree"
   aria-multiselectable="true"
   aria-label="地域选择，按 Tab 键在同一层级内导航，按左右箭头键切换层级">

--- a/packages/veui/src/components/Schedule.vue
+++ b/packages/veui/src/components/Schedule.vue
@@ -1,7 +1,7 @@
 <template>
 <div
   class="veui-schedule"
-  :ui="ui"
+  :ui="realUi"
   role="application"
   aria-label="时段选择"
   :aria-disabled="realDisabled"
@@ -21,7 +21,7 @@
             </template>
             <template v-else>
               <veui-dropdown
-                ui="link"
+                :ui="uiParts.shortcuts"
                 label="默认时段"
                 aria-label="选择预设时段"
                 :options="shortcutOptions"
@@ -47,7 +47,7 @@
     <div class="veui-schedule-head-day">
       <div class="veui-schedule-head-day-item" v-for="i in 7" :key="i">
         <veui-checkbox
-          ui="small"
+          :ui="uiParts.dayPicker"
           :indeterminate="dayChecked[i - 1].indeterminate"
           :checked="dayChecked[i - 1].checked"
           :aria-label="`选择星期${dayNames[i - 1]}全天`"
@@ -107,7 +107,7 @@
         trigger="hover"
         :delay="0"
         :interactive="false"
-        ui="small"
+        :ui="uiParts.tooltip"
         open>
         <slot name="tooltip" v-bind="current">{{ currentLabel }}</slot>
       </veui-tooltip>

--- a/packages/veui/src/components/Searchbox.vue
+++ b/packages/veui/src/components/Searchbox.vue
@@ -5,7 +5,7 @@
     'veui-disabled': realDisabled,
     'veui-readonly': realReadonly
   }"
-  :ui="ui"
+  :ui="realUi"
   @click="handleClickBox"
   ref="self"
 >
@@ -36,7 +36,7 @@
       >
         <veui-icon :name="icons.search"/>
       </button>
-      <veui-button :ui="`${inheritedUi} ${uiParts.button}`"
+      <veui-button :ui="uiParts.button"
         class="veui-searchbox-action-button"
         :disabled="realDisabled || realReadonly"
         aria-label="搜索"
@@ -54,8 +54,7 @@
     <div class="veui-searchbox-suggestion-overlay"
       ref="box"
       role="listbox"
-      :aria-expanded="String(realExpanded)"
-      :ui="inheritedUi">
+      :aria-expanded="String(realExpanded)">
       <slot name="suggestions" :suggestions="realSuggestions" :select="selectSuggestion">
         <template v-for="(suggestion, index) in realSuggestions">
           <div class="veui-searchbox-suggestion-item"

--- a/packages/veui/src/components/Select/Option.vue
+++ b/packages/veui/src/components/Select/Option.vue
@@ -4,7 +4,7 @@
   class="veui-option"
   v-show="!hidden"
   :tabindex="hidden ? -1 : false"
-  :ui="ui"
+  :ui="realUi"
   :class="{
     'veui-option-disabled': disabled,
     'veui-option-selected': selected

--- a/packages/veui/src/components/Select/OptionGroup.vue
+++ b/packages/veui/src/components/Select/OptionGroup.vue
@@ -78,7 +78,6 @@ export default {
         let option = { ...opt, selected: opt.value === this.value }
         return option.options
           ? <veui-option-group
-            ui={this.inheritedUi}
             label={option.label}
             options={option.options}
             position={option.position}
@@ -91,7 +90,6 @@ export default {
               'option-label': this.$scopedSlots['option-label'] || null
             }}/>
           : <veui-option
-            ui={this.inheritedUi}
             label={option.label}
             value={option.value}
             hidden={option.hidden}
@@ -121,7 +119,7 @@ export default {
         'veui-option-group-unlabelled': !this.label,
         'veui-option-group-expanded': this.expanded
       }}
-      ui={this.ui}
+      ui={this.realUi}
       ref="label">
       {
         this.label
@@ -180,7 +178,7 @@ export default {
               tabindex="-1"
               role={this.popupRole}
               aria-expanded={String(this.expanded)}
-              ui={this.ui}
+              ui={this.realUi}
               {...{
                 directives: [{
                   name: 'outside',

--- a/packages/veui/src/components/Select/Select.vue
+++ b/packages/veui/src/components/Select/Select.vue
@@ -86,11 +86,10 @@ export default {
         'veui-select-expanded': this.expanded,
         'veui-input-invalid': this.realInvalid
       }}
-      ui={this.ui}>
+      ui={this.realUi}>
       <veui-button
         ref="button"
         class="veui-select-button"
-        ui={this.ui}
         aria-haspopup="listbox"
         aria-disabled={String(this.realDisabled)}
         aria-readonly={String(this.realReadonly)}
@@ -133,7 +132,7 @@ export default {
             tabindex="-1"
             role="listbox"
             aria-expanded={String(this.expanded)}
-            ui={this.ui}
+            ui={this.realUi}
             onKeydown={this.handleKeydown}>
             {this.$slots.before}
             {
@@ -144,7 +143,7 @@ export default {
             <veui-option-group
               ref="options"
               options={this.realOptions}
-              ui={this.ui}
+              ui={this.realUi}
               scopedSlots={{
                 label: this.$scopedSlots['group-label'] || null,
                 option: this.$scopedSlots.option || null,

--- a/packages/veui/src/components/Slider.vue
+++ b/packages/veui/src/components/Slider.vue
@@ -1,7 +1,7 @@
 <template>
 <div
   :class="sliderClasses"
-  :ui="ui"
+  :ui="realUi"
   role="application">
   <!-- 条 -->
   <div class="veui-slider-track" @click="handleTrackClick" ref="track">

--- a/packages/veui/src/components/Sorter.vue
+++ b/packages/veui/src/components/Sorter.vue
@@ -1,5 +1,5 @@
 <template>
-<veui-icon :ui="ui" :class="klass" @click.native="sort">
+<veui-icon :ui="realUi" :class="klass" @click.native="sort">
   <veui-icon
     :class="{
       'veui-sorter-icon-asc': true,

--- a/packages/veui/src/components/Span.vue
+++ b/packages/veui/src/components/Span.vue
@@ -1,5 +1,5 @@
 <template>
-<span class="veui-span" :ui="ui"><slot/></span>
+<span class="veui-span" :ui="realUi"><slot/></span>
 </template>
 
 <script>

--- a/packages/veui/src/components/Steps.vue
+++ b/packages/veui/src/components/Steps.vue
@@ -1,7 +1,7 @@
 <template>
 <div
   class="veui-steps"
-  :ui="ui"
+  :ui="realUi"
   role="list">
   <veui-link
     v-for="(step, index) in steps"

--- a/packages/veui/src/components/Switch.vue
+++ b/packages/veui/src/components/Switch.vue
@@ -6,7 +6,7 @@
     'veui-readonly': realReadonly,
     'veui-disabled': realDisabled
   }"
-  :ui="ui">
+  :ui="realUi">
   <input
     type="checkbox"
     v-bind="attrs"

--- a/packages/veui/src/components/Table/Table.vue
+++ b/packages/veui/src/components/Table/Table.vue
@@ -1,5 +1,5 @@
 <template>
-<table class="veui-table" :ui="ui">
+<table class="veui-table" :ui="realUi">
   <slot/>
   <colgroup>
     <col v-if="selectable" width="60"/>

--- a/packages/veui/src/components/Tabs/Tabs.vue
+++ b/packages/veui/src/components/Tabs/Tabs.vue
@@ -7,7 +7,7 @@
     'veui-tabs-left-limited': leftLimited,
     'veui-tabs-right-limited': rightLimited
   }"
-  :ui="ui"
+  :ui="realUi"
   v-resize.debounce="listResizeHandler"
 >
   <div :class="{

--- a/packages/veui/src/components/Textarea.vue
+++ b/packages/veui/src/components/Textarea.vue
@@ -6,7 +6,7 @@
     'veui-input-invalid': realInvalid,
     'veui-readonly': realReadonly,
     'veui-disabled': realDisabled
-  }" :ui="ui">
+  }" :ui="realUi">
   <div ref="measurer" v-if="measure" class="veui-textarea-measurer">
     <div class="veui-textarea-measurer-line" v-for="(line, index) in lines" :key="index">
       <div

--- a/packages/veui/src/components/Toast.vue
+++ b/packages/veui/src/components/Toast.vue
@@ -2,7 +2,7 @@
 <transition name="veui-toast">
   <div
     v-if="open"
-    :ui="ui"
+    :ui="realUi"
     class="veui-toast"
     :class="`veui-toast-${type}`"
     role="alert">

--- a/packages/veui/src/components/Tooltip.vue
+++ b/packages/veui/src/components/Tooltip.vue
@@ -159,7 +159,7 @@ export default {
         })}>
         <div
           class="veui-tooltip"
-          ui={this.ui}
+          ui={this.realUi}
           role="tooltip"
           {...{directives}}>
           <div class="veui-tooltip-content">

--- a/packages/veui/src/components/Tree/Tree.vue
+++ b/packages/veui/src/components/Tree/Tree.vue
@@ -2,7 +2,7 @@
   <veui-tree-node :datasource="localDatasource"
     :item-click="itemClick"
     :icons="icons"
-    :ui="ui"
+    :ui="realUi"
     @toggle="toggle"
     @click="handleItemClick"
     v-if="this.$scopedSlots.item">
@@ -13,7 +13,7 @@
   <veui-tree-node :datasource="localDatasource"
     :item-click="itemClick"
     :icons="icons"
-    :ui="ui"
+    :ui="realUi"
     @toggle="toggle"
     @click="handleItemClick"
     v-else-if="this.$scopedSlots['item-label']">
@@ -24,7 +24,7 @@
   <veui-tree-node :datasource="localDatasource"
     :item-click="itemClick"
     :icons="icons"
-    :ui="ui"
+    :ui="realUi"
     @toggle="toggle"
     @click="handleItemClick"
     v-else/>

--- a/packages/veui/src/mixins/ui.js
+++ b/packages/veui/src/mixins/ui.js
@@ -1,7 +1,7 @@
 import { getConfigKey } from '../utils/helper'
 import warn from '../utils/warn'
 import config from '../managers/config'
-import { compact, uniq, find, includes, get, merge, filter } from 'lodash'
+import { compact, uniq, find, includes, get, merge, keys, pickBy } from 'lodash'
 
 export default {
   props: {
@@ -9,7 +9,7 @@ export default {
   },
   computed: {
     uiParts () {
-      return this.getComponentConfig('parts') || ''
+      return this.getComponentConfig('parts') || {}
     },
     uiProps () {
       let ui = (this.ui || '').trim()
@@ -17,7 +17,7 @@ export default {
       let { uiConfig = {} } = this
       return tokens.reduce(
         (result, token) => {
-          let name = find(Object.keys(uiConfig), name => {
+          let name = find(keys(uiConfig), name => {
             let { boolean = false, values = [] } = uiConfig[name]
             if (boolean) {
               return token === name
@@ -43,7 +43,7 @@ export default {
           }
           return result
         },
-        Object.keys(uiConfig).reduce((result, name) => {
+        keys(uiConfig).reduce((result, name) => {
           let prop = uiConfig[name]
           if (prop.boolean) {
             result[name] = false
@@ -59,7 +59,7 @@ export default {
     },
     uiData () {
       let { uiConfig = {}, uiProps } = this
-      return Object.keys(uiProps).reduce((result, name) => {
+      return keys(uiProps).reduce((result, name) => {
         let data = get(uiConfig[name], ['data', uiProps[name]], {})
         merge(result, data)
         return result
@@ -74,14 +74,30 @@ export default {
         ...uiIcons
       }
     },
-    inheritedUi () {
+    inheritedUiProps () {
       if (!this.uiConfig) {
         return this.ui
       }
-      return filter(this.uiProps, (val, key) => {
+
+      return pickBy(this.uiProps, (val, key) => {
         let uiProp = this.uiConfig[key]
-        return !uiProp || uiProp.inherit !== false
-      }).join(' ')
+        return !!uiProp.inherit
+      })
+    },
+    realUi () {
+      // merge ui & $parent's inheritedUi
+      let { uiProps = {} } = this
+      let overrides = pickBy(uiProps, (val, key) => {
+        return val !== 'default' || val === true
+      })
+      let { inheritedUiProps = {} } = this.$parent || {}
+      let props = { ...inheritedUiProps, ...overrides }
+      return keys(props).map(key => {
+        if (props[key] === true) {
+          return key
+        }
+        return props[key]
+      }).filter(val => val !== 'default').join(' ') || null
     }
   },
   methods: {


### PR DESCRIPTION
## ui 机制调整

1. 在主题包中指定 `ui` prop 是否可以继承；
2. 每个组件会自动 merge 父组件中的可继承的 `ui` prop；
3. `ui` mixin 中增加 `computed` 字段 `realUi`，每个组件自身输出用；
4. 在主题包中指定 `parts` 字段，来指定复合组件中内部部件的 `ui`；
5. `ui` mixin 中增加 `computed` 字段 `uiParts`，用来读取主题中为部件设置的 `ui`。

## Uploader 样式重构

尽量利用已有 `ui` 设置样式，去除部分直接使用 CSS 重写的样式。