### PR TITLE
refactor: make inputs focusable

### DIFF
--- a/packages/veui-theme-one-icons/package.json
+++ b/packages/veui-theme-one-icons/package.json
@@ -16,7 +16,7 @@
     "publish": "rm *.js"
   },
   "peerDependencies": {
-    "veui": "1.0.0-alpha.22"
+    "veui": "1.0.0-alpha.24"
   },
   "devDependencies": {
     "babel-plugin-lodash": "^3.2.11",

--- a/packages/veui-theme-one/package.json
+++ b/packages/veui-theme-one/package.json
@@ -21,7 +21,7 @@
     "veui-theme-one-icons": "^1.0.0-alpha.23"
   },
   "peerDependencies": {
-    "veui": "1.0.0-alpha.23"
+    "veui": "1.0.0-alpha.24"
   },
   "devDependencies": {
     "babel-plugin-lodash": "^3.2.11",

--- a/packages/veui/src/components/Calendar.vue
+++ b/packages/veui/src/components/Calendar.vue
@@ -212,7 +212,6 @@ import { normalizeClass } from '../utils/helper'
 import { flattenDeep, findIndex, uniqueId, upperFirst } from 'lodash'
 import ui from '../mixins/ui'
 import input from '../mixins/input'
-import focusable from '../mixins/focusable'
 import i18n from '../mixins/i18n'
 import config from '../managers/config'
 import Icon from './Icon'
@@ -238,7 +237,7 @@ export default {
   components: {
     'veui-icon': Icon
   },
-  mixins: [ui, input, focusable, i18n],
+  mixins: [ui, input, i18n],
   model: {
     prop: 'selected',
     event: 'select'

--- a/packages/veui/src/components/CheckButtonGroup.vue
+++ b/packages/veui/src/components/CheckButtonGroup.vue
@@ -33,7 +33,6 @@
 <script>
 import input from '../mixins/input'
 import ui from '../mixins/ui'
-import focusable from '../mixins/focusable'
 import { focusIn } from '../utils/dom'
 import { includes, findIndex } from 'lodash'
 import Button from './Button'
@@ -43,7 +42,7 @@ export default {
   components: {
     'veui-button': Button
   },
-  mixins: [ui, input, focusable],
+  mixins: [ui, input],
   model: {
     event: 'change'
   },

--- a/packages/veui/src/components/CheckboxGroup.vue
+++ b/packages/veui/src/components/CheckboxGroup.vue
@@ -32,7 +32,6 @@
 <script>
 import ui from '../mixins/ui'
 import input from '../mixins/input'
-import focusable from '../mixins/focusable'
 import { focusIn } from '../utils/dom'
 import { uniqueId, findIndex } from 'lodash'
 import Checkbox from './Checkbox'
@@ -42,7 +41,7 @@ export default {
   components: {
     'veui-checkbox': Checkbox
   },
-  mixins: [ui, input, focusable],
+  mixins: [ui, input],
   model: {
     event: 'change'
   },

--- a/packages/veui/src/components/DatePicker.vue
+++ b/packages/veui/src/components/DatePicker.vue
@@ -155,7 +155,6 @@ import Icon from './Icon'
 import ui from '../mixins/ui'
 import input from '../mixins/input'
 import dropdown from '../mixins/dropdown'
-import focusable from '../mixins/focusable'
 import i18n from '../mixins/i18n'
 import config from '../managers/config'
 import { toDateData } from '../utils/date'
@@ -192,7 +191,7 @@ export default {
     'veui-calendar': Calendar,
     'veui-icon': Icon
   },
-  mixins: [ui, input, dropdown, focusable, i18n],
+  mixins: [ui, input, dropdown, i18n],
   model: {
     prop: 'selected',
     event: 'select'

--- a/packages/veui/src/components/Input.vue
+++ b/packages/veui/src/components/Input.vue
@@ -64,7 +64,6 @@
 <script>
 import ui from '../mixins/ui'
 import input from '../mixins/input'
-import focusable from '../mixins/focusable'
 import activatable from '../mixins/activatable'
 import i18n from '../mixins/i18n'
 import { omit, includes } from 'lodash'
@@ -79,7 +78,7 @@ export default {
   components: {
     'veui-icon': Icon
   },
-  mixins: [ui, input, focusable, activatable, i18n],
+  mixins: [ui, input, activatable, i18n],
   props: {
     ui: String,
     type: {

--- a/packages/veui/src/components/NumberInput.vue
+++ b/packages/veui/src/components/NumberInput.vue
@@ -63,7 +63,6 @@
 import Input from './Input'
 import Button from './Button'
 import ui from '../mixins/ui'
-import focusable from '../mixins/focusable'
 import activatable from '../mixins/activatable'
 import input from '../mixins/input'
 import i18n from '../mixins/i18n'
@@ -88,7 +87,7 @@ export default {
     'veui-input': Input,
     'veui-button': Button
   },
-  mixins: [ui, input, focusable, activatable, i18n],
+  mixins: [ui, input, activatable, i18n],
   props: {
     ui: String,
     value: Number,

--- a/packages/veui/src/components/Radio.vue
+++ b/packages/veui/src/components/Radio.vue
@@ -26,7 +26,6 @@
 <script>
 import ui from '../mixins/ui'
 import input from '../mixins/input'
-import focusable from '../mixins/focusable'
 import activatable from '../mixins/activatable'
 import { getListeners } from '../utils/helper'
 
@@ -34,7 +33,7 @@ const EVENTS = ['click', 'keyup', 'keydown', 'keypress', 'focus', 'blur']
 
 export default {
   name: 'veui-radio',
-  mixins: [ui, input, focusable, activatable],
+  mixins: [ui, input, activatable],
   inheritAttrs: false,
   model: {
     prop: 'model'

--- a/packages/veui/src/components/RadioButtonGroup.vue
+++ b/packages/veui/src/components/RadioButtonGroup.vue
@@ -30,7 +30,6 @@
 <script>
 import ui from '../mixins/ui'
 import input from '../mixins/input'
-import focusable from '../mixins/focusable'
 import { focusIn } from '../utils/dom'
 import Button from './Button'
 
@@ -39,7 +38,7 @@ export default {
   components: {
     'veui-button': Button
   },
-  mixins: [ui, input, focusable],
+  mixins: [ui, input],
   model: {
     event: 'change'
   },

--- a/packages/veui/src/components/RadioGroup.vue
+++ b/packages/veui/src/components/RadioGroup.vue
@@ -31,7 +31,6 @@
 <script>
 import ui from '../mixins/ui'
 import input from '../mixins/input'
-import focusable from '../mixins/focusable'
 import { focusIn } from '../utils/dom'
 import Radio from './Radio'
 import { uniqueId } from 'lodash'
@@ -41,7 +40,7 @@ export default {
   components: {
     'veui-radio': Radio
   },
-  mixins: [ui, input, focusable],
+  mixins: [ui, input],
   model: {
     event: 'change'
   },

--- a/packages/veui/src/components/RegionPicker.vue
+++ b/packages/veui/src/components/RegionPicker.vue
@@ -259,7 +259,6 @@ import Overlay from './Overlay'
 import ui from '../mixins/ui'
 import input from '../mixins/input'
 import overlay from '../mixins/overlay'
-import focusable from '../mixins/focusable'
 import i18n from '../mixins/i18n'
 import outside from '../directives/outside'
 import warn from '../utils/warn'
@@ -274,7 +273,7 @@ export default {
     'veui-overlay': Overlay
   },
   directives: { outside },
-  mixins: [ui, input, overlay, focusable, i18n],
+  mixins: [ui, input, overlay, i18n],
   model: {
     prop: 'selected',
     event: 'select'

--- a/packages/veui/src/components/Schedule.vue
+++ b/packages/veui/src/components/Schedule.vue
@@ -197,7 +197,6 @@ import { includes, find, isFunction, cloneDeep, mapValues, isEqual } from 'lodas
 import ui from '../mixins/ui'
 import input from '../mixins/input'
 import i18n from '../mixins/i18n'
-import focusable from '../mixins/focusable'
 import outside from '../directives/outside'
 import { merge } from '../utils/range'
 import warn from '../utils/warn'
@@ -228,7 +227,7 @@ export default {
     'veui-tooltip': Tooltip,
     'veui-dropdown': Dropdown
   },
-  mixins: [ui, input, focusable, i18n],
+  mixins: [ui, input, i18n],
   model: {
     prop: 'selected',
     event: 'select'

--- a/packages/veui/src/components/Searchbox.vue
+++ b/packages/veui/src/components/Searchbox.vue
@@ -95,7 +95,6 @@
 import ui from '../mixins/ui'
 import input from '../mixins/input'
 import dropdown from '../mixins/dropdown'
-import focusable from '../mixins/focusable'
 import i18n from '../mixins/i18n'
 import Input from './Input'
 import Icon from './Icon'
@@ -121,7 +120,7 @@ export default {
     'veui-overlay': Overlay,
     'veui-button': Button
   },
-  mixins: [ui, input, dropdown, focusable, i18n],
+  mixins: [ui, input, dropdown, i18n],
   props: {
     suggestions: {
       type: Array,

--- a/packages/veui/src/components/Slider.vue
+++ b/packages/veui/src/components/Slider.vue
@@ -104,7 +104,6 @@ import nudge from '../directives/nudge'
 import outside from '../directives/outside'
 import ui from '../mixins/ui'
 import input from '../mixins/input'
-import focusable from '../mixins/focusable'
 import Tooltip from './Tooltip'
 
 export default {
@@ -117,7 +116,7 @@ export default {
     nudge,
     outside
   },
-  mixins: [ui, input, focusable],
+  mixins: [ui, input],
   props: {
     /* eslint-disable vue/require-prop-types */
     value: {},
@@ -141,7 +140,6 @@ export default {
       validator: val => val >= 0
     },
     mark: Boolean,
-
     parse: {
       type: Function,
       default: identity

--- a/packages/veui/src/components/Switch.vue
+++ b/packages/veui/src/components/Switch.vue
@@ -30,7 +30,6 @@
 <script>
 import ui from '../mixins/ui'
 import input from '../mixins/input'
-import focusable from '../mixins/focusable'
 import { pick } from 'lodash'
 import { getListeners } from '../utils/helper'
 
@@ -38,7 +37,7 @@ const EVENTS = ['click', 'keyup', 'keydown', 'keypress', 'focus', 'blur']
 
 export default {
   name: 'veui-switch',
-  mixins: [ui, input, focusable],
+  mixins: [ui, input],
   model: {
     prop: 'model'
   },

--- a/packages/veui/src/components/Textarea.vue
+++ b/packages/veui/src/components/Textarea.vue
@@ -62,7 +62,6 @@
 import { pick } from 'lodash'
 import ui from '../mixins/ui'
 import input from '../mixins/input'
-import focusable from '../mixins/focusable'
 import activatable from '../mixins/activatable'
 import { getListeners } from '../utils/helper'
 import { log10 } from '../utils/math'
@@ -72,7 +71,7 @@ const EVENTS = ['click', 'keyup', 'keydown', 'keypress']
 
 export default {
   name: 'veui-textarea',
-  mixins: [ui, input, focusable, activatable],
+  mixins: [ui, input, activatable],
   props: {
     placeholder: String,
     value: {
@@ -222,7 +221,7 @@ export default {
       if (this.realDisabled || this.realReadonly) {
         return
       }
-      this.$refs.input.focus()
+      this.focus()
     },
     getMeasurersHeight () {
       return this.$refs.measurer.offsetHeight

--- a/packages/veui/src/components/Uploader.vue
+++ b/packages/veui/src/components/Uploader.vue
@@ -399,7 +399,6 @@ import Tooltip from './Tooltip'
 import { cloneDeep, uniqueId, assign, isNumber, last, pick, omit, includes, isEmpty } from 'lodash'
 import ui from '../mixins/ui'
 import input from '../mixins/input'
-import focusable from '../mixins/focusable'
 import i18n from '../mixins/i18n'
 import config from '../managers/config'
 import { stringifyQuery } from '../utils/helper'
@@ -420,7 +419,7 @@ export default {
     'veui-tooltip': Tooltip,
     'veui-uploader-progress': getProgress()
   },
-  mixins: [ui, input, focusable, i18n],
+  mixins: [ui, input, i18n],
   model: {
     event: 'change'
   },

--- a/packages/veui/src/mixins/input.js
+++ b/packages/veui/src/mixins/input.js
@@ -1,9 +1,11 @@
+import { includes } from 'lodash'
 import { getTypedAncestorTracker, isTopMostOfType } from '../utils/helper'
 import '../common/uiTypes'
-import { includes } from 'lodash'
+import focusable from './focusable'
 
 export default {
   uiTypes: ['input'],
+  mixins: [focusable],
   props: {
     name: String,
     readonly: Boolean,


### PR DESCRIPTION
Move mixin `focusable` into `input` for input components.