### PR TITLE
fix: replace `stop()` with `skip()` so that other plugins won't break

### DIFF
--- a/packages/babel-plugin-veui/src/index.js
+++ b/packages/babel-plugin-veui/src/index.js
@@ -30,7 +30,7 @@ export default function (babel) {
                   t.stringLiteral(src)
                 )
               )
-              path.getSibling(path.key - 1).stop()
+              path.getSibling(path.key - 1).skip()
             } else {
               let realName = getComponentName(imported.name)
 
@@ -45,7 +45,7 @@ export default function (babel) {
                   t.stringLiteral(componentSrc)
                 )
               )
-              path.getSibling(path.key - 1).stop()
+              path.getSibling(path.key - 1).skip()
             }
           })
 


### PR DESCRIPTION
fixes #467

`path.skip()` skips traversing the children of the current path.
`path.stop()` stops traversal entirely.

So by using `stop()`, it may stop the execution of other babel plugins on
this file. In this case, it's `proposal-decorators` that failed to run.