### PR TITLE
feat: implement `type` prop for Calendar/DatePicker

### DIFF
--- a/packages/veui/demo/cases/Calendar.vue
+++ b/packages/veui/demo/cases/Calendar.vue
@@ -64,6 +64,22 @@
       设置
     </veui-button>
   </section>
+  <section>
+    <h2>月份选择</h2>
+    <veui-calendar
+      v-model="selected5"
+      type="month"
+    />
+    Selected: {{ selected5 ? `${selected5.getFullYear()}-${selected5.getMonth() + 1}` : '-' }}
+  </section>
+  <section>
+    <h2>年份选择</h2>
+    <veui-calendar
+      v-model="selected6"
+      type="year"
+    />
+    Selected: {{ selected6 ? selected6.getFullYear() : '-' }}
+  </section>
 </article>
 </template>
 
@@ -84,6 +100,8 @@ export default {
       selected2: [today, new Date(today.getFullYear(), today.getMonth() + 1, 13)],
       selected3: [[new Date(2017, 3, 12), new Date(2017, 3, 18)], [new Date(2017, 3, 22), new Date(2017, 3, 24)]],
       selected4: [new Date(2016, 11, 19), new Date(2016, 11, 25)],
+      selected5: new Date(2019, 0, 1),
+      selected6: new Date(2019, 0, 1),
       isDisabled (day) {
         return !(day.getDate() % 5) || day.getDate() === 1
       },

--- a/packages/veui/demo/cases/DatePicker.vue
+++ b/packages/veui/demo/cases/DatePicker.vue
@@ -43,6 +43,20 @@
     </section>
   </section>
   <section>
+    <h2>月份选择</h2>
+    <veui-date-picker
+      v-model="selected3"
+      type="month"
+    />
+  </section>
+  <section>
+    <h2>年份选择</h2>
+    <veui-date-picker
+      v-model="selected3"
+      type="year"
+    />
+  </section>
+  <section>
     <h2>可清除范围选择</h2>
     <section>
       <veui-date-picker
@@ -163,6 +177,7 @@ export default {
     return {
       selected1: null,
       selected2: null,
+      selected3: null,
       shortcuts: [
         {
           label: '上个月',

--- a/packages/veui/src/components/Calendar.vue
+++ b/packages/veui/src/components/Calendar.vue
@@ -91,7 +91,7 @@
     <div
       ref="body"
       class="veui-calendar-body"
-      :class="{ 'veui-calendar-multiple-range': multiple && range }"
+      :class="{ 'veui-calendar-multiple-range': realMultiple && realRange }"
     >
       <table>
         <template v-if="p.view === 'days'">
@@ -205,11 +205,16 @@
 </template>
 
 <script>
-import { getDaysInMonth, fromDateData, isSameDay, mergeRange } from '../utils/date'
+import {
+  getDaysInMonth,
+  fromDateData,
+  isSameDay,
+  mergeRange
+} from '../utils/date'
 import { closest, focusIn } from '../utils/dom'
 import { sign, isPositive } from '../utils/math'
 import { normalizeClass } from '../utils/helper'
-import { flattenDeep, findIndex, uniqueId, upperFirst } from 'lodash'
+import { isInteger, flattenDeep, findIndex, uniqueId, upperFirst } from 'lodash'
 import ui from '../mixins/ui'
 import input from '../mixins/input'
 import focusable from '../mixins/focusable'
@@ -221,16 +226,22 @@ config.defaults({
   'calendar.weekStart': 1
 })
 
-const CELL_SELECTOR = {
+const VIEW_CELL_SELECTOR_MAP = {
   days: '.veui-calendar-day',
   months: '.veui-calendar-month',
   years: '.veui-calendar-year'
 }
 
-const STEP_MAP = {
+const VIEW_STEP_MAP = {
   days: 'month',
   months: 'year',
   years: 'decade'
+}
+
+const TYPE_VIEW_MAP = {
+  date: 'days',
+  month: 'months',
+  year: 'years'
 }
 
 export default {
@@ -244,9 +255,19 @@ export default {
     event: 'select'
   },
   props: {
+    type: {
+      type: String,
+      default: 'date',
+      validator (val) {
+        return ['date', 'month', 'year'].indexOf(val) !== -1
+      }
+    },
     panel: {
       type: Number,
-      default: 1
+      default: 1,
+      validator (val) {
+        return isInteger(val) && val > 0
+      }
     },
     today: {
       type: Date,
@@ -287,8 +308,12 @@ export default {
   },
   data () {
     let views = []
-    for (let i = 0; i < this.panel; i++) {
-      views[i] = 'days'
+    if (this.type !== 'date') {
+      views.push(TYPE_VIEW_MAP[this.type])
+    } else {
+      for (let i = 0; i < this.panel; i++) {
+        views[i] = 'days'
+      }
     }
 
     let current = this.getDefaultDate()
@@ -306,14 +331,22 @@ export default {
     }
   },
   computed: {
+    realRange () {
+      return this.type === 'date' && this.range
+    },
+    realMultiple () {
+      return this.type === 'date' && this.multiple
+    },
     realWeekStart () {
-      return this.weekStart != null ? this.weekStart : config.get('calendar.weekStart')
+      return this.weekStart != null
+        ? this.weekStart
+        : config.get('calendar.weekStart')
     },
     viewMonth () {
       return `${this.year}/${this.month}`
     },
     realSelected () {
-      return this.selected ? this.selected : (this.multiple ? [] : null)
+      return this.selected ? this.selected : this.realMultiple ? [] : null
     },
     realPicking () {
       let [from, to] = this.picking || []
@@ -323,8 +356,10 @@ export default {
       return this.picking
     },
     panels () {
+      let panel = this.type !== 'date' ? 1 : this.panel
+
       let panels = []
-      for (let i = 0; i < this.panel; i++) {
+      for (let i = 0; i < panel; i++) {
         let year = this.year + Math.floor((this.month + i) / 12)
         let month = (this.month + i) % 12
         let view = this.views[i]
@@ -367,9 +402,10 @@ export default {
               }
             }
             let day = weeks[i][j]
-            day.isDisabled = typeof this.disabledDate === 'function'
-              ? this.disabledDate(fromDateData(day))
-              : false
+            day.isDisabled =
+              typeof this.disabledDate === 'function'
+                ? this.disabledDate(fromDateData(day))
+                : false
             if (day.month === month) {
               day.isToday = isSameDay(day, this.today)
               day.isSelected = this.isSelected(day)
@@ -442,15 +478,18 @@ export default {
       let d = fromDateData(day)
       return this.t('dateLabel', {
         year: this.t('year', { year }),
-        month: this.t('month', { month: month + 1 }) || this.t(`monthsLong[${month}]`),
+        month:
+          this.t('month', { month: month + 1 }) ||
+          this.t(`monthsLong[${month}]`),
         date: this.t('date', { date }),
         day: this.t(`daysLong[${d.getDay()}]`)
       })
     },
     getDateClass (day, panel) {
-      let extraClass = typeof this.dateClass === 'function'
-        ? this.dateClass(fromDateData(day))
-        : this.dateClass
+      let extraClass =
+        typeof this.dateClass === 'function'
+          ? this.dateClass(fromDateData(day))
+          : this.dateClass
 
       return {
         'veui-calendar-day': day.month === panel.month,
@@ -458,7 +497,8 @@ export default {
         'veui-calendar-today': day.isToday,
         'veui-calendar-selected': day.isSelected,
         'veui-calendar-in-range': day.rangePosition && day.rangePosition.within,
-        'veui-calendar-range-start': day.rangePosition && day.rangePosition.start,
+        'veui-calendar-range-start':
+          day.rangePosition && day.rangePosition.start,
         'veui-calendar-range-end': day.rangePosition && day.rangePosition.end,
         ...normalizeClass(extraClass)
       }
@@ -467,31 +507,42 @@ export default {
       let month = (i - 1) * 4 + j - 1
       return {
         'veui-calendar-month': true,
-        'veui-calendar-today': month === this.today.getMonth() && panel.year === this.today.getFullYear(),
-        'veui-calendar-selected': (this.realSelected && !this.multiple && !this.range)
-          ? (month === this.realSelected.getMonth() && panel.year === this.realSelected.getFullYear()) : false
+        'veui-calendar-today':
+          month === this.today.getMonth() &&
+          panel.year === this.today.getFullYear(),
+        'veui-calendar-selected':
+          this.realSelected && !this.realMultiple && !this.realRange
+            ? month === this.realSelected.getMonth() &&
+              panel.year === this.realSelected.getFullYear()
+            : false
       }
     },
     getYearClass (panel, i, j) {
       let offset = (i - 1) * 4 + j - 1
-      let year = panel.year - panel.year % 10 + offset
+      let year = panel.year - (panel.year % 10) + offset
       return {
         'veui-calendar-year': offset < 10,
         'veui-calendar-today': year === this.today.getFullYear(),
-        'veui-calendar-selected': (this.realSelected && !this.multiple && !this.range)
-          ? year === this.realSelected.getFullYear() : false
+        'veui-calendar-selected':
+          this.realSelected && !this.realMultiple && !this.realRange
+            ? year === this.realSelected.getFullYear()
+            : false
       }
     },
     getStepLabel (view, type) {
-      return this.t(`${type}${upperFirst(STEP_MAP[view])}`)
+      return this.t(`${type}${upperFirst(VIEW_STEP_MAP[view])}`)
     },
     getYearOffset (i, j, isNext) {
       return isNext
-        ? (i === 2 && j > 2)
+        ? i === 2 && j > 2
           ? 6
-          : (i === 3 ? 2 : 4)
+          : i === 3
+            ? 2
+            : 4
         : i === 1
-          ? (j < 3 ? -2 : -6)
+          ? j < 3
+            ? -2
+            : -6
           : -4
     },
     selectDay (day) {
@@ -502,8 +553,8 @@ export default {
       }
 
       let selected = new Date(day.year, day.month, day.date)
-      if (!this.range) {
-        if (!this.multiple) {
+      if (!this.realRange) {
+        if (!this.realMultiple) {
           // single day selection
           this.$emit('select', selected)
           return
@@ -535,7 +586,7 @@ export default {
       // prepare to select
       this.$set(this.picking, 1, selected)
       let picking = this.picking.sort((d1, d2) => d1 - d2)
-      if (!this.multiple) {
+      if (!this.realMultiple) {
         // single range selection
         this.picking = null
         this.$emit('select', [...picking])
@@ -549,21 +600,25 @@ export default {
       this.$emit('select', ranges)
     },
     markEnd (day) {
-      if (this.range && this.picking) {
+      if (this.realRange && this.picking) {
         let marked = day ? new Date(day.year, day.month, day.date) : null
         this.$set(this.picking, 1, marked)
-        if (this.multiple) {
+        if (this.realMultiple) {
           if (!marked) {
             this.$set(this.picking, 1, this.picking[0])
           }
-          this.pickingRanges = mergeRange(this.realSelected || [], this.picking || [], this.mergeMode)
+          this.pickingRanges = mergeRange(
+            this.realSelected || [],
+            this.picking || [],
+            this.mergeMode
+          )
         }
         this.$emit('selectprogress', this.pickingRanges || this.picking)
       }
     },
     moveFocus (view, delta, offset = null) {
       // 不走数据流了，直接查找 DOM 元素最简单
-      let selector = CELL_SELECTOR[view]
+      let selector = VIEW_CELL_SELECTOR_MAP[view]
       let cells = [...this.$el.querySelectorAll(selector)]
 
       // 查一下当前聚焦元素的偏移量，归一化以后再处理
@@ -623,11 +678,12 @@ export default {
         month = this.panels[0].month
       }
       this.$nextTick(() => {
-        let count = view === 'days'
-          ? getDaysInMonth(year, month)
-          : view === 'months'
-            ? 12
-            : 10
+        let count =
+          view === 'days'
+            ? getDaysInMonth(year, month)
+            : view === 'months'
+              ? 12
+              : 10
         this.moveFocus(view, delta, offset - sign(delta) * count)
       })
     },
@@ -653,6 +709,11 @@ export default {
       }
     },
     selectMonth (i, month) {
+      if (this.type === 'month') {
+        // single day selection
+        this.$emit('select', new Date(this.year, month, 1))
+        return
+      }
       // yearDiff = ⌊(currentMonth + monthDiff) / 12⌋
       this.year += Math.floor((this.month + month - this.panels[i].month) / 12)
       this.month = (month - i + 12) % 12
@@ -660,6 +721,11 @@ export default {
       this.setFocus('month-select', i)
     },
     selectYear (i, year) {
+      if (this.type === 'year') {
+        // single day selection
+        this.$emit('select', new Date(year, 0, 1))
+        return
+      }
       this.year = year + Math.floor((this.panels[i].month - i) / 12)
       this.setView('days')
       this.setFocus('year-select', i)
@@ -668,15 +734,15 @@ export default {
       if (!this.realSelected && !this.picking) {
         return false
       }
-      if (!this.range) {
-        if (!this.multiple) {
+      if (!this.realRange) {
+        if (!this.realMultiple) {
           // single day
           return isSameDay(this.realSelected, day)
         }
         // multiple single days
         return (this.realSelected || []).some(d => isSameDay(d, day))
       }
-      if (!this.multiple) {
+      if (!this.realMultiple) {
         // single range
         let range = this.picking || this.realSelected
         return isSameDay(range[0], day) || isSameDay(range[1], day)
@@ -687,11 +753,11 @@ export default {
       })
     },
     getRangePosition (day) {
-      if (!this.range) {
+      if (!this.realRange) {
         return false
       }
 
-      if (!this.multiple) {
+      if (!this.realMultiple) {
         // single range
         let range = this.realPicking || this.realSelected
         return getRangePosition(day, range)

--- a/packages/veui/src/components/DatePicker.vue
+++ b/packages/veui/src/components/DatePicker.vue
@@ -5,7 +5,7 @@
   :class="{
     'veui-input-invalid': realInvalid,
     'veui-date-picker-empty': !selected,
-    'veui-date-picker-range': range,
+    'veui-date-picker-range': realRange,
     'veui-date-picker-expanded': expanded
   }"
 >
@@ -19,7 +19,7 @@
     @click="expanded = !expanded"
     @keydown.down.up.prevent="expanded = true"
   >
-    <template v-if="range">
+    <template v-if="realRange">
       <span class="veui-date-picker-label">
         <slot
           v-if="selected && selected[0]"
@@ -27,19 +27,13 @@
           position="from"
           v-bind="toDateData(selected[0])"
           :formatted="formatted ? formatted[0] : null"
-        >
-          {{ formatted[0] }}
-        </slot>
+        >{{ formatted[0] }}</slot>
         <slot
           v-else
           name="placeholder"
-        >
-          {{ realPlaceholder }}
-        </slot>
+        >{{ realPlaceholder }}</slot>
       </span>
-      <span class="veui-date-picker-tilde">
-        ~
-      </span>
+      <span class="veui-date-picker-tilde">~</span>
       <span class="veui-date-picker-label">
         <slot
           v-if="selected && selected[1]"
@@ -47,9 +41,7 @@
           position="to"
           v-bind="toDateData(selected[1])"
           :formatted="formatted ? formatted[1] : null"
-        >
-          {{ formatted[1] }}
-        </slot>
+        >{{ formatted[1] }}</slot>
       </span>
     </template>
     <template v-else>
@@ -59,15 +51,11 @@
           name="selected"
           v-bind="toDateData(selected)"
           :formatted="formatted"
-        >
-          {{ formatted }}
-        </slot>
+        >{{ formatted }}</slot>
         <slot
           v-else
           name="placeholder"
-        >
-          {{ realPlaceholder }}
-        </slot>
+        >{{ realPlaceholder }}</slot>
       </span>
     </template>
     <veui-icon
@@ -112,7 +100,7 @@
       @viewchange="handleViewChange"
     >
       <template
-        v-if="range && realShortcuts && realShortcuts.length"
+        v-if="realRange && realShortcuts && realShortcuts.length"
         :slot="shortcutsPosition"
       >
         <div class="veui-date-picker-shortcuts">
@@ -172,17 +160,33 @@ import addMonths from 'date-fns/add_months'
 import addQuarters from 'date-fns/add_quarters'
 import addYears from 'date-fns/add_years'
 
-config.defaults({
-  shortcuts: [],
-  shortcutsPosition: 'before',
-  placeholder: '@@datepicker.selectDate',
-  rangePlaceholder: '@@datepicker.selectRange'
-}, 'datepicker')
+config.defaults(
+  {
+    shortcuts: [],
+    shortcutsPosition: 'before',
+    placeholder: '@@datepicker.selectDate',
+    monthPlaceholder: '@@datepicker.selectMonth',
+    yearPlaceholder: '@@datepicker.selectYear',
+    rangePlaceholder: '@@datepicker.selectRange'
+  },
+  'datepicker'
+)
 
 const CALENDAR_PROPS = [
-  'range', 'weekStart', 'fillMonth',
-  'today', 'disabledDate', 'dateClass'
+  'type',
+  'range',
+  'weekStart',
+  'fillMonth',
+  'today',
+  'disabledDate',
+  'dateClass'
 ]
+
+const TYPE_FORMAT_MAP = {
+  date: 'YYYY-MM-DD',
+  month: 'YYYY-MM',
+  year: 'YYYY'
+}
 
 export default {
   name: 'veui-date-picker',
@@ -208,8 +212,7 @@ export default {
     clearable: Boolean,
     placeholder: String,
     format: {
-      type: [String, Function],
-      default: 'YYYY-MM-DD'
+      type: [String, Function]
     },
     shortcuts: Array,
     shortcutsPosition: {
@@ -229,7 +232,7 @@ export default {
   computed: {
     formatted () {
       let selected = this.localSelected
-      if (this.range) {
+      if (this.realRange) {
         let current = this.picking || selected
         if (Array.isArray(current)) {
           return current.map(date => this.formatDate(date))
@@ -244,20 +247,39 @@ export default {
       return pick(this, CALENDAR_PROPS)
     },
     realPlaceholder () {
-      return this.placeholder ||
-        (this.range
-          ? config.get('datepicker.rangePlaceholder')
-          : config.get('datepicker.placeholder'))
+      if (this.placeholder) {
+        return this.placeholder
+      }
+
+      if (this.type !== 'date') {
+        return config.get(
+          this.type === 'month'
+            ? 'datepicker.monthPlaceholder'
+            : 'datepicker.yearPlaceholder'
+        )
+      }
+
+      return config.get(
+        this.realRange
+          ? 'datepicker.rangePlaceholder'
+          : 'datepicker.placeholder'
+      )
     },
     realPanel () {
-      return this.panel || (this.range ? 2 : 1)
+      if (this.type !== 'date') {
+        return 1
+      }
+      return this.panel || (this.realRange ? 2 : 1)
+    },
+    realRange () {
+      return this.type === 'date' && this.range
     },
     realShortcuts () {
       let shortcuts = this.shortcuts || config.get('datepicker.shortcuts')
       if (!shortcuts) {
         return null
       }
-      return shortcuts.map(({from = 0, to = 0, label}) => {
+      return shortcuts.map(({ from = 0, to = 0, label }) => {
         from = this.getDateByOffset(from)
         to = this.getDateByOffset(to)
         if (from > to) {
@@ -288,7 +310,9 @@ export default {
       if (typeof this.format === 'function') {
         return this.format(date)
       }
-      return format(date, this.format)
+
+      let dateFormat = this.format || TYPE_FORMAT_MAP[this.type]
+      return format(date, dateFormat)
     },
     toDateData (date) {
       if (!date) {
@@ -326,10 +350,9 @@ export default {
     getDateByOffset (offset) {
       offset = isNumber(offset) ? { days: offset } : offset
       return add(
-        startOf(
-          this.today, offset.startOf || 'day',
-          { weekStartsOn: this.weekStart }
-        ),
+        startOf(this.today, offset.startOf || 'day', {
+          weekStartsOn: this.weekStart
+        }),
         omit(offset, 'startOf')
       )
     },

--- a/packages/veui/src/locale/en-US/DatePicker.js
+++ b/packages/veui/src/locale/en-US/DatePicker.js
@@ -5,6 +5,8 @@ i18n.register(
   {
     clear: 'Clear',
     selectDate: 'Select a date',
+    selectMonth: 'Select a month',
+    selectYear: 'Select a year',
     selectRange: 'Select a date range'
   },
   {

--- a/packages/veui/src/locale/zh-Hans/DatePicker.js
+++ b/packages/veui/src/locale/zh-Hans/DatePicker.js
@@ -5,6 +5,8 @@ i18n.register(
   {
     clear: '清除',
     selectDate: '选择时间',
+    selectMonth: '选择月份',
+    selectYear: '选择年份',
     selectRange: '选择时间段'
   },
   {


### PR DESCRIPTION
Add prop: `type: 'date' | 'month' | 'year'`. The type of `selected` keeps as-is (native `Date`s). Users have to call `.getMonth()` and `.getFullYear()` to get the actual selectde month and/or year.

Setting `type` value other than `'date'` would make `range` and `multiple` to be ignored.