### PR TITLE
test: add test case for Schedule

### DIFF
--- a/packages/veui/src/components/Schedule.vue
+++ b/packages/veui/src/components/Schedule.vue
@@ -25,6 +25,7 @@
                   'veui-schedule-shortcut': true,
                   'veui-schedule-shortcut-selected': shortcutChecked[i]
                 }"
+                :disabled="realDisabled || realReadonly"
                 @click="selectShortcut(i)"
               >
                 {{ label }}
@@ -36,6 +37,7 @@
                 :label="t('preset')"
                 :aria-label="t('selectPreset')"
                 :options="shortcutOptions"
+                :disabled="realDisabled || realReadonly"
                 @click="selectShortcut"
               />
             </template>
@@ -85,6 +87,7 @@
           :indeterminate="dayChecked[i - 1].indeterminate"
           :checked="dayChecked[i - 1].checked"
           :aria-label="getDayLabel(i - 1)"
+          :disabled="realDisabled || realReadonly"
           @change="toggleDay(week[i - 1], !dayChecked[i - 1].checked)"
         >
           {{ dayNames[i - 1] }}
@@ -114,7 +117,7 @@
             <button
               :ref="`hour-${week[i]}-${j}`"
               type="button"
-              :disabled="realDisabled || hour.isDisabled"
+              :disabled="realDisabled || realReadonly || hour.isDisabled"
               :class="mergeClass({ 'veui-schedule-selected': hour.isSelected }, week[i], j)"
               :tabindex="i === 0 && j === 0 ? '0' : '-1'"
               :aria-label="getHourLabel(i, j, hour)"
@@ -156,7 +159,7 @@
             >
               <slot
                 name="label"
-                :from="hour.from"
+                :from="hour.start"
                 :to="hour.end"
               >
                 {{
@@ -499,7 +502,26 @@ export default {
     },
     toggleDay (day, checked) {
       if (checked) {
-        this.$set(this.localSelected, day, [[0, 23]])
+        let hours = [[0, 23]]
+
+        for (let i = 0; i < 24; i++) {
+          if (this.disabledHour(day, i)) {
+            hours = hours.reduce((acc, item) => {
+              if (i > item[0] && i < item[1]) {
+                acc.push([item[0], i - 1], [i + 1, item[1]])
+              } else if (i === item[0]) {
+                acc.push([i + 1, item[1]])
+              } else if (i === item[1]) {
+                acc.push([item[0], i - 1])
+              } else {
+                acc.push(item)
+              }
+
+              return acc
+            }, [])
+          }
+        }
+        this.$set(this.localSelected, day, hours)
       } else {
         this.$delete(this.localSelected, day)
       }

--- a/packages/veui/src/components/Schedule.vue
+++ b/packages/veui/src/components/Schedule.vue
@@ -491,7 +491,15 @@ export default {
     },
     pick () {
       if (this.pickingStart) {
-        this.localSelected = this.pickingSelected
+        for (let i = 0; i < 7; i++) {
+          if (this.pickingSelected[i]) {
+            this.$set(
+              this.localSelected,
+              i,
+              this.filterDisabledHours(i, this.pickingSelected[i])
+            )
+          }
+        }
         this.pickingStart = this.pickingEnd = null
         this.$emit('select', this.localSelected)
       }
@@ -500,28 +508,16 @@ export default {
       this.localSelected = this.realShortcuts[i].selected
       this.$emit('select', this.localSelected)
     },
+    filterDisabledHours (day, selectedHours = [[0, 23]]) {
+      let disabledHours = [...Array(24)]
+          .map((_, i) => (this.disabledHour(day, i) ? [i, i] : false))
+          .filter(i => i)
+
+      return merge(selectedHours, disabledHours, { mode: 'substract' })
+    },
     toggleDay (day, checked) {
       if (checked) {
-        let hours = [[0, 23]]
-
-        for (let i = 0; i < 24; i++) {
-          if (this.disabledHour(day, i)) {
-            hours = hours.reduce((acc, item) => {
-              if (i > item[0] && i < item[1]) {
-                acc.push([item[0], i - 1], [i + 1, item[1]])
-              } else if (i === item[0]) {
-                acc.push([i + 1, item[1]])
-              } else if (i === item[1]) {
-                acc.push([item[0], i - 1])
-              } else {
-                acc.push(item)
-              }
-
-              return acc
-            }, [])
-          }
-        }
-        this.$set(this.localSelected, day, hours)
+        this.$set(this.localSelected, day, this.filterDisabledHours(day))
       } else {
         this.$delete(this.localSelected, day)
       }

--- a/packages/veui/src/directives/outside.js
+++ b/packages/veui/src/directives/outside.js
@@ -55,7 +55,7 @@ function initBindingType (type) {
 
 function getElementsByRefs (refs, context) {
   const elements = []
-  refs || [].forEach(ref => {
+  refs.forEach(ref => {
     elements.push(...getNodes(ref, context))
   })
   return elements

--- a/packages/veui/src/directives/outside.js
+++ b/packages/veui/src/directives/outside.js
@@ -55,7 +55,7 @@ function initBindingType (type) {
 
 function getElementsByRefs (refs, context) {
   const elements = []
-  refs.forEach(ref => {
+  refs || [].forEach(ref => {
     elements.push(...getNodes(ref, context))
   })
   return elements

--- a/packages/veui/test/unit/specs/components/Schedule.spec.js
+++ b/packages/veui/test/unit/specs/components/Schedule.spec.js
@@ -23,4 +23,311 @@ describe('components/Schedule', () => {
     button.trigger('mousedown')
     button.trigger('mouseup')
   })
+
+  it('should support selected prop correctly.', () => {
+    let wrapper = mount(Schedule, {
+      sync: false,
+      propsData: {
+        selected: {
+          0: [[0, 23]],
+          1: [[9, 11], [13, 17]],
+          3: [[13, 16]],
+          5: [[9, 9], [16, 17]]
+        }
+      }
+    })
+
+    let rows = wrapper.findAll('.veui-schedule-table-interaction tr')
+    expect(rows.at(0).findAll('td.veui-schedule-selected').length).to.equal(8)
+    expect(rows.at(2).findAll('td.veui-schedule-selected').length).to.equal(4)
+    expect(rows.at(4).findAll('td.veui-schedule-selected').length).to.equal(3)
+    expect(rows.at(6).findAll('td.veui-schedule-selected').length).to.equal(24)
+
+    wrapper.destroy()
+  })
+
+  it('should support other props correctly.', async () => {
+    let wrapper = mount(
+      {
+        components: {
+          'veui-schedule': Schedule
+        },
+        data () {
+          return {
+            selected: {},
+            hourClass (day, hour) {
+              return {
+                night: hour > 19,
+                weekend: day === 6 || day === 0
+              }
+            },
+            disabledHour (day, hour) {
+              return hour < 3 || hour === 7 || hour === 23
+            },
+            shortcuts: [
+              {
+                label: '特选时间',
+                selected: {
+                  3: [[13, 16]],
+                  5: [[9, 9], [16, 17]]
+                }
+              },
+              {
+                label: '周末',
+                selected: {
+                  0: true,
+                  6: true
+                }
+              }
+            ],
+            shortcutsDisplay: 'popup',
+            statuses: [
+              {
+                label: '已选',
+                value: 'selected'
+              },
+              {
+                label: '可选',
+                value: 'available'
+              }
+            ],
+            disabled: false,
+            readonly: false
+          }
+        },
+        template: `
+          <veui-schedule
+            v-model="selected"
+            :hourClass="hourClass"
+            :disabledHour="disabledHour"
+            :shortcuts="shortcuts"
+            :shortcuts-display="shortcutsDisplay"
+            :statuses="statuses"
+            :disabled="disabled"
+            :readonly="readonly"
+          />
+        `
+      },
+      {
+        sync: false
+      }
+    )
+
+    let rows = wrapper.findAll('.veui-schedule-table-interaction tr')
+    let { vm } = wrapper
+
+    // hourClass
+    expect(rows.at(0).findAll('td').at(20).find('button').classes()).to.include('night')
+    expect(rows.at(5).findAll('td').at(20).find('button').classes()).to.include('night')
+    expect(rows.at(5).findAll('td').at(20).find('button').classes()).to.include('weekend')
+
+    // disabledHour
+    expect(rows.at(0).find('td button').attributes('disabled')).to.equal('disabled')
+
+    // head-day-checkbox
+    wrapper.find('.veui-schedule-head-day-item input').trigger('change')
+    await vm.$nextTick()
+    expect(rows.at(0).find('td button').attributes('disabled')).to.equal('disabled')
+    expect(rows.at(0).findAll('td button').at(5).attributes('disabled')).to.not.equal('disabled')
+
+    // shortcuts
+    wrapper.find('.veui-dropdown-button').trigger('click')
+    await vm.$nextTick()
+    wrapper.find('.veui-dropdown-options .veui-option').trigger('click')
+    await vm.$nextTick()
+    expect(vm.selected).to.deep.equal({
+      3: [[13, 16]],
+      5: [[9, 9], [16, 17]]
+    })
+
+    wrapper.find('.veui-dropdown-button').trigger('click')
+    await vm.$nextTick()
+    wrapper.findAll('.veui-dropdown-options .veui-option').at(1).trigger('click')
+    await vm.$nextTick()
+    expect(vm.selected).to.deep.equal({
+      0: [[0, 23]],
+      6: [[0, 23]]
+    })
+
+    // shortcutsDisplay
+    expect(wrapper.find('.veui-schedule-shortcuts').contains('.veui-dropdown')).to.equal(true)
+    vm.shortcutsDisplay = 'inline'
+    await vm.$nextTick()
+    expect(wrapper.find('.veui-schedule-shortcuts').contains('.veui-dropdown')).to.not.equal(true)
+    expect(wrapper.findAll('.veui-schedule-shortcut').length).to.equal(2)
+
+    // statuses
+    expect(wrapper.find('.veui-schedule-legend .veui-schedule-legend-selected').text()).to.equal('已选')
+    expect(wrapper.find('.veui-schedule-legend .veui-schedule-legend-available').text()).to.equal('可选')
+
+    // disabled
+    let button = wrapper.findAll('.veui-schedule-table-interaction tr')
+      .at(4)
+      .findAll('td button')
+      .at(10)
+
+    expect(button.attributes('disabled')).to.not.equal('disabled')
+    vm.disabled = true
+    await vm.$nextTick()
+    expect(button.attributes('disabled')).to.equal('disabled')
+    expect(wrapper.find('.veui-schedule-head-day-item input')
+      .attributes('disabled')).to.equal('disabled')
+    expect(wrapper.find('.veui-schedule-shortcut').attributes('disabled')).to.equal('disabled')
+
+    // readonly
+    vm.disabled = false
+    vm.readonly = true
+    await vm.$nextTick()
+    expect(button.attributes('disabled')).to.equal('disabled')
+    expect(wrapper.find('.veui-schedule-head-day-item input')
+      .attributes('disabled')).to.equal('disabled')
+    expect(wrapper.find('.veui-schedule-shortcut').attributes('disabled')).to.equal('disabled')
+
+    wrapper.destroy()
+  })
+
+  it('should support select event correctly.', done => {
+    let wrapper = mount(
+      {
+        components: {
+          'veui-schedule': Schedule
+        },
+        data () {
+          return {
+            selected: {}
+          }
+        },
+        methods: {
+          selectHandler (val) {
+            expect(val).to.deep.equal({
+              0: [[7, 7]]
+            })
+
+            wrapper.destroy()
+            done()
+          }
+        },
+        template: `<veui-schedule :selected="selected" @select="selectHandler" />`
+      },
+      {
+        sync: false
+      }
+    )
+
+    let button = wrapper.findAll('.veui-schedule-table-interaction tr')
+      .at(6)
+      .findAll('td button')
+      .at(7)
+    button.trigger('mousedown')
+    button.trigger('mouseup')
+  })
+
+  it('should render header slot correctly.', () => {
+    let wrapper = mount(Schedule, {
+      sync: false,
+      slots: {
+        header: '<div class="customized-header">schedule header</div>'
+      }
+    })
+
+    expect(wrapper.find('.customized-header').text()).to.equal('schedule header')
+    wrapper.destroy()
+  })
+
+  it('should render header-content slot correctly.', () => {
+    let wrapper = mount(Schedule, {
+      sync: false,
+      slots: {
+        'header-content': '<h2>Header Content</h2>'
+      }
+    })
+
+    expect(wrapper.find('.veui-schedule-header h2').text()).to.equal('Header Content')
+    wrapper.destroy()
+  })
+
+  it('should render slots of shortcuts & legend correctly.', () => {
+    let wrapper = mount(Schedule, {
+      sync: false,
+      propsData: {
+        shortcuts: [
+          {
+            label: '周末',
+            selected: {
+              0: true,
+              6: true
+            }
+          }
+        ]
+      },
+      slots: {
+        shortcuts: '<span class="customized-shortcuts">shortcuts</span>',
+        legend: '<span class="customized-legend">legend</span>'
+      }
+    })
+
+    expect(wrapper.find('.veui-schedule-header .customized-shortcuts').text()).to.equal('shortcuts')
+    expect(wrapper.find('.veui-schedule-header .customized-legend').text()).to.equal('legend')
+    wrapper.destroy()
+  })
+
+  it('should render slots of legend-label & hour & label & tooltip correctly.', async () => {
+    let wrapper = mount(
+      {
+        components: {
+          'veui-schedule': Schedule
+        },
+        data () {
+          return {
+            statuses: [
+              {
+                label: '已选',
+                value: 'selected'
+              },
+              {
+                label: '可选',
+                value: 'available'
+              }
+            ]
+          }
+        },
+        template:
+        `
+          <veui-schedule :statuses="statuses">
+            <span slot="legend-label" slot-scope="prop">{{ prop.value }}</span>
+            <span slot="hour" slot-scope="prop">{{ prop.day }} {{ prop.hour }}</span>
+            <span slot="label" slot-scope="{from, to}">
+              {{
+                to - from > 0
+                  ? from + ':00–' + (to + 1) +':00'
+                  : ''
+              }}
+            </span>
+            <span class="tooltip-content" slot="tooltip" slot-scope="{day, hour}">{{ day }} {{ hour }}</span>
+          </veui-schedule>
+        `
+      },
+      {
+        sync: false,
+        attachToDocument: true
+      }
+    )
+
+    expect(wrapper.find('.veui-schedule-legend-item span').text()).to.equal('selected')
+    expect(wrapper.find('.veui-schedule-table-interaction tr button').text()).to.equal('1 0')
+
+    let button = wrapper.find('.veui-schedule-table-interaction tr button')
+    button.trigger('mousedown')
+    button.trigger('keydown.right')
+    button.trigger('mouseup')
+
+    await wrapper.vm.$nextTick()
+
+    let cells = wrapper.find('.veui-schedule-table-interaction tr').findAll('td')
+    expect(cells.at(0).classes()).to.include('veui-schedule-selected')
+    expect(wrapper.find('.veui-schedule-table-selected td').text()).to.equal('0:00–2:00')
+
+    expect(wrapper.find('.tooltip-content').text()).to.equal('1 1')
+    wrapper.destroy()
+  })
 })


### PR DESCRIPTION
fix:
1.  设定disabled-hour后，勾选左侧的checkbox，仍会选中当天所有时刻，包括disabled-hour
2. 设定disabled为true后，左侧的checkbox和shortcuts仍可选择
3. 设定readonly为true后，Schedule仍能选择
4. tooltip slot中绑定的from值应为hour.start
5. demo/cases/schedule 页面，鼠标在页面上移动，会报“Uncaught TypeError: Cannot read property 'forEach' of undefined at getElementsByRefs (outside.js?2b20:58) ”的错误