### PR TITLE
Refine props/attrs fall-though behavior for Input/NumberInput/Textarea

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 * [^] 修正了 `Checkbox`、`Radio` 与 `Switch` 组件中原生 `<input>` 状态没有正确同步的问题，以触发 CSS 中正确的伪类样式。
 * [^] 修正了带下拉浮层的组件的 ARIA 标注，使浮层拥有正确的从属关系。
 * [^] 修复了 `Schedule` 组件在拖动选取多日时段时，`selected` 中可能共享同一数组实例的问题。
+* [^] 优化了 `Input`、`NumberInput` 与 `Textarea` 的属性透传机制，现在未被识别为 prop 的属性都会正确输出到原生 `<input>` 或 `<textarea>` 元素上。
+* [+] `Textarea` 新增 `select-on-focus` prop。
 * [^] 优化了原生事件透传机制，原生元素触发的事件将可以被外层组件直接透传。涉及的组件为 `Button`、`Checkbox`、`Radio`、`Switch`、`Input`。`NumberInput`、`Textarea`。
 
   > **相关事件包括：**

--- a/packages/veui/demo/Console.vue
+++ b/packages/veui/demo/Console.vue
@@ -78,7 +78,9 @@ export default {
       if (text != null) {
         return text
       }
-      return `<span style="color: #ccc">${text === '' ? 'empty' : String(text)}</span>`
+      return `<span style="color: #ccc">${
+        text === '' ? 'empty' : String(text)
+      }</span>`
     }
   }
 }
@@ -128,7 +130,7 @@ export default {
     margin: 0;
     line-height: 20px;
     font-size: 10px;
-    transition: height .2s;
+    transition: height 0.2s;
 
     .log {
       position: relative;
@@ -155,7 +157,6 @@ export default {
   }
 
   &.expanded {
-
     .output {
       overflow: auto;
       height: @console-height;

--- a/packages/veui/demo/cases/Input.vue
+++ b/packages/veui/demo/cases/Input.vue
@@ -11,6 +11,7 @@
         <veui-input
           v-model="poem"
           ui="micro"
+          autofocus
         />
       </veui-field>
       <veui-field
@@ -107,7 +108,6 @@
         <veui-input
           v-model="password"
           type="password"
-          autofocus
           placeholder="请输入密码"
           @click="log('click')"
         />

--- a/packages/veui/demo/cases/NumberInput.vue
+++ b/packages/veui/demo/cases/NumberInput.vue
@@ -24,6 +24,8 @@
         <veui-number-input
           v-model="number1"
           ui="tiny"
+          autofocus
+          select-on-focus
           :decimal-place="1"
         />
       </veui-field>

--- a/packages/veui/demo/cases/Textarea.vue
+++ b/packages/veui/demo/cases/Textarea.vue
@@ -6,6 +6,7 @@
     <veui-textarea
       v-model="value"
       line-number
+      autofocus
       ui="small"
       rows="3"
     />
@@ -14,6 +15,7 @@
     <veui-textarea
       v-model="value"
       line-number
+      select-on-focus
       autoresize
       placeholder="请输入"
     />

--- a/packages/veui/src/components/Input.vue
+++ b/packages/veui/src/components/Input.vue
@@ -67,7 +67,7 @@ import ui from '../mixins/ui'
 import input from '../mixins/input'
 import activatable from '../mixins/activatable'
 import i18n from '../mixins/i18n'
-import { omit, includes, pick } from 'lodash'
+import { includes, pick } from 'lodash'
 import Icon from './Icon'
 import { MOUSE_EVENTS, KEYBOARD_EVENTS, FOCUS_EVENTS } from '../utils/dom'
 
@@ -79,6 +79,7 @@ export default {
     'veui-icon': Icon
   },
   mixins: [ui, input, activatable, i18n],
+  inheritAttrs: false,
   props: {
     ui: String,
     type: {
@@ -88,13 +89,11 @@ export default {
         return includes(TYPE_LIST, val)
       }
     },
-    autocomplete: String,
     placeholder: String,
     value: {
       type: [String, Number],
       default: ''
     },
-    autofocus: Boolean,
     selectOnFocus: Boolean,
     composition: Boolean,
     clearable: Boolean
@@ -110,18 +109,11 @@ export default {
   computed: {
     attrs () {
       return {
-        ...omit(
-          this.$props,
-          'placeholder',
-          'selectOnFocus',
-          'composition',
-          'value',
-          'clearable'
-        ),
+        ...this.$attrs,
+        type: this.type,
         name: this.realName,
         disabled: this.realDisabled,
-        readonly: this.realReadonly,
-        ...this.$attrs
+        readonly: this.realReadonly
       }
     },
     inputListeners () {
@@ -136,6 +128,9 @@ export default {
     empty () {
       // compositionValue 不会是数字 0
       return !this.compositionValue && (this.value == null || this.value === '')
+    },
+    realSelectOnFocus () {
+      return this.type !== 'hidden' && this.selectOnFocus
     }
   },
   watch: {
@@ -151,11 +146,6 @@ export default {
       if (val) {
         this.$emit('autofill')
       }
-    }
-  },
-  mounted () {
-    if (this.type !== 'hidden' && this.selectOnFocus) {
-      this.$on('focus', $event => $event.target.select())
     }
   },
   methods: {
@@ -183,6 +173,10 @@ export default {
     },
     handleFocus ($event) {
       this.focused = true
+
+      if (this.realSelectOnFocus && $event.target) {
+        $event.target.select()
+      }
     },
     handleBlur ($event) {
       this.focused = false

--- a/packages/veui/src/components/NumberInput.vue
+++ b/packages/veui/src/components/NumberInput.vue
@@ -70,7 +70,7 @@ import Icon from './Icon'
 import { sign, add, round } from '../utils/math'
 import warn from '../utils/warn'
 import { VALUE_EVENTS } from '../utils/dom'
-import { isInteger, isNaN, pick, get, find, omit } from 'lodash'
+import { isInteger, isNaN, get, find, omit } from 'lodash'
 import nudge from 'veui/directives/nudge'
 import longpress from 'veui/directives/longpress'
 
@@ -86,6 +86,7 @@ export default {
     'veui-button': Button
   },
   mixins: [ui, input, activatable, i18n],
+  inhertiAttrs: false,
   props: {
     ui: String,
     value: Number,
@@ -120,12 +121,7 @@ export default {
     },
     attrs () {
       return {
-        ...pick(this.$props, [
-          'autofocus',
-          'selectOnFocus',
-          'autocomplete',
-          'placeholder'
-        ]),
+        ...this.$attrs,
         name: this.realName,
         disabled: this.realDisabled,
         readonly: this.realReadonly

--- a/packages/veui/src/components/Textarea.vue
+++ b/packages/veui/src/components/Textarea.vue
@@ -75,6 +75,7 @@ import {
 export default {
   name: 'veui-textarea',
   mixins: [ui, input, activatable],
+  inheritAttrs: false,
   props: {
     placeholder: String,
     value: {
@@ -83,7 +84,7 @@ export default {
     },
     lineNumber: Boolean,
     rows: [Number, String],
-    autofocus: Boolean,
+    selectOnFocus: Boolean,
     composition: Boolean,
     autoresize: Boolean
   },
@@ -105,7 +106,7 @@ export default {
     },
     attrs () {
       return {
-        ...pick(this, 'placeholder', 'autofocus'),
+        ...this.$attrs,
         rows: this.normalizedRows,
         disabled: this.realDisabled,
         readonly: this.realReadonly
@@ -136,6 +137,9 @@ export default {
       }
 
       return `${this.rowsHeight}px`
+    },
+    realSelectOnFocus () {
+      return this.type !== 'hidden' && this.selectOnFocus
     }
   },
   watch: {
@@ -188,13 +192,15 @@ export default {
           .reduce((acc, cur) => acc + cur, 0)
       )
     },
-    handleFocus (e) {
+    handleFocus ($event) {
       this.focused = true
-      this.$emit('focus', e)
+
+      if (this.realSelectOnFocus && $event.target) {
+        $event.target.select()
+      }
     },
-    handleBlur (e) {
+    handleBlur () {
       this.focused = false
-      this.$emit('blur', e)
     },
     getLineHeight (elem) {
       let computedStyle = getComputedStyle(elem)

--- a/packages/veui/test/unit/specs/components/Input.spec.js
+++ b/packages/veui/test/unit/specs/components/Input.spec.js
@@ -16,4 +16,14 @@ describe('components/Input', () => {
 
     wrapper.find('input').trigger('input')
   })
+
+  it('should transparently pass-through attrs to the <input> element.', () => {
+    const wrapper = mount(Input, {
+      attrs: {
+        autofocus: ''
+      }
+    })
+
+    expect(wrapper.find('input').element.autofocus).toBe(true)
+  })
 })

--- a/packages/veui/test/unit/specs/components/NumberInput.spec.js
+++ b/packages/veui/test/unit/specs/components/NumberInput.spec.js
@@ -1,4 +1,5 @@
 import { mount } from '@vue/test-utils'
+import Input from '@/components/Input'
 import NumberInput from '@/components/NumberInput'
 
 describe('components/NumberInput', () => {
@@ -15,5 +16,17 @@ describe('components/NumberInput', () => {
     setTimeout(() => {
       expect(changeHandler.mock.calls.length).toBe(0)
     })
+  })
+
+  it('should transparently pass-through attrs to the <input> element.', () => {
+    const wrapper = mount(NumberInput, {
+      attrs: {
+        autofocus: '',
+        selectOnFocus: ''
+      }
+    })
+
+    expect(wrapper.find(Input).props('selectOnFocus')).toBe(true)
+    expect(wrapper.find('input').element.autofocus).toBe(true)
   })
 })

--- a/packages/veui/test/unit/specs/components/Textarea.spec.js
+++ b/packages/veui/test/unit/specs/components/Textarea.spec.js
@@ -1,0 +1,29 @@
+import { mount } from '@vue/test-utils'
+import Textarea from '@/components/Textarea'
+
+describe('components/Textarea', () => {
+  it('should handle value prop with `null` value.', done => {
+    const wrapper = mount(Textarea, {
+      propsData: {
+        value: null
+      }
+    })
+
+    wrapper.vm.$on('input', val => {
+      expect(val).toBe('')
+      done()
+    })
+
+    wrapper.find('textarea').trigger('input')
+  })
+
+  it('should transparently pass-through attrs to the <textarea> element.', () => {
+    const wrapper = mount(Textarea, {
+      attrs: {
+        autofocus: ''
+      }
+    })
+
+    expect(wrapper.find('textarea').element.autofocus).toBe(true)
+  })
+})


### PR DESCRIPTION
* Remove unnecessary props
* Use `inheritAttrs: false`
* Transparently pass down props/attrs to the native `<input>` elements