### PR TITLE
fix: remove .sync support for Checkbox's indeterminate prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## 1.0.0-alpha.25
 
+### ⚠️ 非兼容性变更
+
+* [^] `Checkbox` 的 `indeterminate` prop 不再支持 `.sync`，始终由外部控制。
+
+### 💡 主要变更
+
+* [^] 支持多个 `Checkbox` 在 `v-model` 绑定到同一个数组时自动组成复选框组。
+
 ### 🐞 问题修复
 
 * [^] 修复了部分原生 `<button>` 未设置 `type="button"` 的问题。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### ⚠️ 非兼容性变更
 
 * [^] `Checkbox` 的 `indeterminate` prop 不再支持 `.sync`，始终由外部控制。
+* [^] `Switch` 的 `change` 事件将在数据更新完毕后触发。
 
 ### 💡 主要变更
 

--- a/packages/veui/demo/cases/Checkbox.vue
+++ b/packages/veui/demo/cases/Checkbox.vue
@@ -14,26 +14,26 @@
     </veui-checkbox> {{ current }}
   </section>
   <section>
-    <veui-checkbox v-model="picked1">
+    <veui-checkbox v-model="checked1">
       正常状态
     </veui-checkbox>
   </section>
   <section>
     <veui-checkbox
-      v-model="picked2"
+      v-model="checked2"
       ui="small"
     >
       正常状态
     </veui-checkbox>
   </section>
   <section>
-    <veui-checkbox v-model="picked3">
+    <veui-checkbox v-model="checked3">
       选中状态
     </veui-checkbox>
   </section>
   <section>
     <veui-checkbox
-      v-model="picked4"
+      v-model="checked4"
       ui="small"
     >
       选中状态
@@ -41,7 +41,7 @@
   </section>
   <section>
     <veui-checkbox
-      v-model="picked5"
+      v-model="checked5"
       :indeterminate="indeterminate5"
       @change="indeterminate5 = false"
     >
@@ -50,7 +50,7 @@
   </section>
   <section>
     <veui-checkbox
-      v-model="picked6"
+      v-model="checked6"
       ui="small"
       :indeterminate="indeterminate6"
       @change="indeterminate6 = false"
@@ -60,7 +60,7 @@
   </section>
   <section>
     <veui-checkbox
-      v-model="picked7"
+      v-model="checked7"
       disabled
     >
       选中无效状态
@@ -68,7 +68,7 @@
   </section>
   <section>
     <veui-checkbox
-      v-model="picked8"
+      v-model="checked8"
       ui="small"
       disabled
     >
@@ -77,7 +77,7 @@
   </section>
   <section>
     <veui-checkbox
-      v-model="picked9"
+      v-model="checked9"
       disabled
     >
       未选无效状态
@@ -85,7 +85,7 @@
   </section>
   <section>
     <veui-checkbox
-      v-model="picked10"
+      v-model="checked10"
       ui="small"
       disabled
     >
@@ -94,7 +94,7 @@
   </section>
   <section>
     <veui-checkbox
-      v-model="picked11"
+      v-model="checked11"
       disabled
       indeterminate
     >
@@ -103,7 +103,7 @@
   </section>
   <section>
     <veui-checkbox
-      v-model="picked12"
+      v-model="checked12"
       ui="small"
       disabled
       indeterminate
@@ -118,36 +118,62 @@
     >
       外部控制 <code>checked</code>
     </veui-checkbox>
+    <veui-button ui="tiny" @click="checked13 = !checked13">Toggle</veui-button>
+  </section>
+  <section>
+    <veui-checkbox :checked.sync="checked14">
+      <code>:checked.sync</code> 绑定状态：{{ checked14 }}
+    </veui-checkbox>
+    <veui-button ui="tiny" @click="checked14 = !checked14">Toggle</veui-button>
+  </section>
+  <section>
+    <h4>复选框组</h4>
+    <p>
+      <veui-checkbox
+        :checked="group.length > 0"
+        :indeterminate="group.length > 0 && group.length < 3"
+        @change="group.length ? group = [] : group = ['A', 'B', 'C']"
+      >全部</veui-checkbox>
+    </p>
+    <p>
+      <veui-checkbox v-model="group" value="A">A</veui-checkbox>
+      <veui-checkbox v-model="group" value="B">B</veui-checkbox>
+      <veui-checkbox v-model="group" value="C">C</veui-checkbox>
+    </p>
+    <p>{{ group }}</p>
   </section>
 </article>
 </template>
 
 <script>
-import { Checkbox } from 'veui'
+import { Checkbox, Button } from 'veui'
 
 export default {
   name: 'checkbox-demo',
   components: {
-    'veui-checkbox': Checkbox
+    'veui-checkbox': Checkbox,
+    'veui-button': Button
   },
   data () {
     return {
       current: '已选',
-      picked1: false,
-      picked2: false,
-      picked3: true,
-      picked4: true,
-      picked5: true,
+      checked1: false,
+      checked2: false,
+      checked3: true,
+      checked4: true,
+      checked5: true,
       indeterminate5: true,
-      picked6: false,
+      checked6: false,
       indeterminate6: true,
-      picked7: true,
-      picked8: true,
-      picked9: false,
-      picked10: false,
-      picked11: false,
-      picked12: false,
-      checked13: true
+      checked7: true,
+      checked8: true,
+      checked9: false,
+      checked10: false,
+      checked11: false,
+      checked12: false,
+      checked13: true,
+      checked14: false,
+      group: []
     }
   }
 }
@@ -156,5 +182,10 @@ export default {
 <style lang="less" scoped>
 section {
   margin-bottom: 1em;
+}
+
+.veui-checkbox + .veui-button,
+.veui-checkbox + .veui-checkbox {
+  margin-left: 20px;
 }
 </style>

--- a/packages/veui/demo/cases/Checkbox.vue
+++ b/packages/veui/demo/cases/Checkbox.vue
@@ -42,7 +42,8 @@
   <section>
     <veui-checkbox
       v-model="picked5"
-      indeterminate
+      :indeterminate="indeterminate5"
+      @change="indeterminate5 = false"
     >
       部分选中状态
     </veui-checkbox>
@@ -51,7 +52,8 @@
     <veui-checkbox
       v-model="picked6"
       ui="small"
-      indeterminate
+      :indeterminate="indeterminate6"
+      @change="indeterminate6 = false"
     >
       部分选中状态
     </veui-checkbox>
@@ -109,6 +111,14 @@
       部分选中无效状态
     </veui-checkbox>
   </section>
+  <section>
+    <veui-checkbox
+      :checked="checked13"
+      @change="checked13 = $event"
+    >
+      外部控制 <code>checked</code>
+    </veui-checkbox>
+  </section>
 </article>
 </template>
 
@@ -127,14 +137,17 @@ export default {
       picked2: false,
       picked3: true,
       picked4: true,
-      picked5: false,
+      picked5: true,
+      indeterminate5: true,
       picked6: false,
+      indeterminate6: true,
       picked7: true,
       picked8: true,
       picked9: false,
       picked10: false,
       picked11: false,
-      picked12: false
+      picked12: false,
+      checked13: true
     }
   }
 }

--- a/packages/veui/demo/cases/Radio.vue
+++ b/packages/veui/demo/cases/Radio.vue
@@ -85,6 +85,15 @@
       未选禁用状态
     </veui-radio>
   </section>
+  <section>
+    <h3>单选组</h3>
+    <p>
+      <veui-radio v-model="group" value="A">A</veui-radio>
+      <veui-radio v-model="group" value="B">B</veui-radio>
+      <veui-radio v-model="group" value="C">C</veui-radio>
+    </p>
+    <p>{{ group }}</p>
+  </section>
 </article>
 </template>
 
@@ -100,7 +109,8 @@ export default {
   data () {
     return {
       size: null,
-      checked: false
+      checked: false,
+      group: null
     }
   }
 }

--- a/packages/veui/jest.config.js
+++ b/packages/veui/jest.config.js
@@ -20,16 +20,14 @@ module.exports = {
   coverageDirectory: '<rootDir>/test/unit/coverage',
   coverageReporters: ['lcov', 'text-summary'],
   moduleFileExtensions: ['js', 'vue', 'jsx'],
-  testMatch: [
-    '**/__tests__/**/*.js?(x)',
-    '**/?(*.)(spec|test).js?(x)'
-  ],
+  testMatch: ['**/__tests__/**/*.js?(x)', '**/?(*.)(spec|test).js?(x)'],
   moduleNameMapper: {
     '^veui$': '<rootDir>/src/index.js',
     '^veui\\/(.*)': '<rootDir>/src/$1',
-    '^veui-theme-one-icons\\/(.*)': '<rootDir>/../veui-theme-one-icons/icons/$1',
+    '^veui-theme-one-icons\\/(.*)':
+      '<rootDir>/../veui-theme-one-icons/icons/$1',
     '^@\\/(.*)': '<rootDir>/src/$1',
-    '^vue$': '<rootDir>/node_modules/vue/dist/vue.common.js'
+    '^vue$': '<rootDir>/node_modules/vue/dist/vue.common.prod.js'
   },
   transformIgnorePatterns: [
     '<rootDir>/node_modules/(?!vue-awesome|resize-detector|veui-theme-one)'

--- a/packages/veui/src/components/Checkbox.vue
+++ b/packages/veui/src/components/Checkbox.vue
@@ -11,7 +11,7 @@
     ref="box"
     type="checkbox"
     v-bind="attrs"
-    :indeterminate.prop="localIndeterminate"
+    :indeterminate.prop="indeterminate"
     :checked.prop="localChecked"
     @change="handleChange"
     v-on="boxListeners"
@@ -19,13 +19,13 @@
   <span class="veui-checkbox-box">
     <transition name="veui-checkbox-icon">
       <veui-icon
-        v-if="localIndeterminate"
+        v-if="indeterminate"
         :name="icons.indeterminate"
       />
     </transition>
     <transition name="veui-checkbox-icon">
       <veui-icon
-        v-if="localChecked && !localIndeterminate"
+        v-if="localChecked && !indeterminate"
         :name="icons.checked"
       />
     </transition>
@@ -77,8 +77,7 @@ export default {
   },
   data () {
     return {
-      localChecked: this.checked,
-      localIndeterminate: this.indeterminate
+      localChecked: this.checked
     }
   },
   computed: {
@@ -115,20 +114,6 @@ export default {
         this.localChecked = val === this.trueValue
       },
       immediate: true
-    },
-    indeterminate (val) {
-      this.localIndeterminate = val
-    },
-    localIndeterminate: {
-      handler (val) {
-        if (this.indeterminate !== val) {
-          this.$emit('update:indeterminate', val)
-        }
-        if (val && !this.localChecked) {
-          this.localChecked = true
-        }
-      },
-      immediate: true
     }
   },
   mounted () {
@@ -137,12 +122,8 @@ export default {
   },
   methods: {
     handleChange () {
-      if (this.localIndeterminate) {
-        this.toggleChecked(false)
-        this.localIndeterminate = false
-      } else {
-        this.toggleChecked()
-      }
+      this.toggleChecked()
+      this.$refs.box.indeterminate = this.indeterminate
     },
     toggleChecked (forceValue) {
       if (this.localChecked === forceValue) {

--- a/packages/veui/src/components/Radio.vue
+++ b/packages/veui/src/components/Radio.vue
@@ -97,14 +97,8 @@ export default {
     }
   },
   methods: {
-    handleChange ($event) {
-      this.change($event.target.checked)
-    },
-    change (checked) {
-      if (this.localChecked === checked) {
-        return
-      }
-      this.localChecked = checked
+    handleChange (e) {
+      this.localChecked = e.target.checked
       this.$nextTick(() => {
         this.$emit('change', this.localChecked)
       })
@@ -116,7 +110,10 @@ export default {
       if (this.realDisabled || this.realReadonly) {
         return
       }
-      this.change(true)
+      this.localChecked = true
+      this.$nextTick(() => {
+        this.$emit('change', this.localChecked)
+      })
       this.focus()
     }
   }

--- a/packages/veui/src/components/Switch.vue
+++ b/packages/veui/src/components/Switch.vue
@@ -14,7 +14,7 @@
     type="checkbox"
     v-bind="attrs"
     :checked.prop="localChecked"
-    @change="handleChange($event.target.checked)"
+    @change="handleChange"
     v-on="boxListeners"
   >
   <div class="veui-switch-switcher">
@@ -94,8 +94,10 @@ export default {
   },
   methods: {
     handleChange (checked) {
-      this.localChecked = checked
-      this.$emit('change', checked)
+      this.localChecked = !this.localChecked
+      this.$nextTick(() => {
+        this.$emit('change', this.localChecked)
+      })
     },
     focus () {
       this.$refs.box.focus()
@@ -105,6 +107,10 @@ export default {
         return
       }
       this.localChecked = !this.localChecked
+      this.$nextTick(() => {
+        this.$emit('change', this.localChecked)
+      })
+      this.focus()
     }
   }
 }

--- a/packages/veui/test/unit/specs/components/Switch.spec.js
+++ b/packages/veui/test/unit/specs/components/Switch.spec.js
@@ -1,10 +1,10 @@
 import Vue from 'vue'
 import { mount } from '@vue/test-utils'
-import Checkbox from '@/components/Checkbox'
+import Switch from '@/components/Switch'
 
-describe('components/Checkbox', () => {
+describe('components/Switch', () => {
   it('should handle checked prop with `null` value.', done => {
-    const wrapper = mount(Checkbox, {
+    const wrapper = mount(Switch, {
       propsData: {
         checked: null
       }
@@ -23,7 +23,7 @@ describe('components/Checkbox', () => {
     document.body.appendChild(wrapper)
     new Vue({
       components: {
-        'veui-checkbox': Checkbox
+        'veui-switch': Switch
       },
       data () {
         return {
@@ -43,7 +43,7 @@ describe('components/Checkbox', () => {
         }
       },
       template:
-        '<veui-checkbox v-model="choice" true-value="YES" false-value="NO" @change="handleChange"/>'
+        '<veui-switch v-model="choice" true-value="YES" false-value="NO" @change="handleChange"/>'
     }).$mount(wrapper)
   })
 })


### PR DESCRIPTION
## 🚨 BREAKING CHANGE 🚨

This PR removes `.sync` support for `Checkbox`'s `indeterminate` prop, it's now always decided by the parent component.