### PR TITLE
Expandable row support for Table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### ⚠️ 非兼容性变更
 
-* `Uploader` 组件上传请求响应经过 `convert-response` 函数转换后，需要提供给组件执行后续操作的数据结构有所调整。目前仍然兼容老版本格式，但将在 `1.0.0` 移除。
+* [^] `Uploader` 组件上传请求响应经过 `convert-response` 函数转换后，需要提供给组件执行后续操作的数据结构有所调整。目前仍然兼容老版本格式，但将在 `1.0.0` 移除。
 
   > #### 迁移指南
   >
@@ -34,20 +34,20 @@
   > { "success": false, "message": "..." }
   > ```
 
-* 移除了 `managers/config` 的 `merge` 与 `mergeDefaults` 方法，现在对于 `Object` 类型的配置项需要提供完整值。
+* [-] 移除了 `managers/config` 的 `merge` 与 `mergeDefaults` 方法，现在对于 `Object` 类型的配置项需要提供完整值。
 
 ### 💡 主要变更
 
-* 新增了 I18N 支持，外置了所有文案，并添加了组件级别对应的 `zh-Hans` 与 `en-US` locale。
-* `veui-loader` 新增支持通过 `locale` 选项配置要自动引入的语言包。
-* `veui-loader` 新增支持通过 `global` 选项配置全局引入的模块。
-* `managers/config` 模块的配置现在为响应式数据，支持在组件渲染后进行全局修改。
-* `Field` 组件对应的数据字段名现在默认优先取 `name` prop，且可以被 `field` prop 覆盖。
-* `rule` 模板占位符由 `${...}` 变更为 `{...}`，以方便在模板字符串中进行书写。老语法仍然保持兼容。
-* `Calendar`、`DatePicker` 与 `Schedule` 的范围合并逻辑现在默认为“智能”模式，当用户从已选项开始选择范围时，将从整体已选范围中去除当前选区；当从未选项开始选择时，则将当前选区并入整体。
-* `Table` 组件新增 prop `scroll`，用来限定内容滚动区域的最大高度，设置时会使得表格的头/脚固定。
-* `Table` 组件新增 prop `expandable` 与 `expanded`，用来支持行展开。
-* `Link` 组件新增 prop `rel`、`target`，当 `target` 为 `_blank` 时自动为 `rel` 增加 `noopener` 值，以增强安全性。
+* [+] 新增了 I18N 支持，外置了所有文案，并添加了组件级别对应的 `zh-Hans` 与 `en-US` locale。
+* [+] `veui-loader` 新增支持通过 `locale` 选项配置要自动引入的语言包。
+* [+] `veui-loader` 新增支持通过 `global` 选项配置全局引入的模块。
+* [^] `managers/config` 模块的配置现在为响应式数据，支持在组件渲染后进行全局修改。
+* [^] `Field` 组件对应的数据字段名现在默认优先取 `name` prop，且可以被 `field` prop 覆盖。
+* [^] `rule` 模板占位符由 `${...}` 变更为 `{...}`，以方便在模板字符串中进行书写。老语法仍然保持兼容。
+* [^] `Calendar`、`DatePicker` 与 `Schedule` 的范围合并逻辑现在默认为“智能”模式，当用户从已选项开始选择范围时，将从整体已选范围中去除当前选区；当从未选项开始选择时，则将当前选区并入整体。
+* [+] `Table` 组件新增 prop `scroll`，用来限定内容滚动区域的最大高度，设置时会使得表格的头/脚固定。
+* [+] `Table` 组件新增 prop `expandable` 与 `expanded`，用来支持行展开。
+* [^] `Link` 组件新增 prop `rel`、`target`，当 `target` 为 `_blank` 时自动为 `rel` 增加 `noopener` 值，以增强安全性。
 
 ### 🐞 问题修复
 
@@ -60,19 +60,19 @@
 
 ### ⚠️ 非兼容性变更
 
-* 对 Vue-Awesome 的依赖升级到 `3.1.2`。如果之前有在项目中直接使用 `vue-awesome@2` 的，需要升级到最新版，否则无法混用 VEUI 与 VueAwesome 的图标。
-* `Breadcrumb` 组件的 `default` 作用域插槽重命名为 `item`，因为 Vue 实际的 fallback 逻辑，所以避免使用同名的 slot 和 scoped slot。
-* `Tooltip` 组件的 `custom` prop 被废弃，将在 `1.0.0` 移除。替代方式为：将 `trigger` prop 指定为 `custom` 来使用自定义逻辑控制打开及关闭。
-* `Pagination` 组件内部所有的 `class` 中的 `pager` 被更名为 `pagination`。如果在样式代码中进行过定制，请进行全局替换。
-* `Uploader` 组件的 `progress` prop 的 `'number'` 取值被替换为 `'percent'` 及 `'detail'`，分别表示显示百分比及显示进度详情。进度详情将以 <code>\`${loaded}KB/${total}KB\`</code> 的形式输出。
-* `Uploader` 组件的 prop `convert-response` 函数必须返回转换后的数据对象。
+* [^] 对 Vue-Awesome 的依赖升级到 `3.1.2`。如果之前有在项目中直接使用 `vue-awesome@2` 的，需要升级到最新版，否则无法混用 VEUI 与 VueAwesome 的图标。
+* [^] `Breadcrumb` 组件的 `default` 作用域插槽重命名为 `item`，因为 Vue 实际的 fallback 逻辑，所以避免使用同名的 slot 和 scoped slot。
+* [^] `Tooltip` 组件的 `custom` prop 被废弃，将在 `1.0.0` 移除。替代方式为：将 `trigger` prop 指定为 `custom` 来使用自定义逻辑控制打开及关闭。
+* [^] `Pagination` 组件内部所有的 `class` 中的 `pager` 被更名为 `pagination`。如果在样式代码中进行过定制，请进行全局替换。
+* [^] `Uploader` 组件的 `progress` prop 的 `'number'` 取值被替换为 `'percent'` 及 `'detail'`，分别表示显示百分比及显示进度详情。进度详情将以 <code>\`${loaded}KB/${total}KB\`</code> 的形式输出。
+* [^] `Uploader` 组件的 prop `convert-response` 函数必须返回转换后的数据对象。
 
 ### 💡 主要变更
 
-* 增加主题包为组件部件指定 `ui` 的功能，同时组件现在将自动继承父组件中可继承的 `ui` 字段，并更新了 `veui-theme-one` 中所有相应的部分。
-* `Breadcrumb` 组件的 scoped slot `item`（原 `default`）新增参数 `index`。
-* `Button` 组件增加 `ui` 选项 `dark`。
-* `rule` 的 `validate` 方法现在可以传入额外的上下文的数据，比如在 `Field` 验证时传入整个 `Form` 的 `data`。
+* [^] 增加主题包为组件部件指定 `ui` 的功能，同时组件现在将自动继承父组件中可继承的 `ui` 字段，并更新了 `veui-theme-one` 中所有相应的部分。
+* [+] `Breadcrumb` 组件的 scoped slot `item`（原 `default`）新增参数 `index`。
+* [+] `Button` 组件增加 `ui` 选项 `dark`。
+* [^] `rule` 的 `validate` 方法现在可以传入额外的上下文的数据，比如在 `Field` 验证时传入整个 `Form` 的 `data`。
 
 ### 🐞 问题修复
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * `Field` 组件对应的数据字段名现在默认优先取 `name` prop，且可以被 `field` prop 覆盖。
 * `rule` 模板占位符由 `${...}` 变更为 `{...}`，以方便在模板字符串中进行书写。老语法仍然保持兼容。
 * `Calendar`、`DatePicker` 与 `Schedule` 的范围合并逻辑现在默认为“智能”模式，当用户从已选项开始选择范围时，将从整体已选范围中去除当前选区；当从未选项开始选择时，则将当前选区并入整体。
+* `Table` 组件形状 prop `scroll`，用来限定内容滚动区域的最大高度，设置时会使得表格的头/脚固定。
 * `Link` 组件新增 prop `rel`、`target`，当 `target` 为 `_blank` 时自动为 `rel` 增加 `noopener` 值，以增强安全性。
 
 ### 🐞 问题修复
@@ -52,6 +53,7 @@
 * [^] 修正了 `GridContainer` 的左右边距计算。
 * [^] 修正了 `Link` 组件在默认模式下 `disabled` 未起效的问题。
 * [^] 修正了 `Uploader` 组件 `remove` 事件的回调参数 `file` 提供了错误的文件的问题。
+* [^] 修正了未注册的 `ui` 值不能直接输出的问题（[#378](https://github.com/ecomfe/veui/issues/378)）。
 
 ## 1.0.0-alpha.18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,8 @@
 * `Field` 组件对应的数据字段名现在默认优先取 `name` prop，且可以被 `field` prop 覆盖。
 * `rule` 模板占位符由 `${...}` 变更为 `{...}`，以方便在模板字符串中进行书写。老语法仍然保持兼容。
 * `Calendar`、`DatePicker` 与 `Schedule` 的范围合并逻辑现在默认为“智能”模式，当用户从已选项开始选择范围时，将从整体已选范围中去除当前选区；当从未选项开始选择时，则将当前选区并入整体。
-* `Table` 组件形状 prop `scroll`，用来限定内容滚动区域的最大高度，设置时会使得表格的头/脚固定。
+* `Table` 组件新增 prop `scroll`，用来限定内容滚动区域的最大高度，设置时会使得表格的头/脚固定。
+* `Table` 组件新增 prop `expandable` 与 `expanded`，用来支持行展开。
 * `Link` 组件新增 prop `rel`、`target`，当 `target` 为 `_blank` 时自动为 `rel` 增加 `noopener` 值，以增强安全性。
 
 ### 🐞 问题修复

--- a/packages/veui-theme-one/components/Table.js
+++ b/packages/veui-theme-one/components/Table.js
@@ -9,7 +9,7 @@ config.defaults({
       boolean: true
     },
     bordered: {
-      bolean: true
+      boolean: true
     }
   }
 }, 'table')

--- a/packages/veui-theme-one/components/Table.js
+++ b/packages/veui-theme-one/components/Table.js
@@ -1,6 +1,11 @@
 import config from 'veui/managers/config'
+import '../icons/angle-right'
 
 config.defaults({
+  icons: {
+    expand: 'angle-right',
+    collapse: 'angle-right'
+  },
   ui: {
     slim: {
       boolean: true

--- a/packages/veui-theme-one/components/table.less
+++ b/packages/veui-theme-one/components/table.less
@@ -1,15 +1,37 @@
 @import "../lib.less";
 
 .veui-table {
-  table-layout: fixed;
-  width: 100%;
-  border-collapse: collapse;
   color: @veui-text-color-normal;
+
+  table {
+    width: 100%;
+    table-layout: fixed;
+    border-collapse: collapse;
+  }
+
+  &-fixed-header {
+    position: relative;
+    margin-bottom: -1px;
+    border-bottom: 1px solid @veui-gray-color-7;
+  }
+
+  &-fixed-footer {
+    margin-top: -1px;
+    border-top: 1px solid @veui-gray-color-7;
+  }
+
+  &-fixed-header + &-main {
+    overflow: auto;
+  }
 
   &-cell {
     display: inline-block;
     line-height: 2;
     vertical-align: middle;
+  }
+
+  &-row-selector {
+    width: 60px;
   }
 
   th,
@@ -31,6 +53,7 @@
 
   tfoot th {
     border-top: none;
+    border-bottom: 1px solid @veui-gray-color-7;
   }
 
   td&-no-data {

--- a/packages/veui-theme-one/components/table.less
+++ b/packages/veui-theme-one/components/table.less
@@ -30,8 +30,12 @@
     vertical-align: middle;
   }
 
-  &-row-selector {
+  &-col-select {
     width: 60px;
+  }
+
+  &-col-expand {
+    width: 24px;
   }
 
   th,
@@ -40,6 +44,7 @@
     .padding(_, 16px);
     text-align: left;
     white-space: nowrap;
+    transition: background-color @veui-transition-duration;
   }
 
   th {
@@ -59,12 +64,6 @@
   td&-no-data {
     height: 300px;
     text-align: center;
-  }
-
-  .veui-table-selected-row {
-    td {
-      background-color: @veui-gray-color-9;
-    }
   }
 
   tr:hover {
@@ -104,6 +103,64 @@
     font-size: @veui-font-size-small;
   }
 
+  & &-cell-expand {
+    padding: 0 0 0 10px;
+    text-align: center;
+
+    & + th,
+    & + td {
+      padding-left: 10px;
+    }
+  }
+
+  &-cell-expand {
+    button {
+      .size(1em);
+      background: none;
+      outline: none;
+      border: none;
+      padding: 0;
+      color: @veui-text-color-weak;
+      cursor: pointer;
+      vertical-align: middle;
+      .veui-button-transition();
+
+      &:hover,
+      &.focus-visible {
+        color: @veui-brand-color;
+      }
+
+      &:active {
+        color: @veui-brand-color-1;
+      }
+
+      .veui-icon {
+        display: block;
+      }
+    }
+  }
+
+  &-sub-row {
+    td {
+      background-color: @veui-gray-color-8;
+    }
+
+    &:hover .veui-table-cell-expand {
+      background-color: #fff;
+    }
+  }
+
+  &-sub-row &-cell-expand {
+    position: relative;
+    background-color: #fff;
+
+    &::before {
+      content: "";
+      .absolute(-1px, 0, _);
+      border-top: 1px solid #fff;
+    }
+  }
+
   &[ui~="slim"] {
     th,
     td {
@@ -126,6 +183,14 @@
 
     &:last-child {
       border-right: none;
+    }
+  }
+
+  &-expander {
+    transition: transform @veui-transition-duration;
+
+    &-collapse {
+      transform: rotateZ(90deg);
     }
   }
 }

--- a/packages/veui/demo/cases/Table.vue
+++ b/packages/veui/demo/cases/Table.vue
@@ -22,7 +22,7 @@
       ]"/>
     </section>
     <section>
-      <veui-table ui="alt bordered" :data="data" :column-filter="columns" :key-field="selectSpanRow ? 'group' : 'id'" selectable
+      <veui-table ui="alt bordered custom" scroll="150" :data="data" :column-filter="columns" :key-field="selectSpanRow ? 'group' : 'id'" selectable
         :order-by="orderBy" :order="order" @select="handleSelect" @sort="handleSort" :selected.sync="selected1">
         <veui-table-column field="id" title="数据 ID" sortable>
           <template slot="head"><strong>数据 <span style="color: #3998fc">ID</span></strong></template>

--- a/packages/veui/demo/cases/Table.vue
+++ b/packages/veui/demo/cases/Table.vue
@@ -71,6 +71,42 @@
       </veui-table>
       <p>已选ID：{{ JSON.stringify(selected2) }}</p>
     </section>
+    <section class="container">
+      <veui-table :data="data" :column-filter="columns" key-field="id" selectable expandable>
+        <veui-table-column field="id" title="数据 ID"/>
+        <veui-table-column field="desc" title="数据描述"/>
+        <veui-table-column field="price" title="价格" width="160" align="right">
+          <template slot-scope="props">{{ props.item.price | currency }}</template>
+        </veui-table-column>
+        <veui-table-column field="updateDate" title="更新时间" align="right">
+          <template slot-scope="props">
+            <span :ref="`time-b-${props.item.id}`">{{ props.item.updateDate | date }}</span>
+            <veui-tooltip :target="`time-b-${props.item.id}`">{{ props.item.updateDate | time }}</veui-tooltip>
+          </template>
+        </veui-table-column>
+        <template slot="sub-row" slot-scope="{ desc }">{{ desc }}</template>
+      </veui-table>
+    </section>
+    <section class="container">
+      <veui-table :data="data" :column-filter="columns" key-field="id" expandable>
+        <veui-table-column field="id" title="数据 ID">
+          <template slot="sub-row" slot-scope="{ id }">
+            <em>{{ id }}</em>
+          </template>
+        </veui-table-column>
+        <veui-table-column field="desc" title="数据描述"/>
+        <veui-table-column field="price" title="价格" width="160" align="right">
+          <template slot-scope="props">{{ props.item.price | currency }}</template>
+        </veui-table-column>
+        <veui-table-column field="updateDate" title="更新时间" align="right">
+          <template slot-scope="props">
+            <span :ref="`time-b-${props.item.id}`">{{ props.item.updateDate | date }}</span>
+            <veui-tooltip :target="`time-b-${props.item.id}`">{{ props.item.updateDate | time }}</veui-tooltip>
+          </template>
+        </veui-table-column>
+        <template slot="foot">An awesome table foot!</template>
+      </veui-table>
+    </section>
   </article>
 </template>
 
@@ -106,16 +142,68 @@ export default {
       selectSpanRow: true,
       data: [
         {
-          id: '3154', desc: '数据描述1', price: 1024, updateDate: '20131117', group: '1577', typeId: '788'
+          id: '3154',
+          desc: '数据描述1',
+          price: 1024,
+          updateDate: '20131117',
+          group: '1577',
+          typeId: '788',
+          children: [
+            {
+              id: '31541', desc: '数据描述1-1', price: 1024, updateDate: '20131117', group: '1577', typeId: '788'
+            },
+            {
+              id: '31542', desc: '数据描述1-2', price: 1024, updateDate: '20131117', group: '1577', typeId: '788'
+            }
+          ]
         },
         {
-          id: '3155', desc: '数据描述2', price: 598, updateDate: '20140214', group: '1577', typeId: '788'
+          id: '3155',
+          desc: '数据描述2',
+          price: 598,
+          updateDate: '20140214',
+          group: '1577',
+          typeId: '788',
+          children: [
+            {
+              id: '31551', desc: '数据描述2-1', price: 1024, updateDate: '20131117', group: '1577', typeId: '788'
+            },
+            {
+              id: '31552', desc: '数据描述2-2', price: 1024, updateDate: '20131117', group: '1577', typeId: '788'
+            }
+          ]
         },
         {
-          id: '3156', desc: '数据描述3', price: 820, updateDate: '20170610', group: '1578', typeId: '788'
+          id: '3156',
+          desc: '数据描述3',
+          price: 820,
+          updateDate: '20170610',
+          group: '1578',
+          typeId: '788',
+          children: [
+            {
+              id: '31561', desc: '数据描述3-1', price: 1024, updateDate: '20131117', group: '1577', typeId: '788'
+            },
+            {
+              id: '31562', desc: '数据描述3-2', price: 1024, updateDate: '20131117', group: '1577', typeId: '788'
+            }
+          ]
         },
         {
-          id: '3157', desc: '数据描述4', price: 736, updateDate: '20180109', group: '1578', typeId: '788'
+          id: '3157',
+          desc: '数据描述4',
+          price: 736,
+          updateDate: '20180109',
+          group: '1578',
+          typeId: '788',
+          children: [
+            {
+              id: '31571', desc: '数据描述4-1', price: 1024, updateDate: '20131117', group: '1577', typeId: '788'
+            },
+            {
+              id: '31572', desc: '数据描述4-2', price: 1024, updateDate: '20131117', group: '1577', typeId: '788'
+            }
+          ]
         }
       ],
       nextId: 3158,

--- a/packages/veui/src/components/Table/Column.vue
+++ b/packages/veui/src/components/Table/Column.vue
@@ -37,17 +37,27 @@ export default {
 
     const props = ['title', 'field', 'sortable', 'width', 'align', 'span']
 
+    let renderBody = item => {
+      let defaultRow = this.$scopedSlots.default
+      if (defaultRow) {
+        return defaultRow(item)
+      }
+      return item[this.field]
+    }
+
     this.table.add({
       ...pick(this, ...props, 'id'),
       index,
       hasFoot: () => {
         return !!this.$slots.foot
       },
-      renderBody: item => {
-        if (this.$scopedSlots.default) {
-          return this.$scopedSlots.default(item)
+      renderBody,
+      renderSubRow: item => {
+        let expandRow = this.$scopedSlots['sub-row']
+        if (expandRow) {
+          return expandRow(item)
         }
-        return item[this.field]
+        return renderBody(item)
       },
       renderHead: () => {
         return this.$slots.head || this.title

--- a/packages/veui/src/components/Table/Table.vue
+++ b/packages/veui/src/components/Table/Table.vue
@@ -1,8 +1,8 @@
 <template>
 <div class="veui-table" :ui="realUi">
-  <div v-if="realScroll.y" class="veui-table-fixed-header" aria-hidden="true">
+  <div v-if="scrollableY" class="veui-table-fixed-header" aria-hidden="true">
     <table>
-      <colgroup gutter/>
+      <col-group gutter/>
       <table-head @sort="sort"/>
     </table>
   </div>
@@ -10,20 +10,20 @@
     class="veui-table-main"
     ref="main"
     :style="{
-      maxHeight: realScroll.y
+      maxHeight: scrollableY ? realScroll.y : null
     }"
   >
     <table>
       <slot/>
-      <colgroup/>
-      <table-head v-if="!realScroll.y" @sort="sort"/>
+      <col-group/>
+      <table-head v-if="!scrollableY" @sort="sort"/>
       <table-body><template slot="no-data"><slot name="no-data">{{ t('noData') }}</slot></template></table-body>
-      <table-foot v-if="!realScroll.y && hasFoot"><slot name="foot"/></table-foot>
+      <table-foot v-if="!scrollableY && hasFoot"><slot name="foot"/></table-foot>
     </table>
   </div>
-  <div v-if="realScroll.y" class="veui-table-fixed-footer" aria-hidden="true">
+  <div v-if="scrollableY" class="veui-table-fixed-footer" aria-hidden="true">
     <table>
-      <colgroup gutter/>
+      <col-group gutter/>
       <table-foot v-if="hasFoot"><slot name="foot"/></table-foot>
     </table>
   </div>
@@ -167,6 +167,9 @@ export default {
     },
     hasFoot () {
       return this.$slots.foot || this.columns.some(col => col.hasFoot())
+    },
+    scrollableY () {
+      return this.realScroll.y && this.data.length
     }
   },
   methods: {

--- a/packages/veui/src/components/Table/_ColGroup.js
+++ b/packages/veui/src/components/Table/_ColGroup.js
@@ -10,6 +10,7 @@ export default {
     ...table.mapTableData(
       { realColumns: 'columns' },
       'selectable',
+      'expandable',
       'columnWidths',
       'gutterWidth'
     )
@@ -17,7 +18,8 @@ export default {
   render () {
     return (
       <colgroup>
-        {this.selectable ? <col class="veui-table-row-selector" /> : null}
+        {this.selectable ? <col class="veui-table-col-select" /> : null}
+        {this.expandable ? <col class="veui-table-col-expand" /> : null}
         {this.columns.map((col, i) => (
           <col
             style={{

--- a/packages/veui/src/components/Table/_ColGroup.js
+++ b/packages/veui/src/components/Table/_ColGroup.js
@@ -1,0 +1,42 @@
+import table from '../../mixins/table'
+
+export default {
+  name: 'veui-table-col-group',
+  mixins: [table],
+  props: {
+    gutter: Boolean
+  },
+  computed: {
+    ...table.mapTableData(
+      { realColumns: 'columns' },
+      'selectable',
+      'columnWidths',
+      'gutterWidth'
+    )
+  },
+  render () {
+    return (
+      <colgroup>
+        {this.selectable ? <col class="veui-table-row-selector" /> : null}
+        {this.columns.map((col, i) => (
+          <col
+            style={{
+              width: this.columnWidths[i]
+            }}
+            key={col.field}
+          />
+        ))}
+        {this.gutter ? (
+          <col
+            class="veui-table-header-gutter"
+            aria-hidden="true"
+            style={{
+              width: this.gutterWidth ? `${this.gutterWidth}px` : null,
+              display: this.gutterWidth ? null : 'none'
+            }}
+          />
+        ) : null}
+      </colgroup>
+    )
+  }
+}

--- a/packages/veui/src/components/Table/_TableBody.js
+++ b/packages/veui/src/components/Table/_TableBody.js
@@ -15,7 +15,7 @@ export default {
       'selectable',
       'expandable',
       'keyField',
-      'keys',
+      { realKeys: 'keys' },
       { localExpanded: 'expanded' },
       { realColumns: 'columns' },
       { viewColumnCount: 'columnCount' }

--- a/packages/veui/src/components/Table/_TableFoot.js
+++ b/packages/veui/src/components/Table/_TableFoot.js
@@ -5,9 +5,10 @@ export default {
   mixins: [table],
   computed: {
     ...table.mapTableData(
-      { realColumns: 'columns' },
       'selectable',
-      'selectStatus'
+      'expandable',
+      { realColumns: 'columns' },
+      { viewColumnCount: 'columnCount' }
     )
   },
   render () {
@@ -16,12 +17,14 @@ export default {
         <tr>
           {
             this.$slots.default
-              ? <th colspan={this.columns.length + (this.table.selectable ? 1 : 0)}>{this.$slots.default}</th>
-              : (this.table.selectable ? [<th></th>] : []).concat(
-                this.columns.map(col => (
-                  <th class={col.align ? `veui-table-column-${col.align}` : null}>{col.renderFoot()}</th>
-                ))
-              )
+              ? <th colspan={this.columnCount}>{this.$slots.default}</th>
+              : (this.selectable ? [<th></th>] : [])
+                .concat(this.expandable ? [<th></th>] : [])
+                .concat(
+                  this.columns.map(col => (
+                    <th class={col.align ? `veui-table-column-${col.align}` : null}>{col.renderFoot()}</th>
+                  ))
+                )
           }
         </tr>
       </tfoot>

--- a/packages/veui/src/components/Table/_TableHead.js
+++ b/packages/veui/src/components/Table/_TableHead.js
@@ -18,7 +18,9 @@ export default {
       'selectable',
       'selectMode',
       'selectStatus',
-      { realColumns: 'columns' }
+      'expandable',
+      { realColumns: 'columns' },
+      { viewColumnCount: 'columnCount' }
     )
   },
   render () {
@@ -28,7 +30,7 @@ export default {
           {
             this.selectable
               ? (
-                <th scope="col" role="columnheader">
+                <th scope="col" role="columnheader" class="veui-table-cell-select">
                   <div class="veui-table-cell">
                     {
                       this.selectMode === 'multiple'
@@ -43,6 +45,7 @@ export default {
               )
               : null
           }
+          {this.expandable ? <th class="veui-table-cell-expand"></th> : null}
           {
             this.columns.map(col => (
               <th

--- a/packages/veui/src/components/Table/_TableHead.js
+++ b/packages/veui/src/components/Table/_TableHead.js
@@ -66,6 +66,9 @@ export default {
               </th>
             ))
           }
+          {
+            this.table.gutterWidth ? <th aria-hidden="true"></th> : null
+          }
         </tr>
       </thead>
     )

--- a/packages/veui/src/components/Table/_TableRow.js
+++ b/packages/veui/src/components/Table/_TableRow.js
@@ -1,6 +1,8 @@
 import { find } from 'lodash'
 import Checkbox from '../Checkbox'
 import Radio from '../Radio'
+import Button from '../Button'
+import Icon from '../Icon'
 import table from '../../mixins/table'
 import i18n from '../../mixins/i18n'
 
@@ -8,27 +10,53 @@ export default {
   name: 'veui-table-row',
   components: {
     'veui-checkbox': Checkbox,
-    'veui-radio': Radio
+    'veui-radio': Radio,
+    'veui-button': Button,
+    'veui-icon': Icon
   },
   mixins: [table, i18n],
   props: {
-    index: {
-      type: Number,
-      required: true
-    }
+    index: Number,
+    item: Object,
+    expanded: Boolean
   },
   computed: {
     ...table.mapTableData(
       'data',
-      { realColumns: 'columns' },
       'selectable',
       'selectMode',
       'selectedItems',
+      'expandable',
       'keyField',
-      { realKeys: 'keys' }
+      'icons',
+      { realKeys: 'keys' },
+      { realColumns: 'columns' },
+      { viewColumnCount: 'columnCount' }
     )
   },
   render () {
+    // hero sub row
+    if (this.$slots.default) {
+      return (
+        <tr class="veui-table-sub-row">
+          <td role="cell" colspan={this.columnCount}>
+            <div class="veui-table-cell">{this.$slots.default}</div>
+          </td>
+        </tr>
+      )
+    }
+
+    // isomorphic sub row
+    if (this.item) {
+      return (
+        <tr class="veui-table-sub-row">
+          {this.selectable ? <td role="cell" class="veui-table-cell-select"></td> : null}
+          {this.expandable ? <td role="cell" class="veui-table-cell-expand"></td> : null}
+          {this.renderColumns(this.index, this.item)}
+        </tr>
+      )
+    }
+
     let index = this.index
     let item = this.data[index]
     let key = this.keyField
@@ -61,17 +89,28 @@ export default {
           : null
       }
       {
-        this.columns.map(col => {
-          let data = this.getCellSpan(col)
-          return data
-            ? <td
-              class={col.align ? `veui-table-column-${col.align}` : null}
-              role="cell"
-              {...data}>
-              <div class="veui-table-cell">{col.renderBody({ ...item, item, index })}</div>
-            </td>
-            : null
-        })
+        this.expandable
+          ? <td role="cell" class="veui-table-cell-expand">
+            {
+              (item.children || []).length
+                ? (
+                  <button
+                    label={this.t(this.expanded ? '@table.collapseRow' : '@table.expandRow')}
+                    onClick={() => { this.table.expand(!this.expanded, index) }}>
+                    <transition name="veui-table-expander">
+                      <veui-icon
+                        class={`veui-table-expander veui-table-expander-${this.expanded ? 'collapse' : 'expand'}`}
+                        name={this.expanded ? this.icons.collapse : this.icons.expand}/>
+                    </transition>
+                  </button>
+                )
+                : null
+            }
+          </td>
+          : null
+      }
+      {
+        this.renderColumns(index)
       }
     </tr>
   },
@@ -96,6 +135,25 @@ export default {
       }
 
       return data
+    },
+    renderColumns (index, subItem) {
+      let isSubRow = !!subItem
+      let item = subItem || this.data[index]
+      return this.columns.map(col => {
+        let data = this.getCellSpan(col)
+        return data
+          ? <td
+            class={col.align ? `veui-table-column-${col.align}` : null}
+            role="cell"
+            {...data}>
+            <div class="veui-table-cell">
+              {
+                (isSubRow ? col.renderSubRow : col.renderBody)({ ...item, item, index })
+              }
+            </div>
+          </td>
+          : null
+      })
     }
   }
 }

--- a/packages/veui/src/components/Table/_TableRow.js
+++ b/packages/veui/src/components/Table/_TableRow.js
@@ -95,7 +95,7 @@ export default {
               (item.children || []).length
                 ? (
                   <button
-                    label={this.t(this.expanded ? '@table.collapseRow' : '@table.expandRow')}
+                    aria-label={this.t(this.expanded ? '@table.collapseRow' : '@table.expandRow')}
                     onClick={() => { this.table.expand(!this.expanded, index) }}>
                     <transition name="veui-table-expander">
                       <veui-icon

--- a/packages/veui/src/locale/en-US/Table.js
+++ b/packages/veui/src/locale/en-US/Table.js
@@ -7,7 +7,9 @@ i18n.register(
     selectAll: 'Select all',
     unselectAll: 'Unselect all',
     selectRow: 'Select row',
-    deselectRow: 'Deselect row'
+    deselectRow: 'Deselect row',
+    expandRow: 'Expand row',
+    collapseRow: 'Collapse row'
   },
   {
     ns: 'table'

--- a/packages/veui/src/locale/zh-Hans/Table.js
+++ b/packages/veui/src/locale/zh-Hans/Table.js
@@ -7,7 +7,9 @@ i18n.register(
     selectAll: '选中全部',
     unselectAll: '取消选中全部',
     selectRow: '选中本行',
-    deselectRow: '取消选中本行'
+    deselectRow: '取消选中本行',
+    expandRow: '展开本行',
+    collapseRow: '收起本行'
   },
   {
     ns: 'table'

--- a/packages/veui/src/utils/browser.js
+++ b/packages/veui/src/utils/browser.js
@@ -1,0 +1,21 @@
+let scrollbarWidth = null
+
+export function getScrollbarWidth () {
+  if (scrollbarWidth !== null) {
+    return scrollbarWidth
+  }
+
+  let measurer = document.createElement('div')
+  measurer.style.cssText = 'height:1px;overflow-y:scroll'
+  document.body.appendChild(measurer)
+  scrollbarWidth = measurer.offsetWidth - measurer.clientWidth
+  document.body.removeChild(measurer)
+  return scrollbarWidth
+}
+
+export function getElementScrollbarWidth (el, horizontal) {
+  if (horizontal) {
+    return el.offsetHeight - el.clientHeight
+  }
+  return el.offsetWidth - el.clientWidth
+}

--- a/packages/veui/src/utils/helper.js
+++ b/packages/veui/src/utils/helper.js
@@ -232,3 +232,14 @@ export function deepSet (obj, path, val) {
     context = context[s]
   })
 }
+
+const RE_NUMBER = /^(?:\d*(?:\.\d+)?|\.\d+)$/
+export function normalizeLength (val) {
+  if (!val) {
+    return null
+  }
+  if ((typeof val === 'number' || RE_NUMBER.test(val))) {
+    return Number(val) > 0 ? `${val}px` : null
+  }
+  return val
+}


### PR DESCRIPTION
> （这个 PR 直接 rebase 了 #383）

使用方法：

* `Table` 增加 `expandable` prop，为 `true` 则支持行展开
* 展开行默认与主行的列配置一致（使用 `Column` 组件配置），采用 `data` 项中 `children` 数组座位对应行的数据源
* `Column` 增加了 scoped slot `sub-row`，支持为展开行定制内容格式
* `Table` 也增加了 scoped slot `sub-row`，用来展示打通所有列的展开行，此时覆盖 `Column` 中的配置