### PR TITLE
feat: add `matches` for `Tabs` & `Tab`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [^] 在控制台警告中增加了组件层级信息。
 * [^] 为 `Tree`/`FilterPanel`/`Transfer` 组件的增加了键盘交互。
 * [^] 为所有支持聚焦或激活操作的组件添加了 `focus` 或 `activate` 方法。
+* [^] 对于使用路由模式的 `Tabs` 及 `Tab` 组件，新增函数 prop `matches(current, to)` 来允许指定自定义的激活状态判断，不再需要手动在 `Tabs` 组件中控制 `index`。`Tab` 组件的 `matches` 逻辑优先于上层 `Tabs` 组件中的 `matches`。
 * [^] 使用了更为显著的聚焦样式。
 
 ### 🐞 问题修复

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@
 
 * [+] `Searchbox` 新增了 `suggestions-before` 与 `suggestions-after` 两个插槽。
 * [^] `Searchbox` 提示层只在选择选项后关闭，如果点击自定义插槽而非默认的选择选项时，提示层不再自动关闭。
-* [^] 在控制台警告中增加了组件层级信息。
-* [^] 为 `Tree`/`FilterPanel`/`Transfer` 组件的增加了键盘交互。
-* [^] 为所有支持聚焦或激活操作的组件添加了 `focus` 或 `activate` 方法。
-* [^] 对于使用路由模式的 `Tabs` 及 `Tab` 组件，新增函数 prop `matches(current, to)` 来允许指定自定义的激活状态判断，不再需要手动在 `Tabs` 组件中控制 `index`。`Tab` 组件的 `matches` 逻辑优先于上层 `Tabs` 组件中的 `matches`。
+* [+] 在控制台警告中增加了组件层级信息。
+* [+] 为 `Tree`/`FilterPanel`/`Transfer` 组件的增加了键盘交互。
+* [+] 为所有支持聚焦或激活操作的组件添加了 `focus` 或 `activate` 方法。
+* [+] 对于使用路由模式的 `Tabs` 及 `Tab` 组件，新增函数 prop `matches(current, to)` 来允许指定自定义的激活状态判断，不再需要手动在 `Tabs` 组件中控制 `index`。`Tab` 组件的 `matches` 逻辑优先于上层 `Tabs` 组件中的 `matches`。
+* [+] 增加了全局配置项 `tabs.matches` 来允许全局自定义 `Tab` 组件 `matches` prop 的默认值。
 * [^] 使用了更为显著的聚焦样式。
 
 ### 🐞 问题修复

--- a/packages/veui/demo/cases/Tabs.vue
+++ b/packages/veui/demo/cases/Tabs.vue
@@ -190,7 +190,7 @@
   </section>
   <section>
     <h2>路由模式：</h2>
-    <veui-tabs :active="$route.fullPath">
+    <veui-tabs :matches="(current, to) => current.path === to.path">
       <veui-tab
         label="Button"
         to="/tabs/button"

--- a/packages/veui/src/components/Tabs/Tab.vue
+++ b/packages/veui/src/components/Tabs/Tab.vue
@@ -6,7 +6,7 @@
   :aria-hidden="String(!isActive)"
 >
   <slot v-if="isInited || isActive">
-    <router-view v-if="to && $route && realTo === $route.fullPath"/>
+    <router-view v-if="to && $route && isMatched"/>
   </slot>
 </div>
 </template>
@@ -38,6 +38,7 @@ export default {
       type: [String, Object],
       default: ''
     },
+    matches: Function,
     native: Boolean,
     removable: {
       type: Boolean,
@@ -66,7 +67,15 @@ export default {
         return null
       }
 
-      return this.$router ? this.$router.resolve(this.to).route.fullPath : this.to
+      return this.$router && typeof this.to === 'string'
+        ? this.$router.resolve(this.to).route
+        : this.to
+    },
+    realMatches () {
+      return this.matches || this.tabs.matches || (() => false)
+    },
+    isMatched () {
+      return this.realMatches(this.$route, this.realTo)
     }
   },
   created () {
@@ -80,9 +89,9 @@ export default {
 
     this.tabs.add({
       ...pick(this, ...props, 'id'),
-      name: this.realTo || this.name || this.id,
+      name: this.to ? this.id : (this.name || this.id),
       index
-    })
+    }, this.to && this.isMatched)
 
     props.forEach(prop => {
       this.$watch(prop, val => {

--- a/packages/veui/src/components/Tabs/Tab.vue
+++ b/packages/veui/src/components/Tabs/Tab.vue
@@ -89,7 +89,7 @@ export default {
 
     this.tabs.add({
       ...pick(this, ...props, 'id'),
-      name: this.to ? this.id : (this.name || this.id),
+      name: this.realTo ? this.realTo.fullPath : (this.name || this.id),
       index
     }, this.to && this.isMatched)
 

--- a/packages/veui/src/components/Tabs/Tabs.vue
+++ b/packages/veui/src/components/Tabs/Tabs.vue
@@ -176,8 +176,15 @@ import Icon from '../Icon'
 import resize from '../../directives/resize'
 import ui from '../../mixins/ui'
 import i18n from '../../mixins/i18n'
+import config from '../../managers/config'
 import '../../common/uiTypes'
 import { setTransform, getTransform } from '../../utils/dom'
+
+config.defaults({
+  matches (current, to) {
+    return current.fullPath === to.fullPath
+  }
+}, 'tabs')
 
 export default {
   name: 'veui-tabs',
@@ -199,9 +206,11 @@ export default {
       default: 0
     },
     matches: {
-      type: Function,
-      default (current, to) {
-        return current.fullPath === to.fullPath
+      default () {
+        return config.get('tabs.matches')
+      },
+      validator (value) {
+        return typeof value === 'function'
       }
     },
     addable: {

--- a/packages/veui/src/components/Tabs/Tabs.vue
+++ b/packages/veui/src/components/Tabs/Tabs.vue
@@ -61,6 +61,7 @@
               v-bind="ariaAttrs[i]"
               :to="tab.to"
               :native="tab.native"
+              @click="!tab.disabled && setActive({ index: i })"
             >
               {{ tab.label }}
             </veui-link>
@@ -197,6 +198,12 @@ export default {
       type: Number,
       default: 0
     },
+    matches: {
+      type: Function,
+      default (current, to) {
+        return current.fullPath === to.fullPath
+      }
+    },
     addable: {
       type: Boolean,
       default: false
@@ -310,7 +317,7 @@ export default {
     })
   },
   methods: {
-    add (tab) {
+    add (tab, isMatched) {
       let tabIndex = this.items.length
       let domBaseIndex = tab.index
 
@@ -323,7 +330,8 @@ export default {
       if (
         !this.activeId &&
         tab.name === this.active ||
-        (tabIndex === this.index && !this.active)
+        (tabIndex === this.index && !this.active) ||
+        isMatched
       ) {
         this.localIndex = tabIndex
         this.localActive = tab.name

--- a/packages/veui/src/components/Uploader.vue
+++ b/packages/veui/src/components/Uploader.vue
@@ -526,9 +526,7 @@ export default {
       type: Boolean,
       default: false
     },
-    upload: {
-      type: Function
-    }
+    upload: Function
   },
   data () {
     return {


### PR DESCRIPTION
增加 `matches` 函数 prop，用来判断当前 `Tab` 是否为激活状态，不再需要手动控制 `index`。

默认逻辑与现在的逻辑兼容：

```js
function matches (current, to) {
  return current.fullPath === to.fullPath
}
```

其中 `current` 和 `to` 均为 Vue Router 的 [Route 对象](https://router.vuejs.org/api/#route-object-properties)。