### PR TITLE
!refactor: use Popper.js instead of Tether, update deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,18 +12,18 @@
       }
     },
     "@babel/core": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.5.5.tgz",
-      "integrity": "sha512-i4qoSr2KTtce0DmkuuQBV4AuQgGPUcPXMr9L5MyYAtk06z068lQ10a4O009fe5OB/DfNV+h+qqT7ddNV8UnRjg==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.4.tgz",
+      "integrity": "sha512-Rm0HGw101GY8FTzpWSyRbki/jzq+/PkNQJ+nSulrdY6gFGOsNseCqD6KHRYe2E+EdzuBdr2pxCp6s4Uk6eJ+XQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.5.5",
-        "@babel/generator": "^7.5.5",
-        "@babel/helpers": "^7.5.5",
-        "@babel/parser": "^7.5.5",
-        "@babel/template": "^7.4.4",
-        "@babel/traverse": "^7.5.5",
-        "@babel/types": "^7.5.5",
+        "@babel/generator": "^7.6.4",
+        "@babel/helpers": "^7.6.2",
+        "@babel/parser": "^7.6.4",
+        "@babel/template": "^7.6.0",
+        "@babel/traverse": "^7.6.3",
+        "@babel/types": "^7.6.3",
         "convert-source-map": "^1.1.0",
         "debug": "^4.1.0",
         "json5": "^2.1.0",
@@ -43,9 +43,9 @@
           }
         },
         "json5": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
-          "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
+          "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
@@ -66,16 +66,15 @@
       }
     },
     "@babel/generator": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz",
-      "integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.4.tgz",
+      "integrity": "sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.5.5",
+        "@babel/types": "^7.6.3",
         "jsesc": "^2.5.1",
         "lodash": "^4.17.13",
-        "source-map": "^0.5.0",
-        "trim-right": "^1.0.1"
+        "source-map": "^0.5.0"
       }
     },
     "@babel/helper-function-name": {
@@ -108,14 +107,14 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.5.5.tgz",
-      "integrity": "sha512-nRq2BUhxZFnfEn/ciJuhklHvFOqjJUD5wpx+1bxUF2axL9C+v4DE/dmp5sT2dKnpOs4orZWzpAZqlCy8QqE/7g==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.6.2.tgz",
+      "integrity": "sha512-3/bAUL8zZxYs1cdX2ilEE0WobqbCmKWr/889lf2SS0PpDcpEIY8pb1CCyz0pEcX3pEb+MCbks1jIokz2xLtGTA==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.4.4",
-        "@babel/traverse": "^7.5.5",
-        "@babel/types": "^7.5.5"
+        "@babel/template": "^7.6.0",
+        "@babel/traverse": "^7.6.2",
+        "@babel/types": "^7.6.0"
       }
     },
     "@babel/highlight": {
@@ -167,15 +166,15 @@
       }
     },
     "@babel/parser": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
-      "integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.4.tgz",
+      "integrity": "sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==",
       "dev": true
     },
     "@babel/runtime": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
-      "integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.3.tgz",
+      "integrity": "sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.2"
@@ -190,28 +189,28 @@
       }
     },
     "@babel/template": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
-      "integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
+      "integrity": "sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.4.4",
-        "@babel/types": "^7.4.4"
+        "@babel/parser": "^7.6.0",
+        "@babel/types": "^7.6.0"
       }
     },
     "@babel/traverse": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.5.tgz",
-      "integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.3.tgz",
+      "integrity": "sha512-unn7P4LGsijIxaAJo/wpoU11zN+2IaClkQAxcJWBNCMS6cmVh802IyLHNkAjQ0iYnRS3nnxk5O3fuXW28IMxTw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.5.5",
-        "@babel/generator": "^7.5.5",
+        "@babel/generator": "^7.6.3",
         "@babel/helper-function-name": "^7.1.0",
         "@babel/helper-split-export-declaration": "^7.4.4",
-        "@babel/parser": "^7.5.5",
-        "@babel/types": "^7.5.5",
+        "@babel/parser": "^7.6.3",
+        "@babel/types": "^7.6.3",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.13"
@@ -241,9 +240,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
-      "integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
+      "integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2",
@@ -358,15 +357,15 @@
       }
     },
     "@lerna/add": {
-      "version": "3.16.2",
-      "resolved": "https://registry.npmjs.org/@lerna/add/-/add-3.16.2.tgz",
-      "integrity": "sha512-RAAaF8aODPogj2Ge9Wj3uxPFIBGpog9M+HwSuq03ZnkkO831AmasCTJDqV+GEpl1U2DvnhZQEwHpWmTT0uUeEw==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@lerna/add/-/add-3.18.0.tgz",
+      "integrity": "sha512-Z5EaQbBnJn1LEPb0zb0Q2o9T8F8zOnlCsj6JYpY6aSke17UUT7xx0QMN98iBK+ueUHKjN/vdFdYlNCYRSIdujA==",
       "dev": true,
       "requires": {
         "@evocateur/pacote": "^9.6.3",
-        "@lerna/bootstrap": "3.16.2",
-        "@lerna/command": "3.16.0",
-        "@lerna/filter-options": "3.16.0",
+        "@lerna/bootstrap": "3.18.0",
+        "@lerna/command": "3.18.0",
+        "@lerna/filter-options": "3.18.0",
         "@lerna/npm-conf": "3.16.0",
         "@lerna/validation-error": "3.13.0",
         "dedent": "^0.7.0",
@@ -383,34 +382,23 @@
         }
       }
     },
-    "@lerna/batch-packages": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/batch-packages/-/batch-packages-3.16.0.tgz",
-      "integrity": "sha512-7AdMkANpubY/FKFI01im01tlx6ygOBJ/0JcixMUWoWP/7Ds3SWQF22ID6fbBr38jUWptYLDs2fagtTDL7YUPuA==",
-      "dev": true,
-      "requires": {
-        "@lerna/package-graph": "3.16.0",
-        "npmlog": "^4.1.2"
-      }
-    },
     "@lerna/bootstrap": {
-      "version": "3.16.2",
-      "resolved": "https://registry.npmjs.org/@lerna/bootstrap/-/bootstrap-3.16.2.tgz",
-      "integrity": "sha512-I+gs7eh6rv9Vyd+CwqL7sftRfOOsSzCle8cv/CGlMN7/p7EAVhxEdAw8SYoHIKHzipXszuqqy1Y3opyleD0qdA==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@lerna/bootstrap/-/bootstrap-3.18.0.tgz",
+      "integrity": "sha512-3DZKWIaKvr7sUImoKqSz6eqn84SsOVMnA5QHwgzXiQjoeZ/5cg9x2r+Xj3+3w/lvLoh0j8U2GNtrIaPNis4bKQ==",
       "dev": true,
       "requires": {
-        "@lerna/batch-packages": "3.16.0",
-        "@lerna/command": "3.16.0",
-        "@lerna/filter-options": "3.16.0",
-        "@lerna/has-npm-version": "3.16.0",
-        "@lerna/npm-install": "3.16.0",
-        "@lerna/package-graph": "3.16.0",
+        "@lerna/command": "3.18.0",
+        "@lerna/filter-options": "3.18.0",
+        "@lerna/has-npm-version": "3.16.5",
+        "@lerna/npm-install": "3.16.5",
+        "@lerna/package-graph": "3.18.0",
         "@lerna/pulse-till-done": "3.13.0",
-        "@lerna/rimraf-dir": "3.14.2",
+        "@lerna/rimraf-dir": "3.16.5",
         "@lerna/run-lifecycle": "3.16.2",
-        "@lerna/run-parallel-batches": "3.16.0",
-        "@lerna/symlink-binary": "3.16.2",
-        "@lerna/symlink-dependencies": "3.16.2",
+        "@lerna/run-topologically": "3.18.0",
+        "@lerna/symlink-binary": "3.17.0",
+        "@lerna/symlink-dependencies": "3.17.0",
         "@lerna/validation-error": "3.13.0",
         "dedent": "^0.7.0",
         "get-port": "^4.2.0",
@@ -434,33 +422,33 @@
       }
     },
     "@lerna/changed": {
-      "version": "3.16.4",
-      "resolved": "https://registry.npmjs.org/@lerna/changed/-/changed-3.16.4.tgz",
-      "integrity": "sha512-NCD7XkK744T23iW0wqKEgF4R9MYmReUbyHCZKopFnsNpQdqumc3SOIvQUAkKCP6hQJmYvxvOieoVgy/CVDpZ5g==",
+      "version": "3.18.3",
+      "resolved": "https://registry.npmjs.org/@lerna/changed/-/changed-3.18.3.tgz",
+      "integrity": "sha512-xZW7Rm+DlDIGc0EvKGyJZgT9f8FFa4d52mr/Y752dZuXR2qRmf9tXhVloRG39881s2A6yi3jqLtXZggKhsQW4Q==",
       "dev": true,
       "requires": {
-        "@lerna/collect-updates": "3.16.0",
-        "@lerna/command": "3.16.0",
-        "@lerna/listable": "3.16.0",
+        "@lerna/collect-updates": "3.18.0",
+        "@lerna/command": "3.18.0",
+        "@lerna/listable": "3.18.0",
         "@lerna/output": "3.13.0",
-        "@lerna/version": "3.16.4"
+        "@lerna/version": "3.18.3"
       }
     },
     "@lerna/check-working-tree": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/@lerna/check-working-tree/-/check-working-tree-3.14.2.tgz",
-      "integrity": "sha512-7safqxM/MYoAoxZxulUDtIJIbnBIgo0PB/FHytueG+9VaX7GMnDte2Bt1EKa0dz2sAyQdmQ3Q8ZXpf/6JDjaeg==",
+      "version": "3.16.5",
+      "resolved": "https://registry.npmjs.org/@lerna/check-working-tree/-/check-working-tree-3.16.5.tgz",
+      "integrity": "sha512-xWjVBcuhvB8+UmCSb5tKVLB5OuzSpw96WEhS2uz6hkWVa/Euh1A0/HJwn2cemyK47wUrCQXtczBUiqnq9yX5VQ==",
       "dev": true,
       "requires": {
-        "@lerna/collect-uncommitted": "3.14.2",
-        "@lerna/describe-ref": "3.14.2",
+        "@lerna/collect-uncommitted": "3.16.5",
+        "@lerna/describe-ref": "3.16.5",
         "@lerna/validation-error": "3.13.0"
       }
     },
     "@lerna/child-process": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/@lerna/child-process/-/child-process-3.14.2.tgz",
-      "integrity": "sha512-xnq+W5yQb6RkwI0p16ZQnrn6HkloH/MWTw4lGE1nKsBLAUbmSU5oTE93W1nrG0X3IMF/xWc9UYvNdUGMWvZZ4w==",
+      "version": "3.16.5",
+      "resolved": "https://registry.npmjs.org/@lerna/child-process/-/child-process-3.16.5.tgz",
+      "integrity": "sha512-vdcI7mzei9ERRV4oO8Y1LHBZ3A5+ampRKg1wq5nutLsUA4mEBN6H7JqjWOMY9xZemv6+kATm2ofjJ3lW5TszQg==",
       "dev": true,
       "requires": {
         "chalk": "^2.3.1",
@@ -500,40 +488,40 @@
       }
     },
     "@lerna/clean": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/clean/-/clean-3.16.0.tgz",
-      "integrity": "sha512-5P9U5Y19WmYZr7UAMGXBpY7xCRdlR7zhHy8MAPDKVx70rFIBS6nWXn5n7Kntv74g7Lm1gJ2rsiH5tj1OPcRJgg==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@lerna/clean/-/clean-3.18.0.tgz",
+      "integrity": "sha512-BiwBELZNkarRQqj+v5NPB1aIzsOX+Y5jkZ9a5UbwHzEdBUQ5lQa0qaMLSOve/fSkaiZQxe6qnTyatN75lOcDMg==",
       "dev": true,
       "requires": {
-        "@lerna/command": "3.16.0",
-        "@lerna/filter-options": "3.16.0",
+        "@lerna/command": "3.18.0",
+        "@lerna/filter-options": "3.18.0",
         "@lerna/prompt": "3.13.0",
         "@lerna/pulse-till-done": "3.13.0",
-        "@lerna/rimraf-dir": "3.14.2",
+        "@lerna/rimraf-dir": "3.16.5",
         "p-map": "^2.1.0",
         "p-map-series": "^1.0.0",
         "p-waterfall": "^1.0.0"
       }
     },
     "@lerna/cli": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/@lerna/cli/-/cli-3.13.0.tgz",
-      "integrity": "sha512-HgFGlyCZbYaYrjOr3w/EsY18PdvtsTmDfpUQe8HwDjXlPeCCUgliZjXLOVBxSjiOvPeOSwvopwIHKWQmYbwywg==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@lerna/cli/-/cli-3.18.0.tgz",
+      "integrity": "sha512-AwDyfGx7fxJgeaZllEuyJ9LZ6Tdv9yqRD9RX762yCJu+PCAFvB9bp6OYuRSGli7QQgM0CuOYnSg4xVNOmuGKDA==",
       "dev": true,
       "requires": {
         "@lerna/global-options": "3.13.0",
         "dedent": "^0.7.0",
         "npmlog": "^4.1.2",
-        "yargs": "^12.0.1"
+        "yargs": "^14.2.0"
       }
     },
     "@lerna/collect-uncommitted": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/@lerna/collect-uncommitted/-/collect-uncommitted-3.14.2.tgz",
-      "integrity": "sha512-4EkQu4jIOdNL2BMzy/N0ydHB8+Z6syu6xiiKXOoFl0WoWU9H1jEJCX4TH7CmVxXL1+jcs8FIS2pfQz4oew99Eg==",
+      "version": "3.16.5",
+      "resolved": "https://registry.npmjs.org/@lerna/collect-uncommitted/-/collect-uncommitted-3.16.5.tgz",
+      "integrity": "sha512-ZgqnGwpDZiWyzIQVZtQaj9tRizsL4dUOhuOStWgTAw1EMe47cvAY2kL709DzxFhjr6JpJSjXV5rZEAeU3VE0Hg==",
       "dev": true,
       "requires": {
-        "@lerna/child-process": "3.14.2",
+        "@lerna/child-process": "3.16.5",
         "chalk": "^2.3.1",
         "figgy-pudding": "^3.5.1",
         "npmlog": "^4.1.2"
@@ -571,13 +559,13 @@
       }
     },
     "@lerna/collect-updates": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/collect-updates/-/collect-updates-3.16.0.tgz",
-      "integrity": "sha512-HwAIl815X2TNlmcp28zCrSdXfoZWNP7GJPEqNWYk7xDJTYLqQ+SrmKUePjb3AMGBwYAraZSEJLbHdBpJ5+cHmQ==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@lerna/collect-updates/-/collect-updates-3.18.0.tgz",
+      "integrity": "sha512-LJMKgWsE/var1RSvpKDIxS8eJ7POADEc0HM3FQiTpEczhP6aZfv9x3wlDjaHpZm9MxJyQilqxZcasRANmRcNgw==",
       "dev": true,
       "requires": {
-        "@lerna/child-process": "3.14.2",
-        "@lerna/describe-ref": "3.14.2",
+        "@lerna/child-process": "3.16.5",
+        "@lerna/describe-ref": "3.16.5",
         "minimatch": "^3.0.4",
         "npmlog": "^4.1.2",
         "slash": "^2.0.0"
@@ -592,14 +580,14 @@
       }
     },
     "@lerna/command": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/command/-/command-3.16.0.tgz",
-      "integrity": "sha512-u7tE4GC4/gfbPA9eQg+0ulnoJ+PMoMqomx033r/IxqZrHtmJR9+pF/37S0fsxJ2hX/RMFPC7c9Q/i8NEufSpdQ==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@lerna/command/-/command-3.18.0.tgz",
+      "integrity": "sha512-JQ0TGzuZc9Ky8xtwtSLywuvmkU8X62NTUT3rMNrUykIkOxBaO+tE0O98u2yo/9BYOeTRji9IsjKZEl5i9Qt0xQ==",
       "dev": true,
       "requires": {
-        "@lerna/child-process": "3.14.2",
-        "@lerna/package-graph": "3.16.0",
-        "@lerna/project": "3.16.0",
+        "@lerna/child-process": "3.16.5",
+        "@lerna/package-graph": "3.18.0",
+        "@lerna/project": "3.18.0",
         "@lerna/validation-error": "3.13.0",
         "@lerna/write-log-file": "3.13.0",
         "dedent": "^0.7.0",
@@ -643,14 +631,14 @@
       }
     },
     "@lerna/create": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/create/-/create-3.16.0.tgz",
-      "integrity": "sha512-OZApR1Iz7awutbmj4sAArwhqCyKgcrnw9rH0aWAUrkYWrD1w4TwkvAcYAsfx5GpQGbLQwoXhoyyPwPfZRRWz3Q==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@lerna/create/-/create-3.18.0.tgz",
+      "integrity": "sha512-y9oS7ND5T13c+cCTJHa2Y9in02ppzyjsNynVWFuS40eIzZ3z058d9+3qSBt1nkbbQlVyfLoP6+bZPsjyzap5ig==",
       "dev": true,
       "requires": {
         "@evocateur/pacote": "^9.6.3",
-        "@lerna/child-process": "3.14.2",
-        "@lerna/command": "3.16.0",
+        "@lerna/child-process": "3.16.5",
+        "@lerna/command": "3.18.0",
         "@lerna/npm-conf": "3.16.0",
         "@lerna/validation-error": "3.13.0",
         "camelcase": "^5.0.0",
@@ -706,56 +694,58 @@
       }
     },
     "@lerna/describe-ref": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/@lerna/describe-ref/-/describe-ref-3.14.2.tgz",
-      "integrity": "sha512-qa5pzDRK2oBQXNjyRmRnN7E8a78NMYfQjjlRFB0KNHMsT6mCiL9+8kIS39sSE2NqT8p7xVNo2r2KAS8R/m3CoQ==",
+      "version": "3.16.5",
+      "resolved": "https://registry.npmjs.org/@lerna/describe-ref/-/describe-ref-3.16.5.tgz",
+      "integrity": "sha512-c01+4gUF0saOOtDBzbLMFOTJDHTKbDFNErEY6q6i9QaXuzy9LNN62z+Hw4acAAZuJQhrVWncVathcmkkjvSVGw==",
       "dev": true,
       "requires": {
-        "@lerna/child-process": "3.14.2",
+        "@lerna/child-process": "3.16.5",
         "npmlog": "^4.1.2"
       }
     },
     "@lerna/diff": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/diff/-/diff-3.16.0.tgz",
-      "integrity": "sha512-QUpVs5TPl8vBIne10/vyjUxanQBQQp7Lk3iaB8MnCysKr0O+oy7trWeFVDPEkBTCD177By7yPGyW5Yey1nCBbA==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@lerna/diff/-/diff-3.18.0.tgz",
+      "integrity": "sha512-3iLNlpurc2nV9k22w8ini2Zjm2UPo3xtQgWyqdA6eJjvge0+5AlNAWfPoV6cV+Hc1xDbJD2YDSFpZPJ1ZGilRw==",
       "dev": true,
       "requires": {
-        "@lerna/child-process": "3.14.2",
-        "@lerna/command": "3.16.0",
+        "@lerna/child-process": "3.16.5",
+        "@lerna/command": "3.18.0",
         "@lerna/validation-error": "3.13.0",
         "npmlog": "^4.1.2"
       }
     },
     "@lerna/exec": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/exec/-/exec-3.16.0.tgz",
-      "integrity": "sha512-mH3O5NXf/O88jBaBBTUf+d56CUkxpg782s3Jxy7HWbVuSUULt3iMRPTh+zEXO5/555etsIVVDDyUR76meklrJA==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@lerna/exec/-/exec-3.18.0.tgz",
+      "integrity": "sha512-hwkuzg1+38+pbzdZPhGtLIYJ59z498/BCNzR8d4/nfMYm8lFbw9RgJJajLcdbuJ9LJ08cZ93hf8OlzetL84TYg==",
       "dev": true,
       "requires": {
-        "@lerna/child-process": "3.14.2",
-        "@lerna/command": "3.16.0",
-        "@lerna/filter-options": "3.16.0",
-        "@lerna/run-topologically": "3.16.0",
+        "@lerna/child-process": "3.16.5",
+        "@lerna/command": "3.18.0",
+        "@lerna/filter-options": "3.18.0",
+        "@lerna/run-topologically": "3.18.0",
         "@lerna/validation-error": "3.13.0",
         "p-map": "^2.1.0"
       }
     },
     "@lerna/filter-options": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/filter-options/-/filter-options-3.16.0.tgz",
-      "integrity": "sha512-InIi1fF8+PxpCwir9bIy+pGxrdE6hvN0enIs1eNGCVS1TTE8osNgiZXa838bMQ1yaEccdcnVX6Z03BNKd56kNg==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@lerna/filter-options/-/filter-options-3.18.0.tgz",
+      "integrity": "sha512-UGVcixs3TGzD8XSmFSbwUVVQnAjaZ6Rmt8Vuq2RcR98ULkGB1LiGNMY89XaNBhaaA8vx7yQWiLmJi2AfmD63Qg==",
       "dev": true,
       "requires": {
-        "@lerna/collect-updates": "3.16.0",
-        "@lerna/filter-packages": "3.16.0",
-        "dedent": "^0.7.0"
+        "@lerna/collect-updates": "3.18.0",
+        "@lerna/filter-packages": "3.18.0",
+        "dedent": "^0.7.0",
+        "figgy-pudding": "^3.5.1",
+        "npmlog": "^4.1.2"
       }
     },
     "@lerna/filter-packages": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/filter-packages/-/filter-packages-3.16.0.tgz",
-      "integrity": "sha512-eGFzQTx0ogkGDCnbTuXqssryR6ilp8+dcXt6B+aq1MaqL/vOJRZyqMm4TY3CUOUnzZCi9S2WWyMw3PnAJOF+kg==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@lerna/filter-packages/-/filter-packages-3.18.0.tgz",
+      "integrity": "sha512-6/0pMM04bCHNATIOkouuYmPg6KH3VkPCIgTfQmdkPJTullERyEQfNUKikrefjxo1vHOoCACDpy65JYyKiAbdwQ==",
       "dev": true,
       "requires": {
         "@lerna/validation-error": "3.13.0",
@@ -784,12 +774,12 @@
       }
     },
     "@lerna/github-client": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/github-client/-/github-client-3.16.0.tgz",
-      "integrity": "sha512-IVJjcKjkYaUEPJsDyAblHGEFFNKCRyMagbIDm14L7Ab94ccN6i4TKOqAFEJn2SJHYvKKBdp3Zj2zNlASOMe3DA==",
+      "version": "3.16.5",
+      "resolved": "https://registry.npmjs.org/@lerna/github-client/-/github-client-3.16.5.tgz",
+      "integrity": "sha512-rHQdn8Dv/CJrO3VouOP66zAcJzrHsm+wFuZ4uGAai2At2NkgKH+tpNhQy2H1PSC0Ezj9LxvdaHYrUzULqVK5Hw==",
       "dev": true,
       "requires": {
-        "@lerna/child-process": "3.14.2",
+        "@lerna/child-process": "3.16.5",
         "@octokit/plugin-enterprise-rest": "^3.6.1",
         "@octokit/rest": "^16.28.4",
         "git-url-parse": "^11.1.2",
@@ -814,12 +804,12 @@
       "dev": true
     },
     "@lerna/has-npm-version": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/has-npm-version/-/has-npm-version-3.16.0.tgz",
-      "integrity": "sha512-TIY036dA9J8OyTrZq9J+it2DVKifL65k7hK8HhkUPpitJkw6jwbMObA/8D40LOGgWNPweJWqmlrTbRSwsR7DrQ==",
+      "version": "3.16.5",
+      "resolved": "https://registry.npmjs.org/@lerna/has-npm-version/-/has-npm-version-3.16.5.tgz",
+      "integrity": "sha512-WL7LycR9bkftyqbYop5rEGJ9sRFIV55tSGmbN1HLrF9idwOCD7CLrT64t235t3t4O5gehDnwKI5h2U3oxTrF8Q==",
       "dev": true,
       "requires": {
-        "@lerna/child-process": "3.14.2",
+        "@lerna/child-process": "3.16.5",
         "semver": "^6.2.0"
       },
       "dependencies": {
@@ -832,13 +822,13 @@
       }
     },
     "@lerna/import": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/import/-/import-3.16.0.tgz",
-      "integrity": "sha512-trsOmGHzw0rL/f8BLNvd+9PjoTkXq2Dt4/V2UCha254hMQaYutbxcYu8iKPxz9x86jSPlH7FpbTkkHXDsoY7Yg==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@lerna/import/-/import-3.18.0.tgz",
+      "integrity": "sha512-2pYIkkBTZsEdccfc+dPsKZeSw3tBzKSyl0b2lGrfmNX2Y41qqOzsJCyI1WO1uvEIP8aOaLy4hPpqRIBe4ee7hw==",
       "dev": true,
       "requires": {
-        "@lerna/child-process": "3.14.2",
-        "@lerna/command": "3.16.0",
+        "@lerna/child-process": "3.16.5",
+        "@lerna/command": "3.18.0",
         "@lerna/prompt": "3.13.0",
         "@lerna/pulse-till-done": "3.13.0",
         "@lerna/validation-error": "3.13.0",
@@ -848,27 +838,27 @@
       }
     },
     "@lerna/init": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/init/-/init-3.16.0.tgz",
-      "integrity": "sha512-Ybol/x5xMtBgokx4j7/Y3u0ZmNh0NiSWzBFVaOs2NOJKvuqrWimF67DKVz7yYtTYEjtaMdug64ohFF4jcT/iag==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@lerna/init/-/init-3.18.0.tgz",
+      "integrity": "sha512-/vHpmXkMlSaJaq25v5K13mcs/2L7E32O6dSsEkHaZCDRiV2BOqsZng9jjbE/4ynfsWfLLlU9ZcydwG72C3I+mQ==",
       "dev": true,
       "requires": {
-        "@lerna/child-process": "3.14.2",
-        "@lerna/command": "3.16.0",
+        "@lerna/child-process": "3.16.5",
+        "@lerna/command": "3.18.0",
         "fs-extra": "^8.1.0",
         "p-map": "^2.1.0",
         "write-json-file": "^3.2.0"
       }
     },
     "@lerna/link": {
-      "version": "3.16.2",
-      "resolved": "https://registry.npmjs.org/@lerna/link/-/link-3.16.2.tgz",
-      "integrity": "sha512-eCPg5Lo8HT525fIivNoYF3vWghO3UgEVFdbsiPmhzwI7IQyZro5HWYzLtywSAdEog5XZpd2Bbn0CsoHWBB3gww==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@lerna/link/-/link-3.18.0.tgz",
+      "integrity": "sha512-FbbIpH0EpsC+dpAbvxCoF3cn7F1MAyJjEa5Lh3XkDGATOlinMFuKCbmX0NLpOPQZ5zghvrui97cx+jz5F2IlHw==",
       "dev": true,
       "requires": {
-        "@lerna/command": "3.16.0",
-        "@lerna/package-graph": "3.16.0",
-        "@lerna/symlink-dependencies": "3.16.2",
+        "@lerna/command": "3.18.0",
+        "@lerna/package-graph": "3.18.0",
+        "@lerna/symlink-dependencies": "3.17.0",
         "p-map": "^2.1.0",
         "slash": "^2.0.0"
       },
@@ -882,24 +872,24 @@
       }
     },
     "@lerna/list": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/list/-/list-3.16.0.tgz",
-      "integrity": "sha512-TkvstoPsgKqqQ0KfRumpsdMXfRSEhdXqOLq519XyI5IRWYxhoqXqfi8gG37UoBPhBNoe64japn5OjphF3rOmQA==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@lerna/list/-/list-3.18.0.tgz",
+      "integrity": "sha512-mpB7Q6T+n2CaiPFz0LuOE+rXphDfHm0mKIwShnyS/XDcii8jXv+z9Iytj8p3rfCH2I1L80j2qL6jWzyGy/uzKA==",
       "dev": true,
       "requires": {
-        "@lerna/command": "3.16.0",
-        "@lerna/filter-options": "3.16.0",
-        "@lerna/listable": "3.16.0",
+        "@lerna/command": "3.18.0",
+        "@lerna/filter-options": "3.18.0",
+        "@lerna/listable": "3.18.0",
         "@lerna/output": "3.13.0"
       }
     },
     "@lerna/listable": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/listable/-/listable-3.16.0.tgz",
-      "integrity": "sha512-mtdAT2EEECqrJSDm/aXlOUFr1MRE4p6hppzY//Klp05CogQy6uGaKk+iKG5yyCLaOXFFZvG4HfO11CmoGSDWzw==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@lerna/listable/-/listable-3.18.0.tgz",
+      "integrity": "sha512-9gLGKYNLSKeurD+sJ2RA+nz4Ftulr91U127gefz0RlmAPpYSjwcJkxwa0UfJvpQTXv9C7yzHLnn0BjyAQRjuew==",
       "dev": true,
       "requires": {
-        "@lerna/query-graph": "3.16.0",
+        "@lerna/query-graph": "3.18.0",
         "chalk": "^2.3.1",
         "columnify": "^1.5.4"
       },
@@ -966,9 +956,9 @@
       }
     },
     "@lerna/npm-dist-tag": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/npm-dist-tag/-/npm-dist-tag-3.16.0.tgz",
-      "integrity": "sha512-MQrBkqJJB9+eNphuj9w90QPMOs4NQXMuSRk9NqzeFunOmdDopPCV0Q7IThSxEuWnhJ2n3B7G0vWUP7tNMPdqIQ==",
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@lerna/npm-dist-tag/-/npm-dist-tag-3.18.1.tgz",
+      "integrity": "sha512-vWkZh2T/O9OjPLDrba0BTWO7ug/C3sCwjw7Qyk1aEbxMBXB/eEJPqirwJTWT+EtRJQYB01ky3K8ZFOhElVyjLw==",
       "dev": true,
       "requires": {
         "@evocateur/npm-registry-fetch": "^4.0.0",
@@ -979,12 +969,12 @@
       }
     },
     "@lerna/npm-install": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/npm-install/-/npm-install-3.16.0.tgz",
-      "integrity": "sha512-APUOIilZCzDzce92uLEwzt1r7AEMKT/hWA1ThGJL+PO9Rn8A95Km3o2XZAYG4W0hR+P4O2nSVuKbsjQtz8CjFQ==",
+      "version": "3.16.5",
+      "resolved": "https://registry.npmjs.org/@lerna/npm-install/-/npm-install-3.16.5.tgz",
+      "integrity": "sha512-hfiKk8Eku6rB9uApqsalHHTHY+mOrrHeWEs+gtg7+meQZMTS3kzv4oVp5cBZigndQr3knTLjwthT/FX4KvseFg==",
       "dev": true,
       "requires": {
-        "@lerna/child-process": "3.14.2",
+        "@lerna/child-process": "3.16.5",
         "@lerna/get-npm-exec-opts": "3.13.0",
         "fs-extra": "^8.1.0",
         "npm-package-arg": "^6.1.0",
@@ -1019,12 +1009,12 @@
       }
     },
     "@lerna/npm-run-script": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/@lerna/npm-run-script/-/npm-run-script-3.14.2.tgz",
-      "integrity": "sha512-LbVFv+nvAoRTYLMrJlJ8RiakHXrLslL7Jp/m1R18vYrB8LYWA3ey+nz5Tel2OELzmjUiemAKZsD9h6i+Re5egg==",
+      "version": "3.16.5",
+      "resolved": "https://registry.npmjs.org/@lerna/npm-run-script/-/npm-run-script-3.16.5.tgz",
+      "integrity": "sha512-1asRi+LjmVn3pMjEdpqKJZFT/3ZNpb+VVeJMwrJaV/3DivdNg7XlPK9LTrORuKU4PSvhdEZvJmSlxCKyDpiXsQ==",
       "dev": true,
       "requires": {
-        "@lerna/child-process": "3.14.2",
+        "@lerna/child-process": "3.16.5",
         "@lerna/get-npm-exec-opts": "3.13.0",
         "npmlog": "^4.1.2"
       }
@@ -1113,9 +1103,9 @@
       }
     },
     "@lerna/package-graph": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/package-graph/-/package-graph-3.16.0.tgz",
-      "integrity": "sha512-A2mum/gNbv7zCtAwJqoxzqv89As73OQNK2MgSX1SHWya46qoxO9a9Z2c5lOFQ8UFN5ZxqWMfFYXRCz7qzwmFXw==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@lerna/package-graph/-/package-graph-3.18.0.tgz",
+      "integrity": "sha512-BLYDHO5ihPh20i3zoXfLZ5ZWDCrPuGANgVhl7k5pCmRj90LCvT+C7V3zrw70fErGAfvkcYepMqxD+oBrAYwquQ==",
       "dev": true,
       "requires": {
         "@lerna/prerelease-id-from-version": "3.16.0",
@@ -1151,9 +1141,9 @@
       }
     },
     "@lerna/project": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/project/-/project-3.16.0.tgz",
-      "integrity": "sha512-NrKcKK1EqXqhrGvslz6Q36+ZHuK3zlDhGdghRqnxDcHxMPT01NgLcmsnymmQ+gjMljuLRmvKYYCuHrknzX8VrA==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@lerna/project/-/project-3.18.0.tgz",
+      "integrity": "sha512-+LDwvdAp0BurOAWmeHE3uuticsq9hNxBI0+FMHiIai8jrygpJGahaQrBYWpwbshbQyVLeQgx3+YJdW2TbEdFWA==",
       "dev": true,
       "requires": {
         "@lerna/package": "3.16.0",
@@ -1218,22 +1208,22 @@
       }
     },
     "@lerna/publish": {
-      "version": "3.16.4",
-      "resolved": "https://registry.npmjs.org/@lerna/publish/-/publish-3.16.4.tgz",
-      "integrity": "sha512-XZY+gRuF7/v6PDQwl7lvZaGWs8CnX6WIPIu+OCcyFPSL/rdWegdN7HieKBHskgX798qRQc2GrveaY7bNoTKXAw==",
+      "version": "3.18.3",
+      "resolved": "https://registry.npmjs.org/@lerna/publish/-/publish-3.18.3.tgz",
+      "integrity": "sha512-XlfWOWIhaSK0Y2sX5ppNWI5Y3CDtlxMcQa1hTbZlC5rrDA6vD32iutbmH6Ix3c6wtvVbSkgA39GWsQEXxPS+7w==",
       "dev": true,
       "requires": {
         "@evocateur/libnpmaccess": "^3.1.2",
         "@evocateur/npm-registry-fetch": "^4.0.0",
         "@evocateur/pacote": "^9.6.3",
-        "@lerna/check-working-tree": "3.14.2",
-        "@lerna/child-process": "3.14.2",
-        "@lerna/collect-updates": "3.16.0",
-        "@lerna/command": "3.16.0",
-        "@lerna/describe-ref": "3.14.2",
+        "@lerna/check-working-tree": "3.16.5",
+        "@lerna/child-process": "3.16.5",
+        "@lerna/collect-updates": "3.18.0",
+        "@lerna/command": "3.18.0",
+        "@lerna/describe-ref": "3.16.5",
         "@lerna/log-packed": "3.16.0",
         "@lerna/npm-conf": "3.16.0",
-        "@lerna/npm-dist-tag": "3.16.0",
+        "@lerna/npm-dist-tag": "3.18.1",
         "@lerna/npm-publish": "3.16.2",
         "@lerna/otplease": "3.16.0",
         "@lerna/output": "3.13.0",
@@ -1242,9 +1232,9 @@
         "@lerna/prompt": "3.13.0",
         "@lerna/pulse-till-done": "3.13.0",
         "@lerna/run-lifecycle": "3.16.2",
-        "@lerna/run-topologically": "3.16.0",
+        "@lerna/run-topologically": "3.18.0",
         "@lerna/validation-error": "3.13.0",
-        "@lerna/version": "3.16.4",
+        "@lerna/version": "3.18.3",
         "figgy-pudding": "^3.5.1",
         "fs-extra": "^8.1.0",
         "npm-package-arg": "^6.1.0",
@@ -1273,12 +1263,12 @@
       }
     },
     "@lerna/query-graph": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/query-graph/-/query-graph-3.16.0.tgz",
-      "integrity": "sha512-p0RO+xmHDO95ChJdWkcy9TNLysLkoDARXeRHzY5U54VCwl3Ot/2q8fMCVlA5UeGXDutEyyByl3URqEpcQCWI7Q==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@lerna/query-graph/-/query-graph-3.18.0.tgz",
+      "integrity": "sha512-fgUhLx6V0jDuKZaKj562jkuuhrfVcjl5sscdfttJ8dXNVADfDz76nzzwLY0ZU7/0m69jDedohn5Fx5p7hDEVEg==",
       "dev": true,
       "requires": {
-        "@lerna/package-graph": "3.16.0",
+        "@lerna/package-graph": "3.18.0",
         "figgy-pudding": "^3.5.1"
       }
     },
@@ -1294,12 +1284,12 @@
       }
     },
     "@lerna/rimraf-dir": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/@lerna/rimraf-dir/-/rimraf-dir-3.14.2.tgz",
-      "integrity": "sha512-eFNkZsy44Bu9v1Hrj5Zk6omzg8O9h/7W6QYK1TTUHeyrjTEwytaNQlqF0lrTLmEvq55sviV42NC/8P3M2cvq8Q==",
+      "version": "3.16.5",
+      "resolved": "https://registry.npmjs.org/@lerna/rimraf-dir/-/rimraf-dir-3.16.5.tgz",
+      "integrity": "sha512-bQlKmO0pXUsXoF8lOLknhyQjOZsCc0bosQDoX4lujBXSWxHVTg1VxURtWf2lUjz/ACsJVDfvHZbDm8kyBk5okA==",
       "dev": true,
       "requires": {
-        "@lerna/child-process": "3.14.2",
+        "@lerna/child-process": "3.16.5",
         "npmlog": "^4.1.2",
         "path-exists": "^3.0.0",
         "rimraf": "^2.6.2"
@@ -1314,16 +1304,16 @@
       }
     },
     "@lerna/run": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/run/-/run-3.16.0.tgz",
-      "integrity": "sha512-woTeLlB1OAAz4zzjdI6RyIxSGuxiUPHJZm89E1pDEPoWwtQV6HMdMgrsQd9ATsJ5Ez280HH4bF/LStAlqW8Ufg==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@lerna/run/-/run-3.18.0.tgz",
+      "integrity": "sha512-sblxHBZ9djaaG7wefPcfEicDqzrB7CP1m/jIB0JvPEQwG4C2qp++ewBpkjRw/mBtjtzg0t7v0nNMXzaWYrQckQ==",
       "dev": true,
       "requires": {
-        "@lerna/command": "3.16.0",
-        "@lerna/filter-options": "3.16.0",
-        "@lerna/npm-run-script": "3.14.2",
+        "@lerna/command": "3.18.0",
+        "@lerna/filter-options": "3.18.0",
+        "@lerna/npm-run-script": "3.16.5",
         "@lerna/output": "3.13.0",
-        "@lerna/run-topologically": "3.16.0",
+        "@lerna/run-topologically": "3.18.0",
         "@lerna/timer": "3.13.0",
         "@lerna/validation-error": "3.13.0",
         "p-map": "^2.1.0"
@@ -1341,31 +1331,21 @@
         "npmlog": "^4.1.2"
       }
     },
-    "@lerna/run-parallel-batches": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/run-parallel-batches/-/run-parallel-batches-3.16.0.tgz",
-      "integrity": "sha512-2J/Nyv+MvogmQEfC7VcS21ifk7w0HVvzo2yOZRPvkCzGRu/rducxtB4RTcr58XCZ8h/Bt1aqQYKExu3c/3GXwg==",
-      "dev": true,
-      "requires": {
-        "p-map": "^2.1.0",
-        "p-map-series": "^1.0.0"
-      }
-    },
     "@lerna/run-topologically": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/run-topologically/-/run-topologically-3.16.0.tgz",
-      "integrity": "sha512-4Hlpv4zDtKWa5Z0tPkeu0sK+bxZEKgkNESMGmWrUCNfj7xwvAJurcraK8+a2Y0TFYwf0qjSLY/MzX+ZbJA3Cgw==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@lerna/run-topologically/-/run-topologically-3.18.0.tgz",
+      "integrity": "sha512-lrfEewwuUMC3ioxf9Z9NdHUakN6ihekcPfdYbzR2slmdbjYKmIA5srkWdrK8NwOpQCAuekpOovH2s8X3FGEopg==",
       "dev": true,
       "requires": {
-        "@lerna/query-graph": "3.16.0",
+        "@lerna/query-graph": "3.18.0",
         "figgy-pudding": "^3.5.1",
         "p-queue": "^4.0.0"
       }
     },
     "@lerna/symlink-binary": {
-      "version": "3.16.2",
-      "resolved": "https://registry.npmjs.org/@lerna/symlink-binary/-/symlink-binary-3.16.2.tgz",
-      "integrity": "sha512-kz9XVoFOGSF83gg4gBqH+mG6uxfJfTp8Uy+Cam40CvMiuzfODrGkjuBEFoM/uO2QOAwZvbQDYOBpKUa9ZxHS1Q==",
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/@lerna/symlink-binary/-/symlink-binary-3.17.0.tgz",
+      "integrity": "sha512-RLpy9UY6+3nT5J+5jkM5MZyMmjNHxZIZvXLV+Q3MXrf7Eaa1hNqyynyj4RO95fxbS+EZc4XVSk25DGFQbcRNSQ==",
       "dev": true,
       "requires": {
         "@lerna/create-symlink": "3.16.2",
@@ -1375,14 +1355,14 @@
       }
     },
     "@lerna/symlink-dependencies": {
-      "version": "3.16.2",
-      "resolved": "https://registry.npmjs.org/@lerna/symlink-dependencies/-/symlink-dependencies-3.16.2.tgz",
-      "integrity": "sha512-wnZqGJQ+Jvr1I3inxrkffrFZfmQI7Ta8gySw/UWCy95QtZWF/f5yk8zVIocCAsjzD0wgb3jJE3CFJ9W5iwWk1A==",
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/@lerna/symlink-dependencies/-/symlink-dependencies-3.17.0.tgz",
+      "integrity": "sha512-KmjU5YT1bpt6coOmdFueTJ7DFJL4H1w5eF8yAQ2zsGNTtZ+i5SGFBWpb9AQaw168dydc3s4eu0W0Sirda+F59Q==",
       "dev": true,
       "requires": {
         "@lerna/create-symlink": "3.16.2",
         "@lerna/resolve-symlink": "3.16.0",
-        "@lerna/symlink-binary": "3.16.2",
+        "@lerna/symlink-binary": "3.17.0",
         "fs-extra": "^8.1.0",
         "p-finally": "^1.0.0",
         "p-map": "^2.1.0",
@@ -1405,26 +1385,27 @@
       }
     },
     "@lerna/version": {
-      "version": "3.16.4",
-      "resolved": "https://registry.npmjs.org/@lerna/version/-/version-3.16.4.tgz",
-      "integrity": "sha512-ikhbMeIn5ljCtWTlHDzO4YvTmpGTX1lWFFIZ79Vd1TNyOr+OUuKLo/+p06mCl2WEdZu0W2s5E9oxfAAQbyDxEg==",
+      "version": "3.18.3",
+      "resolved": "https://registry.npmjs.org/@lerna/version/-/version-3.18.3.tgz",
+      "integrity": "sha512-IXXRlyM3Q/jrc+QZio+bgjG4ZaK+4LYmY4Yql1xyY0wZhAKsWP/Q6ho7e1EJNjNC5dUJO99Fq7qB05MkDf2OcQ==",
       "dev": true,
       "requires": {
-        "@lerna/check-working-tree": "3.14.2",
-        "@lerna/child-process": "3.14.2",
-        "@lerna/collect-updates": "3.16.0",
-        "@lerna/command": "3.16.0",
+        "@lerna/check-working-tree": "3.16.5",
+        "@lerna/child-process": "3.16.5",
+        "@lerna/collect-updates": "3.18.0",
+        "@lerna/command": "3.18.0",
         "@lerna/conventional-commits": "3.16.4",
-        "@lerna/github-client": "3.16.0",
+        "@lerna/github-client": "3.16.5",
         "@lerna/gitlab-client": "3.15.0",
         "@lerna/output": "3.13.0",
         "@lerna/prerelease-id-from-version": "3.16.0",
         "@lerna/prompt": "3.13.0",
         "@lerna/run-lifecycle": "3.16.2",
-        "@lerna/run-topologically": "3.16.0",
+        "@lerna/run-topologically": "3.18.0",
         "@lerna/validation-error": "3.13.0",
         "chalk": "^2.3.1",
         "dedent": "^0.7.0",
+        "load-json-file": "^5.3.0",
         "minimatch": "^3.0.4",
         "npmlog": "^4.1.2",
         "p-map": "^2.1.0",
@@ -1433,7 +1414,8 @@
         "p-waterfall": "^1.0.0",
         "semver": "^6.2.0",
         "slash": "^2.0.0",
-        "temp-write": "^3.4.0"
+        "temp-write": "^3.4.0",
+        "write-json-file": "^3.2.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -1456,6 +1438,35 @@
             "supports-color": "^5.3.0"
           }
         },
+        "load-json-file": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
+          "integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.15",
+            "parse-json": "^4.0.0",
+            "pify": "^4.0.1",
+            "strip-bom": "^3.0.0",
+            "type-fest": "^0.3.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        },
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -1476,6 +1487,12 @@
           "requires": {
             "has-flag": "^3.0.0"
           }
+        },
+        "type-fest": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+          "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+          "dev": true
         }
       }
     },
@@ -1506,14 +1523,13 @@
       "dev": true
     },
     "@octokit/endpoint": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.3.3.tgz",
-      "integrity": "sha512-WCeDVK0OHlG7Ppob/5Jh/cOpCtjf7mmidEu7XRxdRt+PGv3wZxO1pt+vF4oUxuMUTOBIJd3ppCi1jiqyOdBZRQ==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.4.1.tgz",
+      "integrity": "sha512-iwn46orWg3F4iqIzAVRfbzhnROyx7BQ7zJE0B7SEeaMIBvk3qmWtswtRk14QkMNUuNiCHQ6mAM00VJxWqrdM1g==",
       "dev": true,
       "requires": {
         "is-plain-object": "^3.0.0",
-        "universal-user-agent": "^3.0.0",
-        "url-template": "^2.0.8"
+        "universal-user-agent": "^4.0.0"
       },
       "dependencies": {
         "is-plain-object": {
@@ -1540,9 +1556,9 @@
       "dev": true
     },
     "@octokit/request": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.0.2.tgz",
-      "integrity": "sha512-z1BQr43g4kOL4ZrIVBMHwi68Yg9VbkRUyuAgqCp1rU3vbYa69+2gIld/+gHclw15bJWQnhqqyEb7h5a5EqgZ0A==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.2.1.tgz",
+      "integrity": "sha512-onjQo4QKyiMAqLM6j3eH8vWw1LEfNCpoZUl6a+TrZVJM1wysBC8F0GhK9K/Vc9UsScSmVs2bstOVD34xpQ2wqQ==",
       "dev": true,
       "requires": {
         "@octokit/endpoint": "^5.1.0",
@@ -1551,7 +1567,7 @@
         "is-plain-object": "^3.0.0",
         "node-fetch": "^2.3.0",
         "once": "^1.4.0",
-        "universal-user-agent": "^3.0.0"
+        "universal-user-agent": "^4.0.0"
       },
       "dependencies": {
         "is-plain-object": {
@@ -1582,12 +1598,12 @@
       }
     },
     "@octokit/rest": {
-      "version": "16.28.8",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.28.8.tgz",
-      "integrity": "sha512-FouTTcLdT++gwgKVnBN8CEVeFvY/OKzeaoH/L9LBvZhbjUotLthFWAdKa8WeOMt5x7Rs7uvBpu7IdcrtRD3wBA==",
+      "version": "16.33.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.33.1.tgz",
+      "integrity": "sha512-lOQ+fJZwkeJ/1PRTdnY1uNja01aKOMioRhQfZtei64gZMXIX3EAfF4koMQMvoLFwsnVBu3ifj1JW1WAAKdXcnA==",
       "dev": true,
       "requires": {
-        "@octokit/request": "^5.0.0",
+        "@octokit/request": "^5.2.0",
         "@octokit/request-error": "^1.0.2",
         "atob-lite": "^2.0.0",
         "before-after-hook": "^2.0.0",
@@ -1598,7 +1614,7 @@
         "lodash.uniq": "^4.5.0",
         "octokit-pagination-methods": "^1.1.0",
         "once": "^1.4.0",
-        "universal-user-agent": "^3.0.0"
+        "universal-user-agent": "^4.0.0"
       }
     },
     "@samverschueren/stream-to-observable": {
@@ -1634,9 +1650,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.7.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.3.tgz",
-      "integrity": "sha512-3SiLAIBkDWDg6vFo0+5YJyHPWU9uwu40Qe+v+0MH8wRKYBimHvvAOyk3EzMrD/TrIlLYfXrqDqrg913PynrMJQ==",
+      "version": "12.11.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.5.tgz",
+      "integrity": "sha512-LC8ALj/24PhByn39nr5jnTvpE7MujK8y7LQmV74kHYF5iQ0odCPkMH4IZNZw+cobKfSXqaC8GgegcbIsQpffdA==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -1706,9 +1722,9 @@
       "dev": true
     },
     "acorn-jsx": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.2.tgz",
-      "integrity": "sha512-tiNTrP1MP0QrChmD2DdupCr6HWSFeKVw5d/dHTu4Y7rkAkRhU/Dt7dphAfIUyxtHpl/eBVip5uTNSpQJHylpAw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
+      "integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==",
       "dev": true
     },
     "agent-base": {
@@ -1933,18 +1949,18 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.6.1.tgz",
-      "integrity": "sha512-aVo5WxR3VyvyJxcJC3h4FKfwCQvQWb1tSI5VHNibddCVWrcD1NvlxEweg3TSgiPztMnWfjpy2FURKA2kvDE+Tw==",
+      "version": "9.6.5",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.6.5.tgz",
+      "integrity": "sha512-rGd50YV8LgwFQ2WQp4XzOTG69u1qQsXn0amww7tjqV5jJuNazgFKYEVItEBngyyvVITKOg20zr2V+9VsrXJQ2g==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.6.3",
-        "caniuse-lite": "^1.0.30000980",
+        "browserslist": "^4.7.0",
+        "caniuse-lite": "^1.0.30000999",
         "chalk": "^2.4.2",
         "normalize-range": "^0.1.2",
         "num2fraction": "^1.2.2",
-        "postcss": "^7.0.17",
-        "postcss-value-parser": "^4.0.0"
+        "postcss": "^7.0.18",
+        "postcss-value-parser": "^4.0.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -2162,9 +2178,9 @@
       "dev": true
     },
     "bluebird": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
-      "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
+      "integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg==",
       "dev": true
     },
     "brace-expansion": {
@@ -2207,14 +2223,14 @@
       }
     },
     "browserslist": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.0.tgz",
-      "integrity": "sha512-9rGNDtnj+HaahxiVV38Gn8n8Lr8REKsel68v1sPFfIGEK6uSXTY3h9acgiT1dZVtOOUtifo/Dn8daDQ5dUgVsA==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.1.tgz",
+      "integrity": "sha512-QtULFqKIAtiyNx7NhZ/p4rB8m3xDozVo/pi5VgTlADLF2tNigz/QH+v0m5qhn7XfHT7u+607NcCNOnC0HZAlMg==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30000989",
-        "electron-to-chromium": "^1.3.247",
-        "node-releases": "^1.1.29"
+        "caniuse-lite": "^1.0.30000999",
+        "electron-to-chromium": "^1.3.284",
+        "node-releases": "^1.1.36"
       }
     },
     "btoa-lite": {
@@ -2343,9 +2359,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000989",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000989.tgz",
-      "integrity": "sha512-vrMcvSuMz16YY6GSVZ0dWDTJP8jqk3iFQ/Aq5iqblPwxSVVZI+zxDyTX0VPqtQsDnfdrBDcsmhgTEOh5R8Lbpw==",
+      "version": "1.0.30001002",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001002.tgz",
+      "integrity": "sha512-pRuxPE8wdrWmVPKcDmJJiGBxr6lFJq4ivdSeo9FTmGj5Rb8NX3Mby2pARG57MXF15hYAhZ0nHV5XxT2ig4bz3g==",
       "dev": true
     },
     "caseless": {
@@ -2404,9 +2420,9 @@
       "dev": true
     },
     "chownr": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz",
-      "integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
+      "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
       "dev": true
     },
     "ci-info": {
@@ -2498,29 +2514,40 @@
       "dev": true
     },
     "cliui": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-      "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
       "dev": true,
       "requires": {
-        "string-width": "^2.1.1",
-        "strip-ansi": "^4.0.0",
-        "wrap-ansi": "^2.0.0"
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
           }
         }
       }
@@ -2561,9 +2588,9 @@
       "dev": true
     },
     "codecov": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.5.0.tgz",
-      "integrity": "sha512-/OsWOfIHaQIr7aeZ4pY0UC1PZT6kimoKFOFYFNb6wxo3iw12nRrh+mNGH72rnXxNsq6SGfesVPizm/6Q3XqcFQ==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.6.1.tgz",
+      "integrity": "sha512-IUJB6WG47nWK7o50etF8jBadxdMw7DmoQg05yIljstXFBGB6clOZsIj6iD4P82T2YaIU3qq+FFu8K9pxgkCJDQ==",
       "dev": true,
       "requires": {
         "argv": "^0.0.2",
@@ -2624,9 +2651,9 @@
       }
     },
     "commander": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
     },
     "common-tags": {
@@ -2709,9 +2736,9 @@
       "dev": true
     },
     "conventional-changelog-angular": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.3.tgz",
-      "integrity": "sha512-YD1xzH7r9yXQte/HF9JBuEDfvjxxwDGGwZU1+ndanbY0oFgA+Po1T9JDSpPLdP0pZT6MhCAsdvFKC4TJ4MTJTA==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.5.tgz",
+      "integrity": "sha512-RrkdWnL/TVyWV1ayWmSsrWorsTDqjL/VwG5ZSEneBQrd65ONcfeA1cW7FLtNweQyMiKOyriCMTKRSlk18DjTrw==",
       "dev": true,
       "requires": {
         "compare-func": "^1.3.1",
@@ -2824,15 +2851,15 @@
       "dev": true
     },
     "conventional-changelog-writer": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.7.tgz",
-      "integrity": "sha512-p/wzs9eYaxhFbrmX/mCJNwJuvvHR+j4Fd0SQa2xyAhYed6KBiZ780LvoqUUvsayP4R1DtC27czalGUhKV2oabw==",
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.9.tgz",
+      "integrity": "sha512-2Y3QfiAM37WvDMjkVNaRtZgxVzWKj73HE61YQ/95T53yle+CRwTVSl6Gbv/lWVKXeZcM5af9n9TDVf0k7Xh+cw==",
       "dev": true,
       "requires": {
         "compare-func": "^1.3.1",
         "conventional-commits-filter": "^2.0.2",
         "dateformat": "^3.0.0",
-        "handlebars": "^4.1.2",
+        "handlebars": "^4.4.0",
         "json-stringify-safe": "^5.0.1",
         "lodash": "^4.2.1",
         "meow": "^4.0.0",
@@ -2869,9 +2896,9 @@
       }
     },
     "conventional-commits-parser": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.3.tgz",
-      "integrity": "sha512-KaA/2EeUkO4bKjinNfGUyqPTX/6w9JGshuQRik4r/wJz7rUw3+D3fDG6sZSEqJvKILzKXFQuFkpPLclcsAuZcg==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.5.tgz",
+      "integrity": "sha512-qVz9+5JwdJzsbt7JbJ6P7NOXBGt8CyLFJYSjKAuPSgO+5UGfcsbk9EMR+lI8Unlvx6qwIc2YDJlrGIfay2ehNA==",
       "dev": true,
       "requires": {
         "JSONStream": "^1.0.4",
@@ -2973,9 +3000,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
+      "version": "2.6.10",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
+      "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==",
       "dev": true
     },
     "core-util-is": {
@@ -3047,9 +3074,9 @@
       }
     },
     "cyclist": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
-      "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
+      "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
       "dev": true
     },
     "dargs": {
@@ -3409,9 +3436,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.251",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.251.tgz",
-      "integrity": "sha512-C5oOBdqJTYago4PBeew9duLqWZ3SlDnTRM+PMIgZd/ILFrT5AfaAGd3jRNEfuPklFHFqOjfwbCvXpyzEYb5sXg==",
+      "version": "1.3.293",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.293.tgz",
+      "integrity": "sha512-DQSBRuU2Z1vG+CEWUIfCEVMHtuaGlhVojzg39mX5dx7PLSFDJ7DSrGUWzaPFFgWR1jo26hj1nXXRQZvFwk7F8w==",
       "dev": true
     },
     "elegant-spinner": {
@@ -3442,9 +3469,9 @@
       }
     },
     "end-of-stream": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"
@@ -3478,9 +3505,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.14.0.tgz",
-      "integrity": "sha512-lri42nNq1tIohUuwFBYEM3wKwcrcJa78jukGDdWsuaNxTtxBFGFkKUQ15nc9J+ipje4mhbQR6JwABb4VvawR3A==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.0.tgz",
+      "integrity": "sha512-xdQnfykZ9JMEiasTAJZJdMWCQ1Vm00NBw79/AWi7ELfZuuPCSOMDZbT9mkOfSctVtfhb+sAAzrm+j//GjjLHLg==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.0",
@@ -3491,8 +3518,8 @@
         "is-regex": "^1.0.4",
         "object-inspect": "^1.6.0",
         "object-keys": "^1.1.1",
-        "string.prototype.trimleft": "^2.0.0",
-        "string.prototype.trimright": "^2.0.0"
+        "string.prototype.trimleft": "^2.1.0",
+        "string.prototype.trimright": "^2.1.0"
       }
     },
     "es-to-primitive": {
@@ -3815,12 +3842,12 @@
       }
     },
     "eslint-utils": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
-      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
       "dev": true,
       "requires": {
-        "eslint-visitor-keys": "^1.0.0"
+        "eslint-visitor-keys": "^1.1.0"
       }
     },
     "eslint-visitor-keys": {
@@ -4260,12 +4287,12 @@
       }
     },
     "fs-minipass": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.6.tgz",
-      "integrity": "sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+      "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
       "dev": true,
       "requires": {
-        "minipass": "^2.2.1"
+        "minipass": "^2.6.0"
       }
     },
     "fs-write-stream-atomic": {
@@ -4354,15 +4381,15 @@
       "dev": true
     },
     "get-caller-file": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
     "get-own-enumerable-property-symbols": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.0.tgz",
-      "integrity": "sha512-CIJYJC4GGF06TakLg8z4GQKvDsx9EMspVxOYih7LerEL/WosUnFIww45CGfxfeKHqlg3twgUrYRT1O3WQqjGCg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.1.tgz",
+      "integrity": "sha512-09/VS4iek66Dh2bctjRkowueRJbY1JDGR1L/zRxO1Qk8Uxs6PnqaNSqalpizPT+CDjre3hnEsuzvhgomz9qYrA==",
       "dev": true
     },
     "get-pkg-repo": {
@@ -4626,9 +4653,9 @@
       }
     },
     "glob": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+      "integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -4640,9 +4667,9 @@
       }
     },
     "glob-parent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.0.0.tgz",
-      "integrity": "sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+      "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
       "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
@@ -4740,9 +4767,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.5.tgz",
+      "integrity": "sha512-0Ce31oWVB7YidkaTq33ZxEbN+UDxMMgThvCe8ptgQViymL5DPis9uLdTA13MiRPhgvqyxIegugrP97iK3JeBHg==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -4844,9 +4871,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
-      "integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
+      "integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
       "dev": true
     },
     "html-tags": {
@@ -4921,9 +4948,9 @@
       }
     },
     "https-proxy-agent": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz",
-      "integrity": "sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.3.tgz",
+      "integrity": "sha512-Ytgnz23gm2DVftnzqRRz2dOXZbGd2uiajSw/95bPp6v53zPRspQjLm/AfBgqbJ2qfeRXWIOMVLpp86+/5yX39Q==",
       "dev": true,
       "requires": {
         "agent-base": "^4.3.0",
@@ -5122,9 +5149,9 @@
       "dev": true
     },
     "ignore-walk": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
-      "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
+      "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
       "dev": true,
       "requires": {
         "minimatch": "^3.0.4"
@@ -5353,12 +5380,6 @@
       "requires": {
         "loose-envify": "^1.0.0"
       }
-    },
-    "invert-kv": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-      "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
-      "dev": true
     },
     "ip": {
       "version": "1.1.5",
@@ -5836,36 +5857,27 @@
       "integrity": "sha512-P+0a/gBzLgVlCnK8I7VcD0yuYJscmWn66wH9tlKsQnmVdg689tLEmziwB9PuazZYLkcm07fvWOKCJJqI55sD5Q==",
       "dev": true
     },
-    "lcid": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-      "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
-      "dev": true,
-      "requires": {
-        "invert-kv": "^2.0.0"
-      }
-    },
     "lerna": {
-      "version": "3.16.4",
-      "resolved": "https://registry.npmjs.org/lerna/-/lerna-3.16.4.tgz",
-      "integrity": "sha512-0HfwXIkqe72lBLZcNO9NMRfylh5Ng1l8tETgYQ260ZdHRbPuaLKE3Wqnd2YYRRkWfwPyEyZO8mZweBR+slVe1A==",
+      "version": "3.18.3",
+      "resolved": "https://registry.npmjs.org/lerna/-/lerna-3.18.3.tgz",
+      "integrity": "sha512-Bnr/RjyDSVA2Vu+NArK7do4UIpyy+EShOON7tignfAekPbi7cNDnMMGgSmbCQdKITkqPACMfCMdyq0hJlg6n3g==",
       "dev": true,
       "requires": {
-        "@lerna/add": "3.16.2",
-        "@lerna/bootstrap": "3.16.2",
-        "@lerna/changed": "3.16.4",
-        "@lerna/clean": "3.16.0",
-        "@lerna/cli": "3.13.0",
-        "@lerna/create": "3.16.0",
-        "@lerna/diff": "3.16.0",
-        "@lerna/exec": "3.16.0",
-        "@lerna/import": "3.16.0",
-        "@lerna/init": "3.16.0",
-        "@lerna/link": "3.16.2",
-        "@lerna/list": "3.16.0",
-        "@lerna/publish": "3.16.4",
-        "@lerna/run": "3.16.0",
-        "@lerna/version": "3.16.4",
+        "@lerna/add": "3.18.0",
+        "@lerna/bootstrap": "3.18.0",
+        "@lerna/changed": "3.18.3",
+        "@lerna/clean": "3.18.0",
+        "@lerna/cli": "3.18.0",
+        "@lerna/create": "3.18.0",
+        "@lerna/diff": "3.18.0",
+        "@lerna/exec": "3.18.0",
+        "@lerna/import": "3.18.0",
+        "@lerna/init": "3.18.0",
+        "@lerna/link": "3.18.0",
+        "@lerna/list": "3.18.0",
+        "@lerna/publish": "3.18.3",
+        "@lerna/run": "3.18.0",
+        "@lerna/version": "3.18.3",
         "import-local": "^2.0.0",
         "npmlog": "^4.1.2"
       }
@@ -6294,9 +6306,9 @@
       }
     },
     "loglevel": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.3.tgz",
-      "integrity": "sha512-LoEDv5pgpvWgPF4kNYuIp0qqSJVWak/dML0RY74xlzMZiT9w77teNAwKYKWBTYjlokMirg+o3jBwp+vlLrcfAA==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.4.tgz",
+      "integrity": "sha512-p0b6mOGKcGa+7nnmKbpzR6qloPbrgLcnio++E+14Vo/XffOGwZtRpUhr8dTH/x2oCMmEoIU0Zwm3ZauhvYD17g==",
       "dev": true
     },
     "loglevel-colored-level-prefix": {
@@ -6367,31 +6379,22 @@
       }
     },
     "make-fetch-happen": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-5.0.0.tgz",
-      "integrity": "sha512-nFr/vpL1Jc60etMVKeaLOqfGjMMb3tAHFVJWxHOFCFS04Zmd7kGlMxo0l1tzfhoQje0/UPnd0X8OeGUiXXnfPA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-5.0.1.tgz",
+      "integrity": "sha512-b4dfaMvUDR67zxUq1+GN7Ke9rH5WvGRmoHuMH7l+gmUCR2tCXFP6mpeJ9Dp+jB6z8mShRopSf1vLRBhRs8Cu5w==",
       "dev": true,
       "requires": {
         "agentkeepalive": "^3.4.1",
         "cacache": "^12.0.0",
         "http-cache-semantics": "^3.8.1",
         "http-proxy-agent": "^2.1.0",
-        "https-proxy-agent": "^2.2.1",
+        "https-proxy-agent": "^2.2.3",
         "lru-cache": "^5.1.1",
         "mississippi": "^3.0.0",
         "node-fetch-npm": "^2.0.2",
         "promise-retry": "^1.1.1",
         "socks-proxy-agent": "^4.0.0",
         "ssri": "^6.0.0"
-      }
-    },
-    "map-age-cleaner": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-      "dev": true,
-      "requires": {
-        "p-defer": "^1.0.0"
       }
     },
     "map-cache": {
@@ -6449,25 +6452,6 @@
       "dev": true,
       "requires": {
         "unist-util-visit": "^1.1.0"
-      }
-    },
-    "mem": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
-      "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
-      "dev": true,
-      "requires": {
-        "map-age-cleaner": "^0.1.1",
-        "mimic-fn": "^2.0.0",
-        "p-is-promise": "^2.0.0"
-      },
-      "dependencies": {
-        "mimic-fn": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-          "dev": true
-        }
       }
     },
     "meow": {
@@ -6563,9 +6547,9 @@
       }
     },
     "merge2": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.4.tgz",
-      "integrity": "sha512-FYE8xI+6pjFOhokZu0We3S5NKCirLbCzSh2Usf3qEyr4X8U+0jNg9P8RZ4qz+V2UoECLVwSyzU3LxXBaLGtD3A==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
+      "integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
       "dev": true
     },
     "micromatch": {
@@ -6636,9 +6620,9 @@
       }
     },
     "minipass": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.5.0.tgz",
-      "integrity": "sha512-9FwMVYhn6ERvMR8XFdOavRz4QK/VJV8elU1x50vYexf9lslDcWe/f4HBRxCPd185ekRSjU6CfYyJCECa/CQy7Q==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
       "dev": true,
       "requires": {
         "safe-buffer": "^5.1.2",
@@ -6646,12 +6630,12 @@
       }
     },
     "minizlib": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
-      "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+      "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
       "dev": true,
       "requires": {
-        "minipass": "^2.2.1"
+        "minipass": "^2.9.0"
       }
     },
     "mississippi": {
@@ -6821,9 +6805,9 @@
       }
     },
     "node-gyp": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-5.0.3.tgz",
-      "integrity": "sha512-z/JdtkFGUm0QaQUusvloyYuGDub3nUbOo5de1Fz57cM++osBTvQatBUSTlF1k/w8vFHPxxXW6zxGvkxXSpaBkQ==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-5.0.5.tgz",
+      "integrity": "sha512-WABl9s4/mqQdZneZHVWVG4TVr6QQJZUC6PAx47ITSk9lreZ1n+7Z9mMAIbA3vnO4J9W20P7LhCxtzfWsAD/KDw==",
       "dev": true,
       "requires": {
         "env-paths": "^1.0.0",
@@ -6835,7 +6819,7 @@
         "request": "^2.87.0",
         "rimraf": "2",
         "semver": "~5.3.0",
-        "tar": "^4.4.8",
+        "tar": "^4.4.12",
         "which": "1"
       },
       "dependencies": {
@@ -6848,12 +6832,20 @@
       }
     },
     "node-releases": {
-      "version": "1.1.29",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.29.tgz",
-      "integrity": "sha512-R5bDhzh6I+tpi/9i2hrrvGJ3yKPYzlVOORDkXhnZuwi5D3q1I5w4vYy24PJXTcLk9Q0kws9TO77T75bcK8/ysQ==",
+      "version": "1.1.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.38.tgz",
+      "integrity": "sha512-/5NZAaOyTj134Oy5Cp/J8mso8OD/D9CSuL+6TOXXsTKO8yjc5e4up75SRPCganCjwFKMj2jbp5tR0dViVdox7g==",
       "dev": true,
       "requires": {
-        "semver": "^5.3.0"
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "nopt": {
@@ -6902,9 +6894,9 @@
       "dev": true
     },
     "npm-lifecycle": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/npm-lifecycle/-/npm-lifecycle-3.1.3.tgz",
-      "integrity": "sha512-M0QmmqbEHBXxDrmc6X3+eKjW9+F7Edg1ENau92WkYw1sox6wojHzEZJIRm1ItljEiaigZlKL8mXni/4ylAy1Dg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/npm-lifecycle/-/npm-lifecycle-3.1.4.tgz",
+      "integrity": "sha512-tgs1PaucZwkxECGKhC/stbEgFyc3TGh2TJcg2CDr6jbvQRdteHNhmMeljRzpe4wgFAXQADoy1cSqqi7mtiAa5A==",
       "dev": true,
       "requires": {
         "byline": "^5.0.0",
@@ -6930,9 +6922,9 @@
       }
     },
     "npm-packlist": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.4.tgz",
-      "integrity": "sha512-zTLo8UcVYtDU3gdeaFu2Xu0n0EvelfHDGuqtNIn5RO7yQj4H1TqNdBc/yZjxnWA0PVB8D3Woyp0i5B43JwQ6Vw==",
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.6.tgz",
+      "integrity": "sha512-u65uQdb+qwtGvEJh/DgQgW1Xg7sqeNbmxYyrvlNznaVTjV3E5P6F/EFjM+BVHXl7JJlsdG8A64M0XI8FI/IOlg==",
       "dev": true,
       "requires": {
         "ignore-walk": "^3.0.1",
@@ -7166,17 +7158,6 @@
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
-    "os-locale": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
-      "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
-      "dev": true,
-      "requires": {
-        "execa": "^1.0.0",
-        "lcid": "^2.0.0",
-        "mem": "^4.0.0"
-      }
-    },
     "os-name": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
@@ -7203,22 +7184,10 @@
         "os-tmpdir": "^1.0.0"
       }
     },
-    "p-defer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
-      "dev": true
-    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true
-    },
-    "p-is-promise": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
-      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
       "dev": true
     },
     "p-limit": {
@@ -7291,12 +7260,12 @@
       }
     },
     "parallel-transform": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
-      "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.2.0.tgz",
+      "integrity": "sha512-P2vSmIu38uIlvdcU7fDkyrxj33gTUy/ABO5ZUbGowxNCopBq/OoD42bP4UmMrJoPyk4Uqf0mu3mtWBhHCZD8yg==",
       "dev": true,
       "requires": {
-        "cyclist": "~0.2.2",
+        "cyclist": "^1.0.1",
         "inherits": "^2.0.3",
         "readable-stream": "^2.1.5"
       }
@@ -7479,9 +7448,9 @@
       "dev": true
     },
     "postcss": {
-      "version": "7.0.17",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.17.tgz",
-      "integrity": "sha512-546ZowA+KZ3OasvQZHsbuEpysvwTZNGJv9EfyCQdsIDltPSWHAeTQ5fQy/Npi2ZDtLI3zs7Ps/p6wThErhm9fQ==",
+      "version": "7.0.18",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.18.tgz",
+      "integrity": "sha512-/7g1QXXgegpF+9GJj4iN7ChGF40sYuGYJ8WZu8DZWnmhQ/G36hfdk3q9LBJmoK+lZ+yzZ5KYpOoxq7LF1BxE8g==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.2",
@@ -8146,9 +8115,9 @@
       "dev": true
     },
     "psl": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.3.1.tgz",
-      "integrity": "sha512-2KLd5fKOdAfShtY2d/8XDWVRnmp3zp40Qt6ge2zBPFARLXOGUf2fHD5eg+TV/5oxBtQKVhjUaKFsAaE4HnwfSA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
+      "integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw==",
       "dev": true
     },
     "pump": {
@@ -8475,9 +8444,9 @@
       "dev": true
     },
     "require-main-filename": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
     "require-relative": {
@@ -8628,9 +8597,9 @@
       }
     },
     "rxjs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
-      "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
+      "integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -9137,23 +9106,23 @@
       }
     },
     "string.prototype.trimleft": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.0.0.tgz",
-      "integrity": "sha1-aLaqjhYsaoDnbjqKDC50cYbicf8=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
+      "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.0.2"
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
       }
     },
     "string.prototype.trimright": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.0.0.tgz",
-      "integrity": "sha1-q0pW2AKgH75yk+EehPJNyBZGYd0=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
+      "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.0.2"
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
       }
     },
     "string_decoder": {
@@ -9574,9 +9543,9 @@
       }
     },
     "stylelint-config-prettier": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-prettier/-/stylelint-config-prettier-5.2.0.tgz",
-      "integrity": "sha512-ehrG/mBi9CTKkOBi0wlStX58+g9eGJhJW/jFEcCm/dUVHg9I2+T90k4tlyratvhlz876dyrTlor7gvDEaohVnA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-prettier/-/stylelint-config-prettier-5.3.0.tgz",
+      "integrity": "sha512-To1lmaEYTmmGsVFSnVmU0cgXBrX4m31fm5sPgFCAH7Ep4ctdJhmTPe1aUnsZ9p2wY+SPhngqaFU5r1njaUyiaA==",
       "dev": true
     },
     "stylelint-config-recommended": {
@@ -9622,9 +9591,9 @@
       "dev": true
     },
     "synchronous-promise": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.9.tgz",
-      "integrity": "sha512-LO95GIW16x69LuND1nuuwM4pjgFGupg7pZ/4lU86AmchPKrhk0o2tpMU2unXRrqo81iAFe1YJ0nAGEVwsrZAgg==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.10.tgz",
+      "integrity": "sha512-6PC+JRGmNjiG3kJ56ZMNWDPL8hjyghF5cMXIFOKg+NiwwEZZIvxTWd0pinWKyD227odg9ygF8xVhhz7gb8Uq7A==",
       "dev": true
     },
     "table": {
@@ -9668,14 +9637,14 @@
       }
     },
     "tar": {
-      "version": "4.4.10",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.10.tgz",
-      "integrity": "sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==",
+      "version": "4.4.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+      "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
       "dev": true,
       "requires": {
         "chownr": "^1.1.1",
         "fs-minipass": "^1.2.5",
-        "minipass": "^2.3.5",
+        "minipass": "^2.8.6",
         "minizlib": "^1.2.1",
         "mkdirp": "^0.5.0",
         "safe-buffer": "^5.1.2",
@@ -9875,12 +9844,6 @@
       "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
       "dev": true
     },
-    "trim-right": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-      "dev": true
-    },
     "trim-trailing-lines": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.2.tgz",
@@ -9960,13 +9923,13 @@
       }
     },
     "uglify-js": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
-      "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.3.tgz",
+      "integrity": "sha512-KfQUgOqTkLp2aZxrMbCuKCDGW9slFYu2A23A36Gs7sGzTLcRBDORdOi5E21KWHFIfkY8kzgi/Pr1cXCh0yIp5g==",
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "~2.20.0",
+        "commander": "~2.20.3",
         "source-map": "~0.6.1"
       },
       "dependencies": {
@@ -10102,12 +10065,12 @@
       }
     },
     "universal-user-agent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-3.0.0.tgz",
-      "integrity": "sha512-T3siHThqoj5X0benA5H0qcDnrKGXzU8TKoX15x/tQHw1hQBvIEBHjxQ2klizYsqBOO/Q+WuxoQUihadeeqDnoA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-4.0.0.tgz",
+      "integrity": "sha512-eM8knLpev67iBDizr/YtqkJsF3GK8gzDc6st/WKzrTuPtcsOKW/0IdL4cnMBsU69pOx0otavLWBDGTwg+dB0aA==",
       "dev": true,
       "requires": {
-        "os-name": "^3.0.0"
+        "os-name": "^3.1.0"
       }
     },
     "universalify": {
@@ -10169,12 +10132,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
-      "dev": true
-    },
-    "url-template": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
-      "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE=",
       "dev": true
     },
     "urlgrey": {
@@ -10253,9 +10210,9 @@
       },
       "dependencies": {
         "is-buffer": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
-          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
           "dev": true
         }
       }
@@ -10333,9 +10290,9 @@
       "dev": true
     },
     "whatwg-url": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
-      "integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
       "dev": true,
       "requires": {
         "lodash.sortby": "^4.7.0",
@@ -10383,33 +10340,49 @@
       "dev": true
     },
     "wrap-ansi": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
       },
       "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "color-convert": "^1.9.0"
           }
         },
         "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
           }
         }
       }
@@ -10523,31 +10496,36 @@
       "dev": true
     },
     "yallist": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
     },
     "yargs": {
-      "version": "12.0.5",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-      "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.0.tgz",
+      "integrity": "sha512-/is78VKbKs70bVZH7w4YaZea6xcJWOAwkhbR0CFuZBmYtfTYF0xjGJF43AYd8g2Uii1yJwmS5GR2vBmrc32sbg==",
       "dev": true,
       "requires": {
-        "cliui": "^4.0.0",
+        "cliui": "^5.0.0",
         "decamelize": "^1.2.0",
         "find-up": "^3.0.0",
-        "get-caller-file": "^1.0.1",
-        "os-locale": "^3.0.0",
+        "get-caller-file": "^2.0.1",
         "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
+        "require-main-filename": "^2.0.0",
         "set-blocking": "^2.0.0",
-        "string-width": "^2.0.0",
+        "string-width": "^3.0.0",
         "which-module": "^2.0.0",
-        "y18n": "^3.2.1 || ^4.0.0",
-        "yargs-parser": "^11.1.1"
+        "y18n": "^4.0.0",
+        "yargs-parser": "^15.0.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
         "find-up": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -10596,13 +10574,33 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
           "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
         }
       }
     },
     "yargs-parser": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-      "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.0.tgz",
+      "integrity": "sha512-xLTUnCMc4JhxrPEPUYD5IBR1mWCK/aT6+RJ/K29JY2y1vD+FhtgKK0AXRWvI262q3QSffAQuTouFIKUuHX89wQ==",
       "dev": true,
       "requires": {
         "camelcase": "^5.0.0",

--- a/packages/babel-plugin-veui/package-lock.json
+++ b/packages/babel-plugin-veui/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "babel-plugin-veui",
-	"version": "1.0.0-alpha.30",
+	"version": "1.0.0-alpha.31",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -34,12 +34,12 @@
 			}
 		},
 		"@babel/cli": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.5.5.tgz",
-			"integrity": "sha512-UHI+7pHv/tk9g6WXQKYz+kmXTI77YtuY3vqC59KIqcoWEjsJJSG6rAxKaLsgj3LDyadsPrCB929gVOKM6Hui0w==",
+			"version": "7.6.4",
+			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.6.4.tgz",
+			"integrity": "sha512-tqrDyvPryBM6xjIyKKUwr3s8CzmmYidwgdswd7Uc/Cv0ogZcuS1TYQTLx/eWKP3UbJ6JxZAiYlBZabXm/rtRsQ==",
 			"dev": true,
 			"requires": {
-				"chokidar": "^2.0.4",
+				"chokidar": "^2.1.8",
 				"commander": "^2.8.1",
 				"convert-source-map": "^1.1.0",
 				"fs-readdir-recursive": "^1.1.0",
@@ -61,18 +61,18 @@
 			}
 		},
 		"@babel/core": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.5.5.tgz",
-			"integrity": "sha512-i4qoSr2KTtce0DmkuuQBV4AuQgGPUcPXMr9L5MyYAtk06z068lQ10a4O009fe5OB/DfNV+h+qqT7ddNV8UnRjg==",
+			"version": "7.6.4",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.4.tgz",
+			"integrity": "sha512-Rm0HGw101GY8FTzpWSyRbki/jzq+/PkNQJ+nSulrdY6gFGOsNseCqD6KHRYe2E+EdzuBdr2pxCp6s4Uk6eJ+XQ==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.5.5",
-				"@babel/generator": "^7.5.5",
-				"@babel/helpers": "^7.5.5",
-				"@babel/parser": "^7.5.5",
-				"@babel/template": "^7.4.4",
-				"@babel/traverse": "^7.5.5",
-				"@babel/types": "^7.5.5",
+				"@babel/generator": "^7.6.4",
+				"@babel/helpers": "^7.6.2",
+				"@babel/parser": "^7.6.4",
+				"@babel/template": "^7.6.0",
+				"@babel/traverse": "^7.6.3",
+				"@babel/types": "^7.6.3",
 				"convert-source-map": "^1.1.0",
 				"debug": "^4.1.0",
 				"json5": "^2.1.0",
@@ -100,16 +100,15 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz",
-			"integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
+			"version": "7.6.4",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.4.tgz",
+			"integrity": "sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.5.5",
+				"@babel/types": "^7.6.3",
 				"jsesc": "^2.5.1",
 				"lodash": "^4.17.13",
-				"source-map": "^0.5.0",
-				"trim-right": "^1.0.1"
+				"source-map": "^0.5.0"
 			}
 		},
 		"@babel/helper-annotate-as-pure": {
@@ -305,14 +304,14 @@
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.5.5.tgz",
-			"integrity": "sha512-nRq2BUhxZFnfEn/ciJuhklHvFOqjJUD5wpx+1bxUF2axL9C+v4DE/dmp5sT2dKnpOs4orZWzpAZqlCy8QqE/7g==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.6.2.tgz",
+			"integrity": "sha512-3/bAUL8zZxYs1cdX2ilEE0WobqbCmKWr/889lf2SS0PpDcpEIY8pb1CCyz0pEcX3pEb+MCbks1jIokz2xLtGTA==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.4.4",
-				"@babel/traverse": "^7.5.5",
-				"@babel/types": "^7.5.5"
+				"@babel/template": "^7.6.0",
+				"@babel/traverse": "^7.6.2",
+				"@babel/types": "^7.6.0"
 			}
 		},
 		"@babel/highlight": {
@@ -327,9 +326,9 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
-			"integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
+			"version": "7.6.4",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.4.tgz",
+			"integrity": "sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==",
 			"dev": true
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
@@ -364,9 +363,9 @@
 			}
 		},
 		"@babel/plugin-proposal-object-rest-spread": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.5.5.tgz",
-			"integrity": "sha512-F2DxJJSQ7f64FyTVl5cw/9MWn6naXGdk3Q3UhDbFEEHv+EilCPoeRD3Zh/Utx1CJz4uyKlQ4uH+bJPbEhMV7Zw==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.6.2.tgz",
+			"integrity": "sha512-LDBXlmADCsMZV1Y9OQwMc0MyGZ8Ta/zlD9N67BfQT8uYwkRswiu2hU6nJKrjrt/58aH/vqfQlR/9yId/7A2gWw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -384,14 +383,14 @@
 			}
 		},
 		"@babel/plugin-proposal-unicode-property-regex": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.4.tgz",
-			"integrity": "sha512-j1NwnOqMG9mFUOH58JTFsA/+ZYzQLUZ/drqWUqxCYLGeu2JFZL8YrNC9hBxKmWtAuOCHPcRpgv7fhap09Fb4kA==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.6.2.tgz",
+			"integrity": "sha512-NxHETdmpeSCtiatMRYWVJo7266rrvAC3DTeG5exQBIH/fMIUK7ejDNznBbn3HQl/o9peymRRg7Yqkx6PdUXmMw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-regex": "^7.4.4",
-				"regexpu-core": "^4.5.4"
+				"regexpu-core": "^4.6.0"
 			}
 		},
 		"@babel/plugin-syntax-async-generators": {
@@ -469,9 +468,9 @@
 			}
 		},
 		"@babel/plugin-transform-block-scoping": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.5.5.tgz",
-			"integrity": "sha512-82A3CLRRdYubkG85lKwhZB0WZoHxLGsJdux/cOVaJCJpvYFl1LVzAIFyRsa7CvXqW8rBM4Zf3Bfn8PHt5DP0Sg==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.6.3.tgz",
+			"integrity": "sha512-7hvrg75dubcO3ZI2rjYTzUrEuh1E9IyDEhhB6qfcooxhDA33xx2MasuLVgdxzcP6R/lipAC6n9ub9maNW6RKdw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -504,23 +503,23 @@
 			}
 		},
 		"@babel/plugin-transform-destructuring": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.5.0.tgz",
-			"integrity": "sha512-YbYgbd3TryYYLGyC7ZR+Tq8H/+bCmwoaxHfJHupom5ECstzbRLTch6gOQbhEY9Z4hiCNHEURgq06ykFv9JZ/QQ==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.6.0.tgz",
+			"integrity": "sha512-2bGIS5P1v4+sWTCnKNDZDxbGvEqi0ijeqM/YqHtVGrvG2y0ySgnEEhXErvE9dA0bnIzY9bIzdFK0jFA46ASIIQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-dotall-regex": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.4.tgz",
-			"integrity": "sha512-P05YEhRc2h53lZDjRPk/OektxCVevFzZs2Gfjd545Wde3k+yFDbXORgl2e0xpbq8mLcKJ7Idss4fAg0zORN/zg==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.6.2.tgz",
+			"integrity": "sha512-KGKT9aqKV+9YMZSkowzYoYEiHqgaDhGmPNZlZxX6UeHC4z30nC1J9IrZuGqbYFB1jaIGdv91ujpze0exiVK8bA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-regex": "^7.4.4",
-				"regexpu-core": "^4.5.4"
+				"regexpu-core": "^4.6.0"
 			}
 		},
 		"@babel/plugin-transform-duplicate-keys": {
@@ -591,9 +590,9 @@
 			}
 		},
 		"@babel/plugin-transform-modules-commonjs": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.5.0.tgz",
-			"integrity": "sha512-xmHq0B+ytyrWJvQTc5OWAC4ii6Dhr0s22STOoydokG51JjWhyYo5mRPXoi+ZmtHQhZZwuXNN+GG5jy5UZZJxIQ==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.6.0.tgz",
+			"integrity": "sha512-Ma93Ix95PNSEngqomy5LSBMAQvYKVe3dy+JlVJSHEXZR5ASL9lQBedMiCyVtmTLraIDVRE3ZjTZvmXXD2Ozw3g==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-transforms": "^7.4.4",
@@ -624,12 +623,12 @@
 			}
 		},
 		"@babel/plugin-transform-named-capturing-groups-regex": {
-			"version": "7.4.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.4.5.tgz",
-			"integrity": "sha512-z7+2IsWafTBbjNsOxU/Iv5CvTJlr5w4+HGu1HovKYTtgJ362f7kBcQglkfmlspKKZ3bgrbSGvLfNx++ZJgCWsg==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.6.3.tgz",
+			"integrity": "sha512-jTkk7/uE6H2s5w6VlMHeWuH+Pcy2lmdwFoeWCVnvIrDUnB5gQqTVI8WfmEAhF2CDEarGrknZcmSFg1+bkfCoSw==",
 			"dev": true,
 			"requires": {
-				"regexp-tree": "^0.1.6"
+				"regexpu-core": "^4.6.0"
 			}
 		},
 		"@babel/plugin-transform-new-target": {
@@ -699,9 +698,9 @@
 			}
 		},
 		"@babel/plugin-transform-spread": {
-			"version": "7.2.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.2.2.tgz",
-			"integrity": "sha512-KWfky/58vubwtS0hLqEnrWJjsMGaOeSBn90Ezn5Jeg9Z8KKHmELbP1yGylMlm5N6TPKeY9A2+UaSYLdxahg01w==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.6.2.tgz",
+			"integrity": "sha512-DpSvPFryKdK1x+EDJYCy28nmAaIMdxmhot62jAXF/o99iA33Zj2Lmcp3vDmz+MUh0LNYVPvfj5iC3feb3/+PFg==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
@@ -737,20 +736,20 @@
 			}
 		},
 		"@babel/plugin-transform-unicode-regex": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.4.tgz",
-			"integrity": "sha512-il+/XdNw01i93+M9J9u4T7/e/Ue/vWfNZE4IRUQjplu2Mqb/AFTDimkw2tdEdSH50wuQXZAbXSql0UphQke+vA==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.6.2.tgz",
+			"integrity": "sha512-orZI6cWlR3nk2YmYdb0gImrgCUwb5cBUwjf6Ks6dvNVvXERkwtJWOQaEOjPiu0Gu1Tq6Yq/hruCZZOOi9F34Dw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-regex": "^7.4.4",
-				"regexpu-core": "^4.5.4"
+				"regexpu-core": "^4.6.0"
 			}
 		},
 		"@babel/preset-env": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.5.5.tgz",
-			"integrity": "sha512-GMZQka/+INwsMz1A5UEql8tG015h5j/qjptpKY2gJ7giy8ohzU710YciJB5rcKsWGWHiW3RUnHib0E5/m3Tp3A==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.6.3.tgz",
+			"integrity": "sha512-CWQkn7EVnwzlOdR5NOm2+pfgSNEZmvGjOhlCHBDq0J8/EStr+G+FvPEiz9B56dR6MoiUFjXhfE4hjLoAKKJtIQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
@@ -758,9 +757,9 @@
 				"@babel/plugin-proposal-async-generator-functions": "^7.2.0",
 				"@babel/plugin-proposal-dynamic-import": "^7.5.0",
 				"@babel/plugin-proposal-json-strings": "^7.2.0",
-				"@babel/plugin-proposal-object-rest-spread": "^7.5.5",
+				"@babel/plugin-proposal-object-rest-spread": "^7.6.2",
 				"@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
-				"@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
+				"@babel/plugin-proposal-unicode-property-regex": "^7.6.2",
 				"@babel/plugin-syntax-async-generators": "^7.2.0",
 				"@babel/plugin-syntax-dynamic-import": "^7.2.0",
 				"@babel/plugin-syntax-json-strings": "^7.2.0",
@@ -769,11 +768,11 @@
 				"@babel/plugin-transform-arrow-functions": "^7.2.0",
 				"@babel/plugin-transform-async-to-generator": "^7.5.0",
 				"@babel/plugin-transform-block-scoped-functions": "^7.2.0",
-				"@babel/plugin-transform-block-scoping": "^7.5.5",
+				"@babel/plugin-transform-block-scoping": "^7.6.3",
 				"@babel/plugin-transform-classes": "^7.5.5",
 				"@babel/plugin-transform-computed-properties": "^7.2.0",
-				"@babel/plugin-transform-destructuring": "^7.5.0",
-				"@babel/plugin-transform-dotall-regex": "^7.4.4",
+				"@babel/plugin-transform-destructuring": "^7.6.0",
+				"@babel/plugin-transform-dotall-regex": "^7.6.2",
 				"@babel/plugin-transform-duplicate-keys": "^7.5.0",
 				"@babel/plugin-transform-exponentiation-operator": "^7.2.0",
 				"@babel/plugin-transform-for-of": "^7.4.4",
@@ -781,10 +780,10 @@
 				"@babel/plugin-transform-literals": "^7.2.0",
 				"@babel/plugin-transform-member-expression-literals": "^7.2.0",
 				"@babel/plugin-transform-modules-amd": "^7.5.0",
-				"@babel/plugin-transform-modules-commonjs": "^7.5.0",
+				"@babel/plugin-transform-modules-commonjs": "^7.6.0",
 				"@babel/plugin-transform-modules-systemjs": "^7.5.0",
 				"@babel/plugin-transform-modules-umd": "^7.2.0",
-				"@babel/plugin-transform-named-capturing-groups-regex": "^7.4.5",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^7.6.3",
 				"@babel/plugin-transform-new-target": "^7.4.4",
 				"@babel/plugin-transform-object-super": "^7.5.5",
 				"@babel/plugin-transform-parameters": "^7.4.4",
@@ -792,12 +791,12 @@
 				"@babel/plugin-transform-regenerator": "^7.4.5",
 				"@babel/plugin-transform-reserved-words": "^7.2.0",
 				"@babel/plugin-transform-shorthand-properties": "^7.2.0",
-				"@babel/plugin-transform-spread": "^7.2.0",
+				"@babel/plugin-transform-spread": "^7.6.2",
 				"@babel/plugin-transform-sticky-regex": "^7.2.0",
 				"@babel/plugin-transform-template-literals": "^7.4.4",
 				"@babel/plugin-transform-typeof-symbol": "^7.2.0",
-				"@babel/plugin-transform-unicode-regex": "^7.4.4",
-				"@babel/types": "^7.5.5",
+				"@babel/plugin-transform-unicode-regex": "^7.6.2",
+				"@babel/types": "^7.6.3",
 				"browserslist": "^4.6.0",
 				"core-js-compat": "^3.1.1",
 				"invariant": "^2.2.2",
@@ -806,28 +805,28 @@
 			}
 		},
 		"@babel/template": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
-			"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
+			"integrity": "sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"@babel/parser": "^7.4.4",
-				"@babel/types": "^7.4.4"
+				"@babel/parser": "^7.6.0",
+				"@babel/types": "^7.6.0"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.5.tgz",
-			"integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.3.tgz",
+			"integrity": "sha512-unn7P4LGsijIxaAJo/wpoU11zN+2IaClkQAxcJWBNCMS6cmVh802IyLHNkAjQ0iYnRS3nnxk5O3fuXW28IMxTw==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.5.5",
-				"@babel/generator": "^7.5.5",
+				"@babel/generator": "^7.6.3",
 				"@babel/helper-function-name": "^7.1.0",
 				"@babel/helper-split-export-declaration": "^7.4.4",
-				"@babel/parser": "^7.5.5",
-				"@babel/types": "^7.5.5",
+				"@babel/parser": "^7.6.3",
+				"@babel/types": "^7.6.3",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0",
 				"lodash": "^4.17.13"
@@ -851,9 +850,9 @@
 			}
 		},
 		"@babel/types": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
-			"integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
+			"integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
 			"dev": true,
 			"requires": {
 				"esutils": "^2.0.2",
@@ -879,28 +878,28 @@
 			}
 		},
 		"@nodelib/fs.scandir": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.2.tgz",
-			"integrity": "sha512-wrIBsjA5pl13f0RN4Zx4FNWmU71lv03meGKnqRUoCyan17s4V3WL92f3w3AIuWbNnpcrQyFBU5qMavJoB8d27w==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+			"integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
 			"dev": true,
 			"requires": {
-				"@nodelib/fs.stat": "2.0.2",
+				"@nodelib/fs.stat": "2.0.3",
 				"run-parallel": "^1.1.9"
 			}
 		},
 		"@nodelib/fs.stat": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.2.tgz",
-			"integrity": "sha512-z8+wGWV2dgUhLqrtRYa03yDx4HWMvXKi1z8g3m2JyxAx8F7xk74asqPk5LAETjqDSGLFML/6CDl0+yFunSYicw==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+			"integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
 			"dev": true
 		},
 		"@nodelib/fs.walk": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.3.tgz",
-			"integrity": "sha512-l6t8xEhfK9Sa4YO5mIRdau7XSOADfmh3jCr0evNHdY+HNkW6xuQhgMH7D73VV6WpZOagrW0UludvMTiifiwTfA==",
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+			"integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
 			"dev": true,
 			"requires": {
-				"@nodelib/fs.scandir": "2.1.2",
+				"@nodelib/fs.scandir": "2.1.3",
 				"fastq": "^1.6.0"
 			}
 		},
@@ -943,9 +942,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "12.7.3",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.3.tgz",
-			"integrity": "sha512-3SiLAIBkDWDg6vFo0+5YJyHPWU9uwu40Qe+v+0MH8wRKYBimHvvAOyk3EzMrD/TrIlLYfXrqDqrg913PynrMJQ==",
+			"version": "12.11.5",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.5.tgz",
+			"integrity": "sha512-LC8ALj/24PhByn39nr5jnTvpE7MujK8y7LQmV74kHYF5iQ0odCPkMH4IZNZw+cobKfSXqaC8GgegcbIsQpffdA==",
 			"dev": true
 		},
 		"ansi-align": {
@@ -1111,18 +1110,18 @@
 			"optional": true
 		},
 		"ava": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/ava/-/ava-2.3.0.tgz",
-			"integrity": "sha512-4VaaSnl13vpTZmqW3aMqioSolT0/ozRkjQxTLi3p8wtyRONuX/uLKL3uF0j50w2BNRoLsJqztnkX2h8xeVp2lg==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/ava/-/ava-2.4.0.tgz",
+			"integrity": "sha512-CQWtzZZZeU2g4StojRv6MO9RIRi4sLxGSB9+3C3hv0ttUEG1tkJLTLyrBQeFS4WEeK12Z4ovE3f2iPVhSy8elA==",
 			"dev": true,
 			"requires": {
 				"@ava/babel-preset-stage-4": "^4.0.0",
 				"@ava/babel-preset-transform-test-files": "^6.0.0",
-				"@babel/core": "^7.5.5",
-				"@babel/generator": "^7.5.5",
+				"@babel/core": "^7.6.0",
+				"@babel/generator": "^7.6.0",
 				"@concordance/react": "^2.0.0",
 				"ansi-escapes": "^4.2.1",
-				"ansi-styles": "^4.0.0",
+				"ansi-styles": "^4.1.0",
 				"arr-flatten": "^1.1.0",
 				"array-union": "^2.1.0",
 				"array-uniq": "^2.1.0",
@@ -1201,9 +1200,9 @@
 					}
 				},
 				"anymatch": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.0.tgz",
-					"integrity": "sha512-Ozz7l4ixzI7Oxj2+cw+p0tVUt27BpaJ+1+q1TCeANWxHpvyn2+Un+YamBdfKu0uh8xLodGhoa1v7595NhKDAuA==",
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+					"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
 					"dev": true,
 					"requires": {
 						"normalize-path": "^3.0.0",
@@ -1226,19 +1225,19 @@
 					}
 				},
 				"chokidar": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.0.2.tgz",
-					"integrity": "sha512-c4PR2egjNjI1um6bamCQ6bUNPDiyofNQruHvKgHQ4gDUP/ITSVSzNsiI5OWtHOsX323i5ha/kk4YmOZ1Ktg7KA==",
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.2.2.tgz",
+					"integrity": "sha512-bw3pm7kZ2Wa6+jQWYP/c7bAZy3i4GwiIiMO2EeRjrE48l8vBqC/WvFhSF0xyM8fQiPEGvwMY/5bqDG7sSEOuhg==",
 					"dev": true,
 					"requires": {
-						"anymatch": "^3.0.1",
-						"braces": "^3.0.2",
-						"fsevents": "^2.0.6",
-						"glob-parent": "^5.0.0",
-						"is-binary-path": "^2.1.0",
-						"is-glob": "^4.0.1",
-						"normalize-path": "^3.0.0",
-						"readdirp": "^3.1.1"
+						"anymatch": "~3.1.1",
+						"braces": "~3.0.2",
+						"fsevents": "~2.1.1",
+						"glob-parent": "~5.1.0",
+						"is-binary-path": "~2.1.0",
+						"is-glob": "~4.0.1",
+						"normalize-path": "~3.0.0",
+						"readdirp": "~3.2.0"
 					}
 				},
 				"color-convert": {
@@ -1281,16 +1280,16 @@
 					}
 				},
 				"fsevents": {
-					"version": "2.0.7",
-					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.0.7.tgz",
-					"integrity": "sha512-a7YT0SV3RB+DjYcppwVDLtn13UQnmg0SWZS7ezZD0UjnLwXmy8Zm21GMVGLaFGimIqcvyMQaOJBrop8MyOp1kQ==",
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.1.tgz",
+					"integrity": "sha512-4FRPXWETxtigtJW/gxzEDsX1LVbPAM93VleB83kZB+ellqbHMkyt2aJfuzNLRvFPnGi6bcE5SvfxgbXPeKteJw==",
 					"dev": true,
 					"optional": true
 				},
 				"glob-parent": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.0.0.tgz",
-					"integrity": "sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==",
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+					"integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
 					"dev": true,
 					"requires": {
 						"is-glob": "^4.0.1"
@@ -1349,9 +1348,9 @@
 					"dev": true
 				},
 				"readdirp": {
-					"version": "3.1.2",
-					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.1.2.tgz",
-					"integrity": "sha512-8rhl0xs2cxfVsqzreYCvs8EwBfn/DhVdqtoLmw19uI3SC5avYX9teCurlErfpPXGmYtMHReGaP2RsLnFvz/lnw==",
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
+					"integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
 					"dev": true,
 					"requires": {
 						"picomatch": "^2.0.4"
@@ -1364,9 +1363,9 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.0.0.tgz",
-					"integrity": "sha512-WRt32iTpYEZWYOpcetGm0NPeSvaebccx7hhS/5M6sAiqnhedtFCHFxkjzZlJvFNCPowiKSFGiZk5USQDFy83vQ==",
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -1481,9 +1480,9 @@
 			"optional": true
 		},
 		"bluebird": {
-			"version": "3.5.5",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
-			"integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
+			"integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg==",
 			"dev": true
 		},
 		"blueimp-md5": {
@@ -1581,14 +1580,14 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.0.tgz",
-			"integrity": "sha512-9rGNDtnj+HaahxiVV38Gn8n8Lr8REKsel68v1sPFfIGEK6uSXTY3h9acgiT1dZVtOOUtifo/Dn8daDQ5dUgVsA==",
+			"version": "4.7.1",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.1.tgz",
+			"integrity": "sha512-QtULFqKIAtiyNx7NhZ/p4rB8m3xDozVo/pi5VgTlADLF2tNigz/QH+v0m5qhn7XfHT7u+607NcCNOnC0HZAlMg==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30000989",
-				"electron-to-chromium": "^1.3.247",
-				"node-releases": "^1.1.29"
+				"caniuse-lite": "^1.0.30000999",
+				"electron-to-chromium": "^1.3.284",
+				"node-releases": "^1.1.36"
 			}
 		},
 		"buffer-from": {
@@ -1596,11 +1595,6 @@
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
 			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
 			"dev": true
-		},
-		"bytes": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-			"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
 		},
 		"cache-base": {
 			"version": "1.0.1",
@@ -1688,9 +1682,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30000989",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000989.tgz",
-			"integrity": "sha512-vrMcvSuMz16YY6GSVZ0dWDTJP8jqk3iFQ/Aq5iqblPwxSVVZI+zxDyTX0VPqtQsDnfdrBDcsmhgTEOh5R8Lbpw==",
+			"version": "1.0.30001002",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001002.tgz",
+			"integrity": "sha512-pRuxPE8wdrWmVPKcDmJJiGBxr6lFJq4ivdSeo9FTmGj5Rb8NX3Mby2pARG57MXF15hYAhZ0nHV5XxT2ig4bz3g==",
 			"dev": true
 		},
 		"chalk": {
@@ -1862,9 +1856,9 @@
 			"dev": true
 		},
 		"commander": {
-			"version": "2.20.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-			"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+			"version": "2.20.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
 			"dev": true
 		},
 		"common-path-prefix": {
@@ -1996,18 +1990,18 @@
 			"optional": true
 		},
 		"core-js": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-			"integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
+			"version": "2.6.10",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
+			"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==",
 			"dev": true
 		},
 		"core-js-compat": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.2.1.tgz",
-			"integrity": "sha512-MwPZle5CF9dEaMYdDeWm73ao/IflDH+FjeJCWEADcEgFSE9TLimFKwJsfmkwzI8eC0Aj0mgvMDjeQjrElkz4/A==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.3.3.tgz",
+			"integrity": "sha512-GNZkENsx5pMnS7Inwv7ZO/s3B68a9WU5kIjxqrD/tkNR8mtfXJRk8fAKRlbvWZSGPc59/TkiOBDYl5Cb65pTVA==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^4.6.6",
+				"browserslist": "^4.7.1",
 				"semver": "^6.3.0"
 			},
 			"dependencies": {
@@ -2051,11 +2045,6 @@
 			"requires": {
 				"array-find-index": "^1.0.1"
 			}
-		},
-		"date-fns": {
-			"version": "1.30.1",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
-			"integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
 		},
 		"date-time": {
 			"version": "2.1.0",
@@ -2268,9 +2257,9 @@
 			}
 		},
 		"dot-prop": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.1.0.tgz",
-			"integrity": "sha512-n1oC6NBF+KM9oVXtjmen4Yo7HyAVWV2UUl50dCYJdw2924K6dX9bf9TTTWaKtYlRn0FEtxG27KS80ayVLixxJA==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.1.1.tgz",
+			"integrity": "sha512-QCHI6Lkf+9fJMpwfAFsTvbiSh6ujoPmhCLiDvD/n4dGtLvHfhuBwPdN6z2x4YSOwwtTcLoO/LP70xELWGF/JVA==",
 			"dev": true,
 			"requires": {
 				"is-obj": "^2.0.0"
@@ -2283,9 +2272,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.3.251",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.251.tgz",
-			"integrity": "sha512-C5oOBdqJTYago4PBeew9duLqWZ3SlDnTRM+PMIgZd/ILFrT5AfaAGd3jRNEfuPklFHFqOjfwbCvXpyzEYb5sXg==",
+			"version": "1.3.293",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.293.tgz",
+			"integrity": "sha512-DQSBRuU2Z1vG+CEWUIfCEVMHtuaGlhVojzg39mX5dx7PLSFDJ7DSrGUWzaPFFgWR1jo26hj1nXXRQZvFwk7F8w==",
 			"dev": true
 		},
 		"emittery": {
@@ -2311,9 +2300,9 @@
 			}
 		},
 		"end-of-stream": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
 			"dev": true,
 			"requires": {
 				"once": "^1.4.0"
@@ -2404,6 +2393,14 @@
 				"p-finally": "^1.0.0",
 				"signal-exit": "^3.0.0",
 				"strip-eof": "^1.0.0"
+			},
+			"dependencies": {
+				"is-stream": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+					"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+					"dev": true
+				}
 			}
 		},
 		"expand-brackets": {
@@ -2545,16 +2542,15 @@
 			"dev": true
 		},
 		"fast-glob": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.0.4.tgz",
-			"integrity": "sha512-wkIbV6qg37xTJwqSsdnIphL1e+LaGz4AIQqr00mIubMaEhv1/HEmJ0uuCGZRNRUkZZmOB5mJKO0ZUTVq+SxMQg==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.1.0.tgz",
+			"integrity": "sha512-TrUz3THiq2Vy3bjfQUB2wNyPdGBeGmdjbzzBLhfHN4YFurYptCKwGq/TfiRavbGywFRzY6U2CdmQ1zmsY5yYaw==",
 			"dev": true,
 			"requires": {
-				"@nodelib/fs.stat": "^2.0.1",
-				"@nodelib/fs.walk": "^1.2.1",
-				"glob-parent": "^5.0.0",
-				"is-glob": "^4.0.1",
-				"merge2": "^1.2.3",
+				"@nodelib/fs.stat": "^2.0.2",
+				"@nodelib/fs.walk": "^1.2.3",
+				"glob-parent": "^5.1.0",
+				"merge2": "^1.3.0",
 				"micromatch": "^4.0.2"
 			},
 			"dependencies": {
@@ -2577,9 +2573,9 @@
 					}
 				},
 				"glob-parent": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.0.0.tgz",
-					"integrity": "sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==",
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+					"integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
 					"dev": true,
 					"requires": {
 						"is-glob": "^4.0.1"
@@ -2622,9 +2618,9 @@
 			}
 		},
 		"figures": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/figures/-/figures-3.0.0.tgz",
-			"integrity": "sha512-HKri+WoWoUgr83pehn/SIgLOMZ9nAWC6dcGj26RY2R4F50u4+RTUz0RCrUlOV3nKRAICW1UGzyb+kcX2qK1S/g==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-3.1.0.tgz",
+			"integrity": "sha512-ravh8VRXqHuMvZt/d8GblBeqDMkdJMBdv/2KntFH+ra5MXkO7nxNKpzQ3n6QD/2da1kH0aWmNISdvhM7gl2gVg==",
 			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^1.0.5"
@@ -3279,9 +3275,9 @@
 			"optional": true
 		},
 		"glob": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-			"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+			"version": "7.1.5",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+			"integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
 			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
@@ -3453,27 +3449,27 @@
 			"dev": true
 		},
 		"hasha": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/hasha/-/hasha-5.0.0.tgz",
-			"integrity": "sha512-PqWdhnQhq6tqD32hZv+l1e5mJHNSudjnaAzgAHfkGiU0ABN6lmbZF8abJIulQHbZ7oiHhP8yL6O910ICMc+5pw==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/hasha/-/hasha-5.1.0.tgz",
+			"integrity": "sha512-OFPDWmzPN1l7atOV1TgBVmNtBxaIysToK6Ve9DK+vT6pYuklw/nPNT+HJbZi0KDcI6vWB+9tgvZ5YD7fA3CXcA==",
 			"dev": true,
 			"requires": {
-				"is-stream": "^1.1.0",
-				"type-fest": "^0.3.0"
+				"is-stream": "^2.0.0",
+				"type-fest": "^0.8.0"
 			},
 			"dependencies": {
 				"type-fest": {
-					"version": "0.3.1",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
-					"integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+					"version": "0.8.1",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+					"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
 					"dev": true
 				}
 			}
 		},
 		"hosted-git-info": {
-			"version": "2.8.4",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
-			"integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==",
+			"version": "2.8.5",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
+			"integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
 			"dev": true
 		},
 		"http-cache-semantics": {
@@ -3819,9 +3815,9 @@
 			}
 		},
 		"is-stream": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+			"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
 			"dev": true
 		},
 		"is-typedarray": {
@@ -3922,9 +3918,9 @@
 			"dev": true
 		},
 		"json5": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
-			"integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
+			"integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
 			"dev": true,
 			"requires": {
 				"minimist": "^1.2.0"
@@ -3995,7 +3991,8 @@
 		"lodash": {
 			"version": "4.17.15",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+			"dev": true
 		},
 		"lodash.clonedeep": {
 			"version": "4.5.0",
@@ -4040,9 +4037,9 @@
 			}
 		},
 		"loud-rejection": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-2.1.0.tgz",
-			"integrity": "sha512-g/6MQxUXYHeVqZ4PGpPL1fS1fOvlXoi7bay0pizmjAd/3JhyXwxzwrnr74yzdmhuerlslbRJ3x7IOXzFz0cE5w==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-2.2.0.tgz",
+			"integrity": "sha512-S0FayMXku80toa5sZ6Ro4C+s+EtFDCsyJNG/AzFMfX3AxD5Si4dZsgzm/kKnbOxHl5Cv8jBlno8+3XYIh2pNjQ==",
 			"dev": true,
 			"requires": {
 				"currently-unhandled": "^0.4.1",
@@ -4167,9 +4164,9 @@
 			}
 		},
 		"merge2": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.4.tgz",
-			"integrity": "sha512-FYE8xI+6pjFOhokZu0We3S5NKCirLbCzSh2Usf3qEyr4X8U+0jNg9P8RZ4qz+V2UoECLVwSyzU3LxXBaLGtD3A==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
+			"integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
 			"dev": true
 		},
 		"micromatch": {
@@ -4306,12 +4303,20 @@
 			}
 		},
 		"node-releases": {
-			"version": "1.1.29",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.29.tgz",
-			"integrity": "sha512-R5bDhzh6I+tpi/9i2hrrvGJ3yKPYzlVOORDkXhnZuwi5D3q1I5w4vYy24PJXTcLk9Q0kws9TO77T75bcK8/ysQ==",
+			"version": "1.1.38",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.38.tgz",
+			"integrity": "sha512-/5NZAaOyTj134Oy5Cp/J8mso8OD/D9CSuL+6TOXXsTKO8yjc5e4up75SRPCganCjwFKMj2jbp5tR0dViVdox7g==",
 			"dev": true,
 			"requires": {
-				"semver": "^5.3.0"
+				"semver": "^6.3.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
 			}
 		},
 		"normalize-package-data": {
@@ -4333,9 +4338,9 @@
 			"dev": true
 		},
 		"normalize-url": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.3.0.tgz",
-			"integrity": "sha512-0NLtR71o4k6GLP+mr6Ty34c5GA6CMoEsncKJxvQd8NzPxaHRJNnb5gZE8R1XF4CPIS7QPHLJ74IFszwtNVAHVQ==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
+			"integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
 			"dev": true
 		},
 		"npm-run-path": {
@@ -5029,12 +5034,6 @@
 				"safe-regex": "^1.1.0"
 			}
 		},
-		"regexp-tree": {
-			"version": "0.1.13",
-			"resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.13.tgz",
-			"integrity": "sha512-hwdV/GQY5F8ReLZWO+W1SRoN5YfpOKY6852+tBFcma72DKBIcHjPRIlIvQN35bCOljuAfP2G2iB0FC/w236mUw==",
-			"dev": true
-		},
 		"regexp.prototype.flags": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
@@ -5045,9 +5044,9 @@
 			}
 		},
 		"regexpu-core": {
-			"version": "4.5.5",
-			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.5.tgz",
-			"integrity": "sha512-FpI67+ky9J+cDizQUJlIlNZFKual/lUkFr1AG6zOCpwZ9cLrg8UUVakyUQJD7fCDIe9Z2nwTQJNPyonatNmDFQ==",
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.6.0.tgz",
+			"integrity": "sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==",
 			"dev": true,
 			"requires": {
 				"regenerate": "^1.4.0",
@@ -5078,9 +5077,9 @@
 			}
 		},
 		"regjsgen": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
-			"integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==",
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.1.tgz",
+			"integrity": "sha512-5qxzGZjDs9w4tzT3TPhCJqWdCc3RLYwy9J2NB0nm5Lz+S273lvWcpjaTGHsT1dc6Hhfq41uSEOw8wBmxrKOuyg==",
 			"dev": true
 		},
 		"regjsparser": {
@@ -5135,11 +5134,6 @@
 			"resolved": "https://registry.npmjs.org/require-precompiled/-/require-precompiled-0.1.0.tgz",
 			"integrity": "sha1-WhtS63Dr7UPrmC6XTIWrWVceVvo=",
 			"dev": true
-		},
-		"resize-detector": {
-			"version": "0.1.10",
-			"resolved": "https://registry.npmjs.org/resize-detector/-/resize-detector-0.1.10.tgz",
-			"integrity": "sha512-iLcXC8A6Fb0DfA+TRiywrK/0A22bFqkhntjMJMEzXDA4XkcEkfwpNbv7W8iewUiD0xYIaeiXOfiEehTqGKsUFw=="
 		},
 		"resolve": {
 			"version": "1.12.0",
@@ -5695,11 +5689,6 @@
 				"execa": "^0.7.0"
 			}
 		},
-		"tether": {
-			"version": "1.4.7",
-			"resolved": "https://registry.npmjs.org/tether/-/tether-1.4.7.tgz",
-			"integrity": "sha512-Z0J1aExjoFU8pybVkQAo/vD2wfSO63r+XOPfWQMC5qtf1bI7IWqNk4MiyBcgvvnY8kqnY06dVdvwTK2S3PU/Fw=="
-		},
 		"time-zone": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/time-zone/-/time-zone-1.0.0.tgz",
@@ -5975,24 +5964,6 @@
 				"spdx-expression-parse": "^3.0.0"
 			}
 		},
-		"veui": {
-			"version": "1.0.0-alpha.30",
-			"resolved": "https://registry.npmjs.org/veui/-/veui-1.0.0-alpha.30.tgz",
-			"integrity": "sha512-wnZerOwOL2IGDvTCPRtPi4ckjxmb30D5l8LTS7fkef+nhf79SxBqmn+iRgA08GtzU4PGi/riHVd2zJFRHryW9Q==",
-			"requires": {
-				"bytes": "^3.0.0",
-				"date-fns": "^1.29.0",
-				"lodash": "^4.17.4",
-				"resize-detector": "^0.1.6",
-				"tether": "^1.4.5",
-				"vue-awesome": "^3.3.1"
-			}
-		},
-		"vue-awesome": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/vue-awesome/-/vue-awesome-3.5.4.tgz",
-			"integrity": "sha512-RRuo08A6mFye2RyLVdnODH5kyLiHANMl9EzKXZXCeMrsP4SY3nyjkQnTGlgbbVOBQuaGBMrFp9HPOJYDaVNk/w=="
-		},
 		"wcwidth": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -6060,9 +6031,9 @@
 			"dev": true
 		},
 		"write-file-atomic": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.0.tgz",
-			"integrity": "sha512-EIgkf60l2oWsffja2Sf2AL384dx328c0B+cIYPTQq5q2rOYuDV00/iPFBOUiDKKwKMOhkymH8AidPaRvzfxY+Q==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.1.tgz",
+			"integrity": "sha512-JPStrIyyVJ6oCSz/691fAjFtefZ6q+fP6tm+OS4Qw6o+TGQxNp1ziY2PgS+X/m0V8OWhZiO/m4xSj+Pr4RrZvw==",
 			"dev": true,
 			"requires": {
 				"imurmurhash": "^0.1.4",

--- a/packages/babel-preset-veui/package-lock.json
+++ b/packages/babel-preset-veui/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "babel-preset-veui",
-	"version": "1.0.0-alpha.30",
+	"version": "1.0.0-alpha.31",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -43,18 +43,18 @@
 			}
 		},
 		"@babel/core": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.5.5.tgz",
-			"integrity": "sha512-i4qoSr2KTtce0DmkuuQBV4AuQgGPUcPXMr9L5MyYAtk06z068lQ10a4O009fe5OB/DfNV+h+qqT7ddNV8UnRjg==",
+			"version": "7.6.4",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.4.tgz",
+			"integrity": "sha512-Rm0HGw101GY8FTzpWSyRbki/jzq+/PkNQJ+nSulrdY6gFGOsNseCqD6KHRYe2E+EdzuBdr2pxCp6s4Uk6eJ+XQ==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.5.5",
-				"@babel/generator": "^7.5.5",
-				"@babel/helpers": "^7.5.5",
-				"@babel/parser": "^7.5.5",
-				"@babel/template": "^7.4.4",
-				"@babel/traverse": "^7.5.5",
-				"@babel/types": "^7.5.5",
+				"@babel/generator": "^7.6.4",
+				"@babel/helpers": "^7.6.2",
+				"@babel/parser": "^7.6.4",
+				"@babel/template": "^7.6.0",
+				"@babel/traverse": "^7.6.3",
+				"@babel/types": "^7.6.3",
 				"convert-source-map": "^1.1.0",
 				"debug": "^4.1.0",
 				"json5": "^2.1.0",
@@ -82,16 +82,15 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz",
-			"integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
+			"version": "7.6.4",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.4.tgz",
+			"integrity": "sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.5.5",
+				"@babel/types": "^7.6.3",
 				"jsesc": "^2.5.1",
 				"lodash": "^4.17.13",
-				"source-map": "^0.5.0",
-				"trim-right": "^1.0.1"
+				"source-map": "^0.5.0"
 			},
 			"dependencies": {
 				"jsesc": {
@@ -213,14 +212,14 @@
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.5.5.tgz",
-			"integrity": "sha512-nRq2BUhxZFnfEn/ciJuhklHvFOqjJUD5wpx+1bxUF2axL9C+v4DE/dmp5sT2dKnpOs4orZWzpAZqlCy8QqE/7g==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.6.2.tgz",
+			"integrity": "sha512-3/bAUL8zZxYs1cdX2ilEE0WobqbCmKWr/889lf2SS0PpDcpEIY8pb1CCyz0pEcX3pEb+MCbks1jIokz2xLtGTA==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.4.4",
-				"@babel/traverse": "^7.5.5",
-				"@babel/types": "^7.5.5"
+				"@babel/template": "^7.6.0",
+				"@babel/traverse": "^7.6.2",
+				"@babel/types": "^7.6.0"
 			}
 		},
 		"@babel/highlight": {
@@ -272,9 +271,9 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
-			"integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
+			"version": "7.6.4",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.4.tgz",
+			"integrity": "sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==",
 			"dev": true
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
@@ -336,20 +335,20 @@
 			}
 		},
 		"@babel/plugin-transform-dotall-regex": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.4.tgz",
-			"integrity": "sha512-P05YEhRc2h53lZDjRPk/OektxCVevFzZs2Gfjd545Wde3k+yFDbXORgl2e0xpbq8mLcKJ7Idss4fAg0zORN/zg==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.6.2.tgz",
+			"integrity": "sha512-KGKT9aqKV+9YMZSkowzYoYEiHqgaDhGmPNZlZxX6UeHC4z30nC1J9IrZuGqbYFB1jaIGdv91ujpze0exiVK8bA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-regex": "^7.4.4",
-				"regexpu-core": "^4.5.4"
+				"regexpu-core": "^4.6.0"
 			},
 			"dependencies": {
 				"regexpu-core": {
-					"version": "4.5.5",
-					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.5.tgz",
-					"integrity": "sha512-FpI67+ky9J+cDizQUJlIlNZFKual/lUkFr1AG6zOCpwZ9cLrg8UUVakyUQJD7fCDIe9Z2nwTQJNPyonatNmDFQ==",
+					"version": "4.6.0",
+					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.6.0.tgz",
+					"integrity": "sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==",
 					"dev": true,
 					"requires": {
 						"regenerate": "^1.4.0",
@@ -361,9 +360,9 @@
 					}
 				},
 				"regjsgen": {
-					"version": "0.5.0",
-					"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
-					"integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==",
+					"version": "0.5.1",
+					"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.1.tgz",
+					"integrity": "sha512-5qxzGZjDs9w4tzT3TPhCJqWdCc3RLYwy9J2NB0nm5Lz+S273lvWcpjaTGHsT1dc6Hhfq41uSEOw8wBmxrKOuyg==",
 					"dev": true
 				},
 				"regjsparser": {
@@ -378,9 +377,9 @@
 			}
 		},
 		"@babel/plugin-transform-modules-commonjs": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.5.0.tgz",
-			"integrity": "sha512-xmHq0B+ytyrWJvQTc5OWAC4ii6Dhr0s22STOoydokG51JjWhyYo5mRPXoi+ZmtHQhZZwuXNN+GG5jy5UZZJxIQ==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.6.0.tgz",
+			"integrity": "sha512-Ma93Ix95PNSEngqomy5LSBMAQvYKVe3dy+JlVJSHEXZR5ASL9lQBedMiCyVtmTLraIDVRE3ZjTZvmXXD2Ozw3g==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-transforms": "^7.4.4",
@@ -390,28 +389,28 @@
 			}
 		},
 		"@babel/template": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
-			"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
+			"integrity": "sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"@babel/parser": "^7.4.4",
-				"@babel/types": "^7.4.4"
+				"@babel/parser": "^7.6.0",
+				"@babel/types": "^7.6.0"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.5.tgz",
-			"integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.3.tgz",
+			"integrity": "sha512-unn7P4LGsijIxaAJo/wpoU11zN+2IaClkQAxcJWBNCMS6cmVh802IyLHNkAjQ0iYnRS3nnxk5O3fuXW28IMxTw==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.5.5",
-				"@babel/generator": "^7.5.5",
+				"@babel/generator": "^7.6.3",
 				"@babel/helper-function-name": "^7.1.0",
 				"@babel/helper-split-export-declaration": "^7.4.4",
-				"@babel/parser": "^7.5.5",
-				"@babel/types": "^7.5.5",
+				"@babel/parser": "^7.6.3",
+				"@babel/types": "^7.6.3",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0",
 				"lodash": "^4.17.13"
@@ -441,9 +440,9 @@
 			}
 		},
 		"@babel/types": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
-			"integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
+			"integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
 			"requires": {
 				"esutils": "^2.0.2",
 				"lodash": "^4.17.13",
@@ -468,28 +467,28 @@
 			}
 		},
 		"@nodelib/fs.scandir": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.2.tgz",
-			"integrity": "sha512-wrIBsjA5pl13f0RN4Zx4FNWmU71lv03meGKnqRUoCyan17s4V3WL92f3w3AIuWbNnpcrQyFBU5qMavJoB8d27w==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+			"integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
 			"dev": true,
 			"requires": {
-				"@nodelib/fs.stat": "2.0.2",
+				"@nodelib/fs.stat": "2.0.3",
 				"run-parallel": "^1.1.9"
 			}
 		},
 		"@nodelib/fs.stat": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.2.tgz",
-			"integrity": "sha512-z8+wGWV2dgUhLqrtRYa03yDx4HWMvXKi1z8g3m2JyxAx8F7xk74asqPk5LAETjqDSGLFML/6CDl0+yFunSYicw==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+			"integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
 			"dev": true
 		},
 		"@nodelib/fs.walk": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.3.tgz",
-			"integrity": "sha512-l6t8xEhfK9Sa4YO5mIRdau7XSOADfmh3jCr0evNHdY+HNkW6xuQhgMH7D73VV6WpZOagrW0UludvMTiifiwTfA==",
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+			"integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
 			"dev": true,
 			"requires": {
-				"@nodelib/fs.scandir": "2.1.2",
+				"@nodelib/fs.scandir": "2.1.3",
 				"fastq": "^1.6.0"
 			}
 		},
@@ -532,9 +531,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "12.7.3",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.3.tgz",
-			"integrity": "sha512-3SiLAIBkDWDg6vFo0+5YJyHPWU9uwu40Qe+v+0MH8wRKYBimHvvAOyk3EzMrD/TrIlLYfXrqDqrg913PynrMJQ==",
+			"version": "12.11.5",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.5.tgz",
+			"integrity": "sha512-LC8ALj/24PhByn39nr5jnTvpE7MujK8y7LQmV74kHYF5iQ0odCPkMH4IZNZw+cobKfSXqaC8GgegcbIsQpffdA==",
 			"dev": true
 		},
 		"ansi-align": {
@@ -600,9 +599,9 @@
 			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
 		},
 		"anymatch": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.0.tgz",
-			"integrity": "sha512-Ozz7l4ixzI7Oxj2+cw+p0tVUt27BpaJ+1+q1TCeANWxHpvyn2+Un+YamBdfKu0uh8xLodGhoa1v7595NhKDAuA==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+			"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
 			"dev": true,
 			"requires": {
 				"normalize-path": "^3.0.0",
@@ -655,18 +654,18 @@
 			"dev": true
 		},
 		"ava": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/ava/-/ava-2.3.0.tgz",
-			"integrity": "sha512-4VaaSnl13vpTZmqW3aMqioSolT0/ozRkjQxTLi3p8wtyRONuX/uLKL3uF0j50w2BNRoLsJqztnkX2h8xeVp2lg==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/ava/-/ava-2.4.0.tgz",
+			"integrity": "sha512-CQWtzZZZeU2g4StojRv6MO9RIRi4sLxGSB9+3C3hv0ttUEG1tkJLTLyrBQeFS4WEeK12Z4ovE3f2iPVhSy8elA==",
 			"dev": true,
 			"requires": {
 				"@ava/babel-preset-stage-4": "^4.0.0",
 				"@ava/babel-preset-transform-test-files": "^6.0.0",
-				"@babel/core": "^7.5.5",
-				"@babel/generator": "^7.5.5",
+				"@babel/core": "^7.6.0",
+				"@babel/generator": "^7.6.0",
 				"@concordance/react": "^2.0.0",
 				"ansi-escapes": "^4.2.1",
-				"ansi-styles": "^4.0.0",
+				"ansi-styles": "^4.1.0",
 				"arr-flatten": "^1.1.0",
 				"array-union": "^2.1.0",
 				"array-uniq": "^2.1.0",
@@ -848,9 +847,9 @@
 					}
 				},
 				"supports-color": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.0.0.tgz",
-					"integrity": "sha512-WRt32iTpYEZWYOpcetGm0NPeSvaebccx7hhS/5M6sAiqnhedtFCHFxkjzZlJvFNCPowiKSFGiZk5USQDFy83vQ==",
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -1459,14 +1458,6 @@
 				"esutils": "^2.0.2"
 			}
 		},
-		"babel-plugin-veui": {
-			"version": "1.0.0-alpha.30",
-			"resolved": "https://registry.npmjs.org/babel-plugin-veui/-/babel-plugin-veui-1.0.0-alpha.30.tgz",
-			"integrity": "sha512-WCr2oJO2LW6L+N00eLwO9xWWY8c1nP6LlB7ZbfLH0ssrxiB/RYnXGNRKg3k6YJbDji3qL1qXkNf+Ta24zBy2yQ==",
-			"requires": {
-				"veui": "^1.0.0-alpha.30"
-			}
-		},
 		"babel-preset-env": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
@@ -1627,9 +1618,9 @@
 			"dev": true
 		},
 		"bluebird": {
-			"version": "3.5.5",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
-			"integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
+			"integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg==",
 			"dev": true
 		},
 		"blueimp-md5": {
@@ -1762,11 +1753,6 @@
 			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
 			"dev": true
 		},
-		"bytes": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-			"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
-		},
 		"cacheable-request": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
@@ -1835,9 +1821,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30000989",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000989.tgz",
-			"integrity": "sha512-vrMcvSuMz16YY6GSVZ0dWDTJP8jqk3iFQ/Aq5iqblPwxSVVZI+zxDyTX0VPqtQsDnfdrBDcsmhgTEOh5R8Lbpw=="
+			"version": "1.0.30001002",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001002.tgz",
+			"integrity": "sha512-pRuxPE8wdrWmVPKcDmJJiGBxr6lFJq4ivdSeo9FTmGj5Rb8NX3Mby2pARG57MXF15hYAhZ0nHV5XxT2ig4bz3g=="
 		},
 		"chalk": {
 			"version": "1.1.3",
@@ -1852,19 +1838,19 @@
 			}
 		},
 		"chokidar": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.0.2.tgz",
-			"integrity": "sha512-c4PR2egjNjI1um6bamCQ6bUNPDiyofNQruHvKgHQ4gDUP/ITSVSzNsiI5OWtHOsX323i5ha/kk4YmOZ1Ktg7KA==",
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.2.2.tgz",
+			"integrity": "sha512-bw3pm7kZ2Wa6+jQWYP/c7bAZy3i4GwiIiMO2EeRjrE48l8vBqC/WvFhSF0xyM8fQiPEGvwMY/5bqDG7sSEOuhg==",
 			"dev": true,
 			"requires": {
-				"anymatch": "^3.0.1",
-				"braces": "^3.0.2",
-				"fsevents": "^2.0.6",
-				"glob-parent": "^5.0.0",
-				"is-binary-path": "^2.1.0",
-				"is-glob": "^4.0.1",
-				"normalize-path": "^3.0.0",
-				"readdirp": "^3.1.1"
+				"anymatch": "~3.1.1",
+				"braces": "~3.0.2",
+				"fsevents": "~2.1.1",
+				"glob-parent": "~5.1.0",
+				"is-binary-path": "~2.1.0",
+				"is-glob": "~4.0.1",
+				"normalize-path": "~3.0.0",
+				"readdirp": "~3.2.0"
 			}
 		},
 		"chunkd": {
@@ -2081,9 +2067,9 @@
 			"dev": true
 		},
 		"core-js": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-			"integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
+			"version": "2.6.10",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
+			"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
 		},
 		"cross-spawn": {
 			"version": "5.1.0",
@@ -2110,11 +2096,6 @@
 			"requires": {
 				"array-find-index": "^1.0.1"
 			}
-		},
-		"date-fns": {
-			"version": "1.30.1",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
-			"integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
 		},
 		"date-time": {
 			"version": "2.1.0",
@@ -2282,9 +2263,9 @@
 			}
 		},
 		"dot-prop": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.1.0.tgz",
-			"integrity": "sha512-n1oC6NBF+KM9oVXtjmen4Yo7HyAVWV2UUl50dCYJdw2924K6dX9bf9TTTWaKtYlRn0FEtxG27KS80ayVLixxJA==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.1.1.tgz",
+			"integrity": "sha512-QCHI6Lkf+9fJMpwfAFsTvbiSh6ujoPmhCLiDvD/n4dGtLvHfhuBwPdN6z2x4YSOwwtTcLoO/LP70xELWGF/JVA==",
 			"dev": true,
 			"requires": {
 				"is-obj": "^2.0.0"
@@ -2297,9 +2278,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.3.251",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.251.tgz",
-			"integrity": "sha512-C5oOBdqJTYago4PBeew9duLqWZ3SlDnTRM+PMIgZd/ILFrT5AfaAGd3jRNEfuPklFHFqOjfwbCvXpyzEYb5sXg=="
+			"version": "1.3.293",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.293.tgz",
+			"integrity": "sha512-DQSBRuU2Z1vG+CEWUIfCEVMHtuaGlhVojzg39mX5dx7PLSFDJ7DSrGUWzaPFFgWR1jo26hj1nXXRQZvFwk7F8w=="
 		},
 		"emittery": {
 			"version": "0.4.1",
@@ -2324,9 +2305,9 @@
 			}
 		},
 		"end-of-stream": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
 			"dev": true,
 			"requires": {
 				"once": "^1.4.0"
@@ -2415,6 +2396,14 @@
 				"p-finally": "^1.0.0",
 				"signal-exit": "^3.0.0",
 				"strip-eof": "^1.0.0"
+			},
+			"dependencies": {
+				"is-stream": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+					"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+					"dev": true
+				}
 			}
 		},
 		"fast-diff": {
@@ -2424,16 +2413,15 @@
 			"dev": true
 		},
 		"fast-glob": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.0.4.tgz",
-			"integrity": "sha512-wkIbV6qg37xTJwqSsdnIphL1e+LaGz4AIQqr00mIubMaEhv1/HEmJ0uuCGZRNRUkZZmOB5mJKO0ZUTVq+SxMQg==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.1.0.tgz",
+			"integrity": "sha512-TrUz3THiq2Vy3bjfQUB2wNyPdGBeGmdjbzzBLhfHN4YFurYptCKwGq/TfiRavbGywFRzY6U2CdmQ1zmsY5yYaw==",
 			"dev": true,
 			"requires": {
-				"@nodelib/fs.stat": "^2.0.1",
-				"@nodelib/fs.walk": "^1.2.1",
-				"glob-parent": "^5.0.0",
-				"is-glob": "^4.0.1",
-				"merge2": "^1.2.3",
+				"@nodelib/fs.stat": "^2.0.2",
+				"@nodelib/fs.walk": "^1.2.3",
+				"glob-parent": "^5.1.0",
+				"merge2": "^1.3.0",
 				"micromatch": "^4.0.2"
 			}
 		},
@@ -2447,9 +2435,9 @@
 			}
 		},
 		"figures": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/figures/-/figures-3.0.0.tgz",
-			"integrity": "sha512-HKri+WoWoUgr83pehn/SIgLOMZ9nAWC6dcGj26RY2R4F50u4+RTUz0RCrUlOV3nKRAICW1UGzyb+kcX2qK1S/g==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-3.1.0.tgz",
+			"integrity": "sha512-ravh8VRXqHuMvZt/d8GblBeqDMkdJMBdv/2KntFH+ra5MXkO7nxNKpzQ3n6QD/2da1kH0aWmNISdvhM7gl2gVg==",
 			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^1.0.5"
@@ -2480,9 +2468,9 @@
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.0.7.tgz",
-			"integrity": "sha512-a7YT0SV3RB+DjYcppwVDLtn13UQnmg0SWZS7ezZD0UjnLwXmy8Zm21GMVGLaFGimIqcvyMQaOJBrop8MyOp1kQ==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.1.tgz",
+			"integrity": "sha512-4FRPXWETxtigtJW/gxzEDsX1LVbPAM93VleB83kZB+ellqbHMkyt2aJfuzNLRvFPnGi6bcE5SvfxgbXPeKteJw==",
 			"dev": true,
 			"optional": true
 		},
@@ -2516,9 +2504,9 @@
 			"dev": true
 		},
 		"glob": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-			"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+			"version": "7.1.5",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+			"integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -2529,9 +2517,9 @@
 			}
 		},
 		"glob-parent": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.0.0.tgz",
-			"integrity": "sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+			"integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
 			"dev": true,
 			"requires": {
 				"is-glob": "^4.0.1"
@@ -2639,19 +2627,19 @@
 			"dev": true
 		},
 		"hasha": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/hasha/-/hasha-5.0.0.tgz",
-			"integrity": "sha512-PqWdhnQhq6tqD32hZv+l1e5mJHNSudjnaAzgAHfkGiU0ABN6lmbZF8abJIulQHbZ7oiHhP8yL6O910ICMc+5pw==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/hasha/-/hasha-5.1.0.tgz",
+			"integrity": "sha512-OFPDWmzPN1l7atOV1TgBVmNtBxaIysToK6Ve9DK+vT6pYuklw/nPNT+HJbZi0KDcI6vWB+9tgvZ5YD7fA3CXcA==",
 			"dev": true,
 			"requires": {
-				"is-stream": "^1.1.0",
-				"type-fest": "^0.3.0"
+				"is-stream": "^2.0.0",
+				"type-fest": "^0.8.0"
 			},
 			"dependencies": {
 				"type-fest": {
-					"version": "0.3.1",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
-					"integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+					"version": "0.8.1",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+					"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
 					"dev": true
 				}
 			}
@@ -2667,9 +2655,9 @@
 			}
 		},
 		"hosted-git-info": {
-			"version": "2.8.4",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
-			"integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==",
+			"version": "2.8.5",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
+			"integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
 			"dev": true
 		},
 		"html-tags": {
@@ -2929,9 +2917,9 @@
 			}
 		},
 		"is-stream": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+			"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
 			"dev": true
 		},
 		"is-typedarray": {
@@ -3009,9 +2997,9 @@
 			"dev": true
 		},
 		"json5": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
-			"integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
+			"integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
 			"dev": true,
 			"requires": {
 				"minimist": "^1.2.0"
@@ -3142,9 +3130,9 @@
 			}
 		},
 		"loud-rejection": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-2.1.0.tgz",
-			"integrity": "sha512-g/6MQxUXYHeVqZ4PGpPL1fS1fOvlXoi7bay0pizmjAd/3JhyXwxzwrnr74yzdmhuerlslbRJ3x7IOXzFz0cE5w==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-2.2.0.tgz",
+			"integrity": "sha512-S0FayMXku80toa5sZ6Ro4C+s+EtFDCsyJNG/AzFMfX3AxD5Si4dZsgzm/kKnbOxHl5Cv8jBlno8+3XYIh2pNjQ==",
 			"dev": true,
 			"requires": {
 				"currently-unhandled": "^0.4.1",
@@ -3252,9 +3240,9 @@
 			}
 		},
 		"merge2": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.4.tgz",
-			"integrity": "sha512-FYE8xI+6pjFOhokZu0We3S5NKCirLbCzSh2Usf3qEyr4X8U+0jNg9P8RZ4qz+V2UoECLVwSyzU3LxXBaLGtD3A==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
+			"integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
 			"dev": true
 		},
 		"micromatch": {
@@ -3352,9 +3340,9 @@
 			"dev": true
 		},
 		"normalize-url": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.3.0.tgz",
-			"integrity": "sha512-0NLtR71o4k6GLP+mr6Ty34c5GA6CMoEsncKJxvQd8NzPxaHRJNnb5gZE8R1XF4CPIS7QPHLJ74IFszwtNVAHVQ==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
+			"integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
 			"dev": true
 		},
 		"npm-run-path": {
@@ -3914,9 +3902,9 @@
 			}
 		},
 		"readdirp": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.1.2.tgz",
-			"integrity": "sha512-8rhl0xs2cxfVsqzreYCvs8EwBfn/DhVdqtoLmw19uI3SC5avYX9teCurlErfpPXGmYtMHReGaP2RsLnFvz/lnw==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
+			"integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
 			"dev": true,
 			"requires": {
 				"picomatch": "^2.0.4"
@@ -4048,11 +4036,6 @@
 			"resolved": "https://registry.npmjs.org/require-precompiled/-/require-precompiled-0.1.0.tgz",
 			"integrity": "sha1-WhtS63Dr7UPrmC6XTIWrWVceVvo=",
 			"dev": true
-		},
-		"resize-detector": {
-			"version": "0.1.10",
-			"resolved": "https://registry.npmjs.org/resize-detector/-/resize-detector-0.1.10.tgz",
-			"integrity": "sha512-iLcXC8A6Fb0DfA+TRiywrK/0A22bFqkhntjMJMEzXDA4XkcEkfwpNbv7W8iewUiD0xYIaeiXOfiEehTqGKsUFw=="
 		},
 		"resolve": {
 			"version": "1.12.0",
@@ -4403,11 +4386,6 @@
 				"execa": "^0.7.0"
 			}
 		},
-		"tether": {
-			"version": "1.4.7",
-			"resolved": "https://registry.npmjs.org/tether/-/tether-1.4.7.tgz",
-			"integrity": "sha512-Z0J1aExjoFU8pybVkQAo/vD2wfSO63r+XOPfWQMC5qtf1bI7IWqNk4MiyBcgvvnY8kqnY06dVdvwTK2S3PU/Fw=="
-		},
 		"time-zone": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/time-zone/-/time-zone-1.0.0.tgz",
@@ -4591,24 +4569,6 @@
 				"spdx-expression-parse": "^3.0.0"
 			}
 		},
-		"veui": {
-			"version": "1.0.0-alpha.30",
-			"resolved": "https://registry.npmjs.org/veui/-/veui-1.0.0-alpha.30.tgz",
-			"integrity": "sha512-wnZerOwOL2IGDvTCPRtPi4ckjxmb30D5l8LTS7fkef+nhf79SxBqmn+iRgA08GtzU4PGi/riHVd2zJFRHryW9Q==",
-			"requires": {
-				"bytes": "^3.0.0",
-				"date-fns": "^1.29.0",
-				"lodash": "^4.17.4",
-				"resize-detector": "^0.1.6",
-				"tether": "^1.4.5",
-				"vue-awesome": "^3.3.1"
-			}
-		},
-		"vue-awesome": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/vue-awesome/-/vue-awesome-3.5.4.tgz",
-			"integrity": "sha512-RRuo08A6mFye2RyLVdnODH5kyLiHANMl9EzKXZXCeMrsP4SY3nyjkQnTGlgbbVOBQuaGBMrFp9HPOJYDaVNk/w=="
-		},
 		"wcwidth": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -4675,9 +4635,9 @@
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"write-file-atomic": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.0.tgz",
-			"integrity": "sha512-EIgkf60l2oWsffja2Sf2AL384dx328c0B+cIYPTQq5q2rOYuDV00/iPFBOUiDKKwKMOhkymH8AidPaRvzfxY+Q==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.1.tgz",
+			"integrity": "sha512-JPStrIyyVJ6oCSz/691fAjFtefZ6q+fP6tm+OS4Qw6o+TGQxNp1ziY2PgS+X/m0V8OWhZiO/m4xSj+Pr4RrZvw==",
 			"dev": true,
 			"requires": {
 				"imurmurhash": "^0.1.4",

--- a/packages/veui-loader/package-lock.json
+++ b/packages/veui-loader/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "veui-loader",
-	"version": "1.0.0-alpha.30",
+	"version": "1.0.0-alpha.31",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -34,12 +34,12 @@
 			}
 		},
 		"@babel/cli": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.5.5.tgz",
-			"integrity": "sha512-UHI+7pHv/tk9g6WXQKYz+kmXTI77YtuY3vqC59KIqcoWEjsJJSG6rAxKaLsgj3LDyadsPrCB929gVOKM6Hui0w==",
+			"version": "7.6.4",
+			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.6.4.tgz",
+			"integrity": "sha512-tqrDyvPryBM6xjIyKKUwr3s8CzmmYidwgdswd7Uc/Cv0ogZcuS1TYQTLx/eWKP3UbJ6JxZAiYlBZabXm/rtRsQ==",
 			"dev": true,
 			"requires": {
-				"chokidar": "^2.0.4",
+				"chokidar": "^2.1.8",
 				"commander": "^2.8.1",
 				"convert-source-map": "^1.1.0",
 				"fs-readdir-recursive": "^1.1.0",
@@ -61,18 +61,18 @@
 			}
 		},
 		"@babel/core": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.5.5.tgz",
-			"integrity": "sha512-i4qoSr2KTtce0DmkuuQBV4AuQgGPUcPXMr9L5MyYAtk06z068lQ10a4O009fe5OB/DfNV+h+qqT7ddNV8UnRjg==",
+			"version": "7.6.4",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.4.tgz",
+			"integrity": "sha512-Rm0HGw101GY8FTzpWSyRbki/jzq+/PkNQJ+nSulrdY6gFGOsNseCqD6KHRYe2E+EdzuBdr2pxCp6s4Uk6eJ+XQ==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.5.5",
-				"@babel/generator": "^7.5.5",
-				"@babel/helpers": "^7.5.5",
-				"@babel/parser": "^7.5.5",
-				"@babel/template": "^7.4.4",
-				"@babel/traverse": "^7.5.5",
-				"@babel/types": "^7.5.5",
+				"@babel/generator": "^7.6.4",
+				"@babel/helpers": "^7.6.2",
+				"@babel/parser": "^7.6.4",
+				"@babel/template": "^7.6.0",
+				"@babel/traverse": "^7.6.3",
+				"@babel/types": "^7.6.3",
 				"convert-source-map": "^1.1.0",
 				"debug": "^4.1.0",
 				"json5": "^2.1.0",
@@ -92,9 +92,9 @@
 					}
 				},
 				"json5": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
-					"integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
+					"integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
 					"dev": true,
 					"requires": {
 						"minimist": "^1.2.0"
@@ -109,16 +109,15 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz",
-			"integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
+			"version": "7.6.4",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.4.tgz",
+			"integrity": "sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.5.5",
+				"@babel/types": "^7.6.3",
 				"jsesc": "^2.5.1",
 				"lodash": "^4.17.13",
-				"source-map": "^0.5.0",
-				"trim-right": "^1.0.1"
+				"source-map": "^0.5.0"
 			}
 		},
 		"@babel/helper-annotate-as-pure": {
@@ -314,14 +313,14 @@
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.5.5.tgz",
-			"integrity": "sha512-nRq2BUhxZFnfEn/ciJuhklHvFOqjJUD5wpx+1bxUF2axL9C+v4DE/dmp5sT2dKnpOs4orZWzpAZqlCy8QqE/7g==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.6.2.tgz",
+			"integrity": "sha512-3/bAUL8zZxYs1cdX2ilEE0WobqbCmKWr/889lf2SS0PpDcpEIY8pb1CCyz0pEcX3pEb+MCbks1jIokz2xLtGTA==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.4.4",
-				"@babel/traverse": "^7.5.5",
-				"@babel/types": "^7.5.5"
+				"@babel/template": "^7.6.0",
+				"@babel/traverse": "^7.6.2",
+				"@babel/types": "^7.6.0"
 			}
 		},
 		"@babel/highlight": {
@@ -336,9 +335,9 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
-			"integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
+			"version": "7.6.4",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.4.tgz",
+			"integrity": "sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==",
 			"dev": true
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
@@ -373,9 +372,9 @@
 			}
 		},
 		"@babel/plugin-proposal-object-rest-spread": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.5.5.tgz",
-			"integrity": "sha512-F2DxJJSQ7f64FyTVl5cw/9MWn6naXGdk3Q3UhDbFEEHv+EilCPoeRD3Zh/Utx1CJz4uyKlQ4uH+bJPbEhMV7Zw==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.6.2.tgz",
+			"integrity": "sha512-LDBXlmADCsMZV1Y9OQwMc0MyGZ8Ta/zlD9N67BfQT8uYwkRswiu2hU6nJKrjrt/58aH/vqfQlR/9yId/7A2gWw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -393,14 +392,14 @@
 			}
 		},
 		"@babel/plugin-proposal-unicode-property-regex": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.4.tgz",
-			"integrity": "sha512-j1NwnOqMG9mFUOH58JTFsA/+ZYzQLUZ/drqWUqxCYLGeu2JFZL8YrNC9hBxKmWtAuOCHPcRpgv7fhap09Fb4kA==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.6.2.tgz",
+			"integrity": "sha512-NxHETdmpeSCtiatMRYWVJo7266rrvAC3DTeG5exQBIH/fMIUK7ejDNznBbn3HQl/o9peymRRg7Yqkx6PdUXmMw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-regex": "^7.4.4",
-				"regexpu-core": "^4.5.4"
+				"regexpu-core": "^4.6.0"
 			}
 		},
 		"@babel/plugin-syntax-async-generators": {
@@ -478,9 +477,9 @@
 			}
 		},
 		"@babel/plugin-transform-block-scoping": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.5.5.tgz",
-			"integrity": "sha512-82A3CLRRdYubkG85lKwhZB0WZoHxLGsJdux/cOVaJCJpvYFl1LVzAIFyRsa7CvXqW8rBM4Zf3Bfn8PHt5DP0Sg==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.6.3.tgz",
+			"integrity": "sha512-7hvrg75dubcO3ZI2rjYTzUrEuh1E9IyDEhhB6qfcooxhDA33xx2MasuLVgdxzcP6R/lipAC6n9ub9maNW6RKdw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -513,23 +512,23 @@
 			}
 		},
 		"@babel/plugin-transform-destructuring": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.5.0.tgz",
-			"integrity": "sha512-YbYgbd3TryYYLGyC7ZR+Tq8H/+bCmwoaxHfJHupom5ECstzbRLTch6gOQbhEY9Z4hiCNHEURgq06ykFv9JZ/QQ==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.6.0.tgz",
+			"integrity": "sha512-2bGIS5P1v4+sWTCnKNDZDxbGvEqi0ijeqM/YqHtVGrvG2y0ySgnEEhXErvE9dA0bnIzY9bIzdFK0jFA46ASIIQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-dotall-regex": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.4.tgz",
-			"integrity": "sha512-P05YEhRc2h53lZDjRPk/OektxCVevFzZs2Gfjd545Wde3k+yFDbXORgl2e0xpbq8mLcKJ7Idss4fAg0zORN/zg==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.6.2.tgz",
+			"integrity": "sha512-KGKT9aqKV+9YMZSkowzYoYEiHqgaDhGmPNZlZxX6UeHC4z30nC1J9IrZuGqbYFB1jaIGdv91ujpze0exiVK8bA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-regex": "^7.4.4",
-				"regexpu-core": "^4.5.4"
+				"regexpu-core": "^4.6.0"
 			}
 		},
 		"@babel/plugin-transform-duplicate-keys": {
@@ -600,9 +599,9 @@
 			}
 		},
 		"@babel/plugin-transform-modules-commonjs": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.5.0.tgz",
-			"integrity": "sha512-xmHq0B+ytyrWJvQTc5OWAC4ii6Dhr0s22STOoydokG51JjWhyYo5mRPXoi+ZmtHQhZZwuXNN+GG5jy5UZZJxIQ==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.6.0.tgz",
+			"integrity": "sha512-Ma93Ix95PNSEngqomy5LSBMAQvYKVe3dy+JlVJSHEXZR5ASL9lQBedMiCyVtmTLraIDVRE3ZjTZvmXXD2Ozw3g==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-transforms": "^7.4.4",
@@ -633,12 +632,12 @@
 			}
 		},
 		"@babel/plugin-transform-named-capturing-groups-regex": {
-			"version": "7.4.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.4.5.tgz",
-			"integrity": "sha512-z7+2IsWafTBbjNsOxU/Iv5CvTJlr5w4+HGu1HovKYTtgJ362f7kBcQglkfmlspKKZ3bgrbSGvLfNx++ZJgCWsg==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.6.3.tgz",
+			"integrity": "sha512-jTkk7/uE6H2s5w6VlMHeWuH+Pcy2lmdwFoeWCVnvIrDUnB5gQqTVI8WfmEAhF2CDEarGrknZcmSFg1+bkfCoSw==",
 			"dev": true,
 			"requires": {
-				"regexp-tree": "^0.1.6"
+				"regexpu-core": "^4.6.0"
 			}
 		},
 		"@babel/plugin-transform-new-target": {
@@ -699,9 +698,9 @@
 			}
 		},
 		"@babel/plugin-transform-runtime": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.5.5.tgz",
-			"integrity": "sha512-6Xmeidsun5rkwnGfMOp6/z9nSzWpHFNVr2Jx7kwoq4mVatQfQx5S56drBgEHF+XQbKOdIaOiMIINvp/kAwMN+w==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.6.2.tgz",
+			"integrity": "sha512-cqULw/QB4yl73cS5Y0TZlQSjDvNkzDbu0FurTZyHlJpWE5T3PCMdnyV+xXoH1opr1ldyHODe3QAX3OMAii5NxA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
@@ -720,9 +719,9 @@
 			}
 		},
 		"@babel/plugin-transform-spread": {
-			"version": "7.2.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.2.2.tgz",
-			"integrity": "sha512-KWfky/58vubwtS0hLqEnrWJjsMGaOeSBn90Ezn5Jeg9Z8KKHmELbP1yGylMlm5N6TPKeY9A2+UaSYLdxahg01w==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.6.2.tgz",
+			"integrity": "sha512-DpSvPFryKdK1x+EDJYCy28nmAaIMdxmhot62jAXF/o99iA33Zj2Lmcp3vDmz+MUh0LNYVPvfj5iC3feb3/+PFg==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
@@ -758,20 +757,20 @@
 			}
 		},
 		"@babel/plugin-transform-unicode-regex": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.4.tgz",
-			"integrity": "sha512-il+/XdNw01i93+M9J9u4T7/e/Ue/vWfNZE4IRUQjplu2Mqb/AFTDimkw2tdEdSH50wuQXZAbXSql0UphQke+vA==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.6.2.tgz",
+			"integrity": "sha512-orZI6cWlR3nk2YmYdb0gImrgCUwb5cBUwjf6Ks6dvNVvXERkwtJWOQaEOjPiu0Gu1Tq6Yq/hruCZZOOi9F34Dw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-regex": "^7.4.4",
-				"regexpu-core": "^4.5.4"
+				"regexpu-core": "^4.6.0"
 			}
 		},
 		"@babel/preset-env": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.5.5.tgz",
-			"integrity": "sha512-GMZQka/+INwsMz1A5UEql8tG015h5j/qjptpKY2gJ7giy8ohzU710YciJB5rcKsWGWHiW3RUnHib0E5/m3Tp3A==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.6.3.tgz",
+			"integrity": "sha512-CWQkn7EVnwzlOdR5NOm2+pfgSNEZmvGjOhlCHBDq0J8/EStr+G+FvPEiz9B56dR6MoiUFjXhfE4hjLoAKKJtIQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
@@ -779,9 +778,9 @@
 				"@babel/plugin-proposal-async-generator-functions": "^7.2.0",
 				"@babel/plugin-proposal-dynamic-import": "^7.5.0",
 				"@babel/plugin-proposal-json-strings": "^7.2.0",
-				"@babel/plugin-proposal-object-rest-spread": "^7.5.5",
+				"@babel/plugin-proposal-object-rest-spread": "^7.6.2",
 				"@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
-				"@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
+				"@babel/plugin-proposal-unicode-property-regex": "^7.6.2",
 				"@babel/plugin-syntax-async-generators": "^7.2.0",
 				"@babel/plugin-syntax-dynamic-import": "^7.2.0",
 				"@babel/plugin-syntax-json-strings": "^7.2.0",
@@ -790,11 +789,11 @@
 				"@babel/plugin-transform-arrow-functions": "^7.2.0",
 				"@babel/plugin-transform-async-to-generator": "^7.5.0",
 				"@babel/plugin-transform-block-scoped-functions": "^7.2.0",
-				"@babel/plugin-transform-block-scoping": "^7.5.5",
+				"@babel/plugin-transform-block-scoping": "^7.6.3",
 				"@babel/plugin-transform-classes": "^7.5.5",
 				"@babel/plugin-transform-computed-properties": "^7.2.0",
-				"@babel/plugin-transform-destructuring": "^7.5.0",
-				"@babel/plugin-transform-dotall-regex": "^7.4.4",
+				"@babel/plugin-transform-destructuring": "^7.6.0",
+				"@babel/plugin-transform-dotall-regex": "^7.6.2",
 				"@babel/plugin-transform-duplicate-keys": "^7.5.0",
 				"@babel/plugin-transform-exponentiation-operator": "^7.2.0",
 				"@babel/plugin-transform-for-of": "^7.4.4",
@@ -802,10 +801,10 @@
 				"@babel/plugin-transform-literals": "^7.2.0",
 				"@babel/plugin-transform-member-expression-literals": "^7.2.0",
 				"@babel/plugin-transform-modules-amd": "^7.5.0",
-				"@babel/plugin-transform-modules-commonjs": "^7.5.0",
+				"@babel/plugin-transform-modules-commonjs": "^7.6.0",
 				"@babel/plugin-transform-modules-systemjs": "^7.5.0",
 				"@babel/plugin-transform-modules-umd": "^7.2.0",
-				"@babel/plugin-transform-named-capturing-groups-regex": "^7.4.5",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^7.6.3",
 				"@babel/plugin-transform-new-target": "^7.4.4",
 				"@babel/plugin-transform-object-super": "^7.5.5",
 				"@babel/plugin-transform-parameters": "^7.4.4",
@@ -813,12 +812,12 @@
 				"@babel/plugin-transform-regenerator": "^7.4.5",
 				"@babel/plugin-transform-reserved-words": "^7.2.0",
 				"@babel/plugin-transform-shorthand-properties": "^7.2.0",
-				"@babel/plugin-transform-spread": "^7.2.0",
+				"@babel/plugin-transform-spread": "^7.6.2",
 				"@babel/plugin-transform-sticky-regex": "^7.2.0",
 				"@babel/plugin-transform-template-literals": "^7.4.4",
 				"@babel/plugin-transform-typeof-symbol": "^7.2.0",
-				"@babel/plugin-transform-unicode-regex": "^7.4.4",
-				"@babel/types": "^7.5.5",
+				"@babel/plugin-transform-unicode-regex": "^7.6.2",
+				"@babel/types": "^7.6.3",
 				"browserslist": "^4.6.0",
 				"core-js-compat": "^3.1.1",
 				"invariant": "^2.2.2",
@@ -827,37 +826,37 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
-			"integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.3.tgz",
+			"integrity": "sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==",
 			"dev": true,
 			"requires": {
 				"regenerator-runtime": "^0.13.2"
 			}
 		},
 		"@babel/template": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
-			"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
+			"integrity": "sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"@babel/parser": "^7.4.4",
-				"@babel/types": "^7.4.4"
+				"@babel/parser": "^7.6.0",
+				"@babel/types": "^7.6.0"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.5.tgz",
-			"integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.3.tgz",
+			"integrity": "sha512-unn7P4LGsijIxaAJo/wpoU11zN+2IaClkQAxcJWBNCMS6cmVh802IyLHNkAjQ0iYnRS3nnxk5O3fuXW28IMxTw==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.5.5",
-				"@babel/generator": "^7.5.5",
+				"@babel/generator": "^7.6.3",
 				"@babel/helper-function-name": "^7.1.0",
 				"@babel/helper-split-export-declaration": "^7.4.4",
-				"@babel/parser": "^7.5.5",
-				"@babel/types": "^7.5.5",
+				"@babel/parser": "^7.6.3",
+				"@babel/types": "^7.6.3",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0",
 				"lodash": "^4.17.13"
@@ -881,9 +880,9 @@
 			}
 		},
 		"@babel/types": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
-			"integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
+			"integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
 			"dev": true,
 			"requires": {
 				"esutils": "^2.0.2",
@@ -909,28 +908,28 @@
 			}
 		},
 		"@nodelib/fs.scandir": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.2.tgz",
-			"integrity": "sha512-wrIBsjA5pl13f0RN4Zx4FNWmU71lv03meGKnqRUoCyan17s4V3WL92f3w3AIuWbNnpcrQyFBU5qMavJoB8d27w==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+			"integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
 			"dev": true,
 			"requires": {
-				"@nodelib/fs.stat": "2.0.2",
+				"@nodelib/fs.stat": "2.0.3",
 				"run-parallel": "^1.1.9"
 			}
 		},
 		"@nodelib/fs.stat": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.2.tgz",
-			"integrity": "sha512-z8+wGWV2dgUhLqrtRYa03yDx4HWMvXKi1z8g3m2JyxAx8F7xk74asqPk5LAETjqDSGLFML/6CDl0+yFunSYicw==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+			"integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
 			"dev": true
 		},
 		"@nodelib/fs.walk": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.3.tgz",
-			"integrity": "sha512-l6t8xEhfK9Sa4YO5mIRdau7XSOADfmh3jCr0evNHdY+HNkW6xuQhgMH7D73VV6WpZOagrW0UludvMTiifiwTfA==",
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+			"integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
 			"dev": true,
 			"requires": {
-				"@nodelib/fs.scandir": "2.1.2",
+				"@nodelib/fs.scandir": "2.1.3",
 				"fastq": "^1.6.0"
 			}
 		},
@@ -973,9 +972,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "12.7.3",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.3.tgz",
-			"integrity": "sha512-3SiLAIBkDWDg6vFo0+5YJyHPWU9uwu40Qe+v+0MH8wRKYBimHvvAOyk3EzMrD/TrIlLYfXrqDqrg913PynrMJQ==",
+			"version": "12.11.5",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.5.tgz",
+			"integrity": "sha512-LC8ALj/24PhByn39nr5jnTvpE7MujK8y7LQmV74kHYF5iQ0odCPkMH4IZNZw+cobKfSXqaC8GgegcbIsQpffdA==",
 			"dev": true
 		},
 		"@webassemblyjs/ast": {
@@ -1395,18 +1394,18 @@
 			"dev": true
 		},
 		"ava": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/ava/-/ava-2.3.0.tgz",
-			"integrity": "sha512-4VaaSnl13vpTZmqW3aMqioSolT0/ozRkjQxTLi3p8wtyRONuX/uLKL3uF0j50w2BNRoLsJqztnkX2h8xeVp2lg==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/ava/-/ava-2.4.0.tgz",
+			"integrity": "sha512-CQWtzZZZeU2g4StojRv6MO9RIRi4sLxGSB9+3C3hv0ttUEG1tkJLTLyrBQeFS4WEeK12Z4ovE3f2iPVhSy8elA==",
 			"dev": true,
 			"requires": {
 				"@ava/babel-preset-stage-4": "^4.0.0",
 				"@ava/babel-preset-transform-test-files": "^6.0.0",
-				"@babel/core": "^7.5.5",
-				"@babel/generator": "^7.5.5",
+				"@babel/core": "^7.6.0",
+				"@babel/generator": "^7.6.0",
 				"@concordance/react": "^2.0.0",
 				"ansi-escapes": "^4.2.1",
-				"ansi-styles": "^4.0.0",
+				"ansi-styles": "^4.1.0",
 				"arr-flatten": "^1.1.0",
 				"array-union": "^2.1.0",
 				"array-uniq": "^2.1.0",
@@ -1485,9 +1484,9 @@
 					}
 				},
 				"anymatch": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.0.tgz",
-					"integrity": "sha512-Ozz7l4ixzI7Oxj2+cw+p0tVUt27BpaJ+1+q1TCeANWxHpvyn2+Un+YamBdfKu0uh8xLodGhoa1v7595NhKDAuA==",
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+					"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
 					"dev": true,
 					"requires": {
 						"normalize-path": "^3.0.0",
@@ -1510,19 +1509,19 @@
 					}
 				},
 				"chokidar": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.0.2.tgz",
-					"integrity": "sha512-c4PR2egjNjI1um6bamCQ6bUNPDiyofNQruHvKgHQ4gDUP/ITSVSzNsiI5OWtHOsX323i5ha/kk4YmOZ1Ktg7KA==",
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.2.2.tgz",
+					"integrity": "sha512-bw3pm7kZ2Wa6+jQWYP/c7bAZy3i4GwiIiMO2EeRjrE48l8vBqC/WvFhSF0xyM8fQiPEGvwMY/5bqDG7sSEOuhg==",
 					"dev": true,
 					"requires": {
-						"anymatch": "^3.0.1",
-						"braces": "^3.0.2",
-						"fsevents": "^2.0.6",
-						"glob-parent": "^5.0.0",
-						"is-binary-path": "^2.1.0",
-						"is-glob": "^4.0.1",
-						"normalize-path": "^3.0.0",
-						"readdirp": "^3.1.1"
+						"anymatch": "~3.1.1",
+						"braces": "~3.0.2",
+						"fsevents": "~2.1.1",
+						"glob-parent": "~5.1.0",
+						"is-binary-path": "~2.1.0",
+						"is-glob": "~4.0.1",
+						"normalize-path": "~3.0.0",
+						"readdirp": "~3.2.0"
 					}
 				},
 				"color-convert": {
@@ -1575,16 +1574,16 @@
 					}
 				},
 				"fsevents": {
-					"version": "2.0.7",
-					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.0.7.tgz",
-					"integrity": "sha512-a7YT0SV3RB+DjYcppwVDLtn13UQnmg0SWZS7ezZD0UjnLwXmy8Zm21GMVGLaFGimIqcvyMQaOJBrop8MyOp1kQ==",
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.1.tgz",
+					"integrity": "sha512-4FRPXWETxtigtJW/gxzEDsX1LVbPAM93VleB83kZB+ellqbHMkyt2aJfuzNLRvFPnGi6bcE5SvfxgbXPeKteJw==",
 					"dev": true,
 					"optional": true
 				},
 				"glob-parent": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.0.0.tgz",
-					"integrity": "sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==",
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+					"integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
 					"dev": true,
 					"requires": {
 						"is-glob": "^4.0.1"
@@ -1682,9 +1681,9 @@
 					"dev": true
 				},
 				"readdirp": {
-					"version": "3.1.2",
-					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.1.2.tgz",
-					"integrity": "sha512-8rhl0xs2cxfVsqzreYCvs8EwBfn/DhVdqtoLmw19uI3SC5avYX9teCurlErfpPXGmYtMHReGaP2RsLnFvz/lnw==",
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
+					"integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
 					"dev": true,
 					"requires": {
 						"picomatch": "^2.0.4"
@@ -1697,9 +1696,9 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.0.0.tgz",
-					"integrity": "sha512-WRt32iTpYEZWYOpcetGm0NPeSvaebccx7hhS/5M6sAiqnhedtFCHFxkjzZlJvFNCPowiKSFGiZk5USQDFy83vQ==",
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -1819,9 +1818,9 @@
 			"dev": true
 		},
 		"bluebird": {
-			"version": "3.5.5",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
-			"integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
+			"integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg==",
 			"dev": true
 		},
 		"blueimp-md5": {
@@ -2000,14 +1999,14 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.0.tgz",
-			"integrity": "sha512-9rGNDtnj+HaahxiVV38Gn8n8Lr8REKsel68v1sPFfIGEK6uSXTY3h9acgiT1dZVtOOUtifo/Dn8daDQ5dUgVsA==",
+			"version": "4.7.1",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.1.tgz",
+			"integrity": "sha512-QtULFqKIAtiyNx7NhZ/p4rB8m3xDozVo/pi5VgTlADLF2tNigz/QH+v0m5qhn7XfHT7u+607NcCNOnC0HZAlMg==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30000989",
-				"electron-to-chromium": "^1.3.247",
-				"node-releases": "^1.1.29"
+				"caniuse-lite": "^1.0.30000999",
+				"electron-to-chromium": "^1.3.284",
+				"node-releases": "^1.1.36"
 			}
 		},
 		"buffer": {
@@ -2072,9 +2071,9 @@
 					}
 				},
 				"yallist": {
-					"version": "3.0.3",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+					"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
 					"dev": true
 				}
 			}
@@ -2164,9 +2163,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30000989",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000989.tgz",
-			"integrity": "sha512-vrMcvSuMz16YY6GSVZ0dWDTJP8jqk3iFQ/Aq5iqblPwxSVVZI+zxDyTX0VPqtQsDnfdrBDcsmhgTEOh5R8Lbpw==",
+			"version": "1.0.30001002",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001002.tgz",
+			"integrity": "sha512-pRuxPE8wdrWmVPKcDmJJiGBxr6lFJq4ivdSeo9FTmGj5Rb8NX3Mby2pARG57MXF15hYAhZ0nHV5XxT2ig4bz3g==",
 			"dev": true
 		},
 		"chalk": {
@@ -2201,9 +2200,9 @@
 			}
 		},
 		"chownr": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz",
-			"integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
+			"integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
 			"dev": true
 		},
 		"chrome-trace-event": {
@@ -2359,9 +2358,9 @@
 			"dev": true
 		},
 		"commander": {
-			"version": "2.20.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-			"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+			"version": "2.20.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
 			"dev": true
 		},
 		"common-path-prefix": {
@@ -2538,18 +2537,18 @@
 			"dev": true
 		},
 		"core-js": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-			"integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
+			"version": "2.6.10",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
+			"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==",
 			"dev": true
 		},
 		"core-js-compat": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.2.1.tgz",
-			"integrity": "sha512-MwPZle5CF9dEaMYdDeWm73ao/IflDH+FjeJCWEADcEgFSE9TLimFKwJsfmkwzI8eC0Aj0mgvMDjeQjrElkz4/A==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.3.3.tgz",
+			"integrity": "sha512-GNZkENsx5pMnS7Inwv7ZO/s3B68a9WU5kIjxqrD/tkNR8mtfXJRk8fAKRlbvWZSGPc59/TkiOBDYl5Cb65pTVA==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^4.6.6",
+				"browserslist": "^4.7.1",
 				"semver": "^6.3.0"
 			},
 			"dependencies": {
@@ -2650,9 +2649,9 @@
 			}
 		},
 		"cyclist": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
-			"integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
+			"integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
 			"dev": true
 		},
 		"date-now": {
@@ -2893,9 +2892,9 @@
 			"dev": true
 		},
 		"dot-prop": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.1.0.tgz",
-			"integrity": "sha512-n1oC6NBF+KM9oVXtjmen4Yo7HyAVWV2UUl50dCYJdw2924K6dX9bf9TTTWaKtYlRn0FEtxG27KS80ayVLixxJA==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.1.1.tgz",
+			"integrity": "sha512-QCHI6Lkf+9fJMpwfAFsTvbiSh6ujoPmhCLiDvD/n4dGtLvHfhuBwPdN6z2x4YSOwwtTcLoO/LP70xELWGF/JVA==",
 			"dev": true,
 			"requires": {
 				"is-obj": "^2.0.0"
@@ -2920,15 +2919,15 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.3.251",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.251.tgz",
-			"integrity": "sha512-C5oOBdqJTYago4PBeew9duLqWZ3SlDnTRM+PMIgZd/ILFrT5AfaAGd3jRNEfuPklFHFqOjfwbCvXpyzEYb5sXg==",
+			"version": "1.3.293",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.293.tgz",
+			"integrity": "sha512-DQSBRuU2Z1vG+CEWUIfCEVMHtuaGlhVojzg39mX5dx7PLSFDJ7DSrGUWzaPFFgWR1jo26hj1nXXRQZvFwk7F8w==",
 			"dev": true
 		},
 		"elliptic": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.0.tgz",
-			"integrity": "sha512-eFOJTMyCYb7xtE/caJ6JJu+bhi67WCYNbkGSknu20pmM8Ke/bqOfdnZWxyoGN26JgfxTbXrsCkEw4KheCT/KGg==",
+			"version": "6.5.1",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.1.tgz",
+			"integrity": "sha512-xvJINNLbTeWQjrl6X+7eQCrIy/YPv5XCpKW6kB5mKvtnGILoLDcySuwomfdzt0BMdLNVnuRNTuzKNHj0bva1Cg==",
 			"dev": true,
 			"requires": {
 				"bn.js": "^4.4.0",
@@ -2968,23 +2967,35 @@
 			}
 		},
 		"end-of-stream": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
 			"dev": true,
 			"requires": {
 				"once": "^1.4.0"
 			}
 		},
 		"enhanced-resolve": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz",
-			"integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.1.tgz",
+			"integrity": "sha512-98p2zE+rL7/g/DzMHMTF4zZlCgeVdJ7yr6xzEpJRYwFYrGi9ANdn5DnJURg6RpBkyk60XYDnWIv51VfIhfNGuA==",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
-				"memory-fs": "^0.4.0",
+				"memory-fs": "^0.5.0",
 				"tapable": "^1.0.0"
+			},
+			"dependencies": {
+				"memory-fs": {
+					"version": "0.5.0",
+					"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
+					"integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
+					"dev": true,
+					"requires": {
+						"errno": "^0.1.3",
+						"readable-stream": "^2.0.1"
+					}
+				}
 			}
 		},
 		"equal-length": {
@@ -3116,6 +3127,14 @@
 				"p-finally": "^1.0.0",
 				"signal-exit": "^3.0.0",
 				"strip-eof": "^1.0.0"
+			},
+			"dependencies": {
+				"is-stream": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+					"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+					"dev": true
+				}
 			}
 		},
 		"expand-brackets": {
@@ -3252,16 +3271,15 @@
 			"dev": true
 		},
 		"fast-glob": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.0.4.tgz",
-			"integrity": "sha512-wkIbV6qg37xTJwqSsdnIphL1e+LaGz4AIQqr00mIubMaEhv1/HEmJ0uuCGZRNRUkZZmOB5mJKO0ZUTVq+SxMQg==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.1.0.tgz",
+			"integrity": "sha512-TrUz3THiq2Vy3bjfQUB2wNyPdGBeGmdjbzzBLhfHN4YFurYptCKwGq/TfiRavbGywFRzY6U2CdmQ1zmsY5yYaw==",
 			"dev": true,
 			"requires": {
-				"@nodelib/fs.stat": "^2.0.1",
-				"@nodelib/fs.walk": "^1.2.1",
-				"glob-parent": "^5.0.0",
-				"is-glob": "^4.0.1",
-				"merge2": "^1.2.3",
+				"@nodelib/fs.stat": "^2.0.2",
+				"@nodelib/fs.walk": "^1.2.3",
+				"glob-parent": "^5.1.0",
+				"merge2": "^1.3.0",
 				"micromatch": "^4.0.2"
 			},
 			"dependencies": {
@@ -3284,9 +3302,9 @@
 					}
 				},
 				"glob-parent": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.0.0.tgz",
-					"integrity": "sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==",
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+					"integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
 					"dev": true,
 					"requires": {
 						"is-glob": "^4.0.1"
@@ -3341,9 +3359,9 @@
 			"dev": true
 		},
 		"figures": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/figures/-/figures-3.0.0.tgz",
-			"integrity": "sha512-HKri+WoWoUgr83pehn/SIgLOMZ9nAWC6dcGj26RY2R4F50u4+RTUz0RCrUlOV3nKRAICW1UGzyb+kcX2qK1S/g==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-3.1.0.tgz",
+			"integrity": "sha512-ravh8VRXqHuMvZt/d8GblBeqDMkdJMBdv/2KntFH+ra5MXkO7nxNKpzQ3n6QD/2da1kH0aWmNISdvhM7gl2gVg==",
 			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^1.0.5"
@@ -4098,9 +4116,9 @@
 			"dev": true
 		},
 		"glob": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-			"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+			"version": "7.1.5",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+			"integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
 			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
@@ -4287,19 +4305,19 @@
 			}
 		},
 		"hasha": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/hasha/-/hasha-5.0.0.tgz",
-			"integrity": "sha512-PqWdhnQhq6tqD32hZv+l1e5mJHNSudjnaAzgAHfkGiU0ABN6lmbZF8abJIulQHbZ7oiHhP8yL6O910ICMc+5pw==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/hasha/-/hasha-5.1.0.tgz",
+			"integrity": "sha512-OFPDWmzPN1l7atOV1TgBVmNtBxaIysToK6Ve9DK+vT6pYuklw/nPNT+HJbZi0KDcI6vWB+9tgvZ5YD7fA3CXcA==",
 			"dev": true,
 			"requires": {
-				"is-stream": "^1.1.0",
-				"type-fest": "^0.3.0"
+				"is-stream": "^2.0.0",
+				"type-fest": "^0.8.0"
 			},
 			"dependencies": {
 				"type-fest": {
-					"version": "0.3.1",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
-					"integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+					"version": "0.8.1",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+					"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
 					"dev": true
 				}
 			}
@@ -4316,9 +4334,9 @@
 			}
 		},
 		"hosted-git-info": {
-			"version": "2.8.4",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
-			"integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==",
+			"version": "2.8.5",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
+			"integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
 			"dev": true
 		},
 		"http-cache-semantics": {
@@ -4736,9 +4754,9 @@
 			}
 		},
 		"is-stream": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+			"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
 			"dev": true
 		},
 		"is-typedarray": {
@@ -4973,9 +4991,9 @@
 			}
 		},
 		"loud-rejection": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-2.1.0.tgz",
-			"integrity": "sha512-g/6MQxUXYHeVqZ4PGpPL1fS1fOvlXoi7bay0pizmjAd/3JhyXwxzwrnr74yzdmhuerlslbRJ3x7IOXzFz0cE5w==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-2.2.0.tgz",
+			"integrity": "sha512-S0FayMXku80toa5sZ6Ro4C+s+EtFDCsyJNG/AzFMfX3AxD5Si4dZsgzm/kKnbOxHl5Cv8jBlno8+3XYIh2pNjQ==",
 			"dev": true,
 			"requires": {
 				"currently-unhandled": "^0.4.1",
@@ -5125,9 +5143,9 @@
 			}
 		},
 		"merge2": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.4.tgz",
-			"integrity": "sha512-FYE8xI+6pjFOhokZu0We3S5NKCirLbCzSh2Usf3qEyr4X8U+0jNg9P8RZ4qz+V2UoECLVwSyzU3LxXBaLGtD3A==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
+			"integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
 			"dev": true
 		},
 		"micromatch": {
@@ -5365,12 +5383,20 @@
 			}
 		},
 		"node-releases": {
-			"version": "1.1.29",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.29.tgz",
-			"integrity": "sha512-R5bDhzh6I+tpi/9i2hrrvGJ3yKPYzlVOORDkXhnZuwi5D3q1I5w4vYy24PJXTcLk9Q0kws9TO77T75bcK8/ysQ==",
+			"version": "1.1.38",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.38.tgz",
+			"integrity": "sha512-/5NZAaOyTj134Oy5Cp/J8mso8OD/D9CSuL+6TOXXsTKO8yjc5e4up75SRPCganCjwFKMj2jbp5tR0dViVdox7g==",
 			"dev": true,
 			"requires": {
-				"semver": "^5.3.0"
+				"semver": "^6.3.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
 			}
 		},
 		"normalize-package-data": {
@@ -5392,9 +5418,9 @@
 			"dev": true
 		},
 		"normalize-url": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.3.0.tgz",
-			"integrity": "sha512-0NLtR71o4k6GLP+mr6Ty34c5GA6CMoEsncKJxvQd8NzPxaHRJNnb5gZE8R1XF4CPIS7QPHLJ74IFszwtNVAHVQ==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
+			"integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
 			"dev": true
 		},
 		"npm-run-path": {
@@ -5664,20 +5690,20 @@
 			"dev": true
 		},
 		"parallel-transform": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
-			"integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.2.0.tgz",
+			"integrity": "sha512-P2vSmIu38uIlvdcU7fDkyrxj33gTUy/ABO5ZUbGowxNCopBq/OoD42bP4UmMrJoPyk4Uqf0mu3mtWBhHCZD8yg==",
 			"dev": true,
 			"requires": {
-				"cyclist": "~0.2.2",
+				"cyclist": "^1.0.1",
 				"inherits": "^2.0.3",
 				"readable-stream": "^2.1.5"
 			}
 		},
 		"parse-asn1": {
-			"version": "5.1.4",
-			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.4.tgz",
-			"integrity": "sha512-Qs5duJcuvNExRfFZ99HDD3z4mAi3r9Wl/FOjEOijlxwCZs7E7mW2vjTpgQ4J8LpTF8x5v+1Vn5UQFejmWT11aw==",
+			"version": "5.1.5",
+			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
+			"integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
 			"dev": true,
 			"requires": {
 				"asn1.js": "^4.0.0",
@@ -6175,12 +6201,6 @@
 				"safe-regex": "^1.1.0"
 			}
 		},
-		"regexp-tree": {
-			"version": "0.1.13",
-			"resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.13.tgz",
-			"integrity": "sha512-hwdV/GQY5F8ReLZWO+W1SRoN5YfpOKY6852+tBFcma72DKBIcHjPRIlIvQN35bCOljuAfP2G2iB0FC/w236mUw==",
-			"dev": true
-		},
 		"regexp.prototype.flags": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
@@ -6191,9 +6211,9 @@
 			}
 		},
 		"regexpu-core": {
-			"version": "4.5.5",
-			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.5.tgz",
-			"integrity": "sha512-FpI67+ky9J+cDizQUJlIlNZFKual/lUkFr1AG6zOCpwZ9cLrg8UUVakyUQJD7fCDIe9Z2nwTQJNPyonatNmDFQ==",
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.6.0.tgz",
+			"integrity": "sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==",
 			"dev": true,
 			"requires": {
 				"regenerate": "^1.4.0",
@@ -6224,9 +6244,9 @@
 			}
 		},
 		"regjsgen": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
-			"integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==",
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.1.tgz",
+			"integrity": "sha512-5qxzGZjDs9w4tzT3TPhCJqWdCc3RLYwy9J2NB0nm5Lz+S273lvWcpjaTGHsT1dc6Hhfq41uSEOw8wBmxrKOuyg==",
 			"dev": true
 		},
 		"regjsparser": {
@@ -6422,9 +6442,9 @@
 			"dev": true
 		},
 		"serialize-javascript": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.0.tgz",
-			"integrity": "sha512-UkGlcYMtw4d9w7YfCtJFgdRTps8N4L0A48R+SmcGL57ki1+yHwJXnalk5bjgrw+ljv6SfzjzPjhohod2qllg/Q==",
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
+			"integrity": "sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==",
 			"dev": true
 		},
 		"set-value": {
@@ -6924,9 +6944,9 @@
 			}
 		},
 		"terser": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-4.2.1.tgz",
-			"integrity": "sha512-cGbc5utAcX4a9+2GGVX4DsenG6v0x3glnDi5hx8816X1McEAwPlPgRtXPJzSBsbpILxZ8MQMT0KvArLuE0HP5A==",
+			"version": "4.3.9",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-4.3.9.tgz",
+			"integrity": "sha512-NFGMpHjlzmyOtPL+fDw3G7+6Ueh/sz4mkaUYa4lJCxOPTNzd0Uj0aZJOmsDYoSQyfuVoWDMSWTPU3huyOm2zdA==",
 			"dev": true,
 			"requires": {
 				"commander": "^2.20.0",
@@ -7361,9 +7381,9 @@
 			}
 		},
 		"webpack": {
-			"version": "4.39.3",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.39.3.tgz",
-			"integrity": "sha512-BXSI9M211JyCVc3JxHWDpze85CvjC842EvpRsVTc/d15YJGlox7GIDd38kJgWrb3ZluyvIjgenbLDMBQPDcxYQ==",
+			"version": "4.41.2",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.2.tgz",
+			"integrity": "sha512-Zhw69edTGfbz9/8JJoyRQ/pq8FYUoY0diOXqW0T6yhgdhCv6wr0hra5DwwWexNRns2Z2+gsnrNcbe9hbGBgk/A==",
 			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.8.5",
@@ -7476,9 +7496,9 @@
 			"dev": true
 		},
 		"write-file-atomic": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.0.tgz",
-			"integrity": "sha512-EIgkf60l2oWsffja2Sf2AL384dx328c0B+cIYPTQq5q2rOYuDV00/iPFBOUiDKKwKMOhkymH8AidPaRvzfxY+Q==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.1.tgz",
+			"integrity": "sha512-JPStrIyyVJ6oCSz/691fAjFtefZ6q+fP6tm+OS4Qw6o+TGQxNp1ziY2PgS+X/m0V8OWhZiO/m4xSj+Pr4RrZvw==",
 			"dev": true,
 			"requires": {
 				"imurmurhash": "^0.1.4",

--- a/packages/veui-theme-dls-icons/package-lock.json
+++ b/packages/veui-theme-dls-icons/package-lock.json
@@ -1,757 +1,757 @@
 {
-  "name": "veui-theme-dls-icons",
-  "version": "1.0.0-alpha.30",
-  "lockfileVersion": 1,
-  "requires": true,
-  "dependencies": {
-    "@types/q": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
-      "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==",
-      "dev": true
-    },
-    "ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "requires": {
-        "color-convert": "^1.9.0"
-      }
-    },
-    "argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "requires": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
-    },
-    "boolbase": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
-      "dev": true
-    },
-    "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
-      "requires": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      }
-    },
-    "clean-deep": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/clean-deep/-/clean-deep-3.0.2.tgz",
-      "integrity": "sha512-sLUtFxYtHc3jM9pmwyYXOLln0nnQ1OhFrefQ7nqUlva1crHDbi4gVO+nnMSm5jztFXIRDMt+kMNh0mOscbARow==",
-      "dev": true,
-      "requires": {
-        "lodash.isempty": "^4.4.0",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.transform": "^4.6.0"
-      }
-    },
-    "coa": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/coa/-/coa-2.0.2.tgz",
-      "integrity": "sha512-q5/jG+YQnSy4nRTV4F7lPepBJZ8qBNJJDBuJdoejDyLXgmL7IEo+Le2JDZudFTFt7mrCqIRaSjws4ygRCTCAXA==",
-      "dev": true,
-      "requires": {
-        "@types/q": "^1.5.1",
-        "chalk": "^2.4.1",
-        "q": "^1.1.2"
-      }
-    },
-    "color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "requires": {
-        "color-name": "1.1.3"
-      }
-    },
-    "color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
-    },
-    "concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
-    },
-    "css-select": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-2.0.2.tgz",
-      "integrity": "sha512-dSpYaDVoWaELjvZ3mS6IKZM/y2PMPa/XYoEfYNZePL4U/XgyxZNroHEHReDx/d+VgXh9VbCTtFqLkFbmeqeaRQ==",
-      "dev": true,
-      "requires": {
-        "boolbase": "^1.0.0",
-        "css-what": "^2.1.2",
-        "domutils": "^1.7.0",
-        "nth-check": "^1.0.2"
-      }
-    },
-    "css-select-base-adapter": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
-      "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==",
-      "dev": true
-    },
-    "css-tree": {
-      "version": "1.0.0-alpha.33",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.33.tgz",
-      "integrity": "sha512-SPt57bh5nQnpsTBsx/IXbO14sRc9xXu5MtMAVuo0BaQQmyf0NupNPPSoMaqiAF5tDFafYsTkfeH4Q/HCKXkg4w==",
-      "dev": true,
-      "requires": {
-        "mdn-data": "2.0.4",
-        "source-map": "^0.5.3"
-      }
-    },
-    "css-what": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
-      "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
-      "dev": true
-    },
-    "csso": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/csso/-/csso-3.5.1.tgz",
-      "integrity": "sha512-vrqULLffYU1Q2tLdJvaCYbONStnfkfimRxXNaGjxMldI0C7JPBC4rB1RyjhfdZ4m1frm8pM9uRPKH3d2knZ8gg==",
-      "dev": true,
-      "requires": {
-        "css-tree": "1.0.0-alpha.29"
-      },
-      "dependencies": {
-        "css-tree": {
-          "version": "1.0.0-alpha.29",
-          "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.29.tgz",
-          "integrity": "sha512-sRNb1XydwkW9IOci6iB2xmy8IGCj6r/fr+JWitvJ2JxQRPzN3T4AGGVWCMlVmVwM1gtgALJRmGIlWv5ppnGGkg==",
-          "dev": true,
-          "requires": {
-            "mdn-data": "~1.1.0",
-            "source-map": "^0.5.3"
-          }
-        },
-        "mdn-data": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
-          "integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA==",
-          "dev": true
-        }
-      }
-    },
-    "deep-rename-keys": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/deep-rename-keys/-/deep-rename-keys-0.2.1.tgz",
-      "integrity": "sha1-7eeFN9emaivmFRfir5Vtf1ij8dg=",
-      "dev": true,
-      "requires": {
-        "kind-of": "^3.0.2",
-        "rename-keys": "^1.1.2"
-      }
-    },
-    "define-properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
-      "requires": {
-        "object-keys": "^1.0.12"
-      }
-    },
-    "dom-serializer": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.1.tgz",
-      "integrity": "sha512-sK3ujri04WyjwQXVoK4PU3y8ula1stq10GJZpqHIUgoGZdsGzAGu65BnU3d08aTVSvO7mGPZUc0wTEDL+qGE0Q==",
-      "dev": true,
-      "requires": {
-        "domelementtype": "^2.0.1",
-        "entities": "^2.0.0"
-      },
-      "dependencies": {
-        "domelementtype": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
-          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==",
-          "dev": true
-        }
-      }
-    },
-    "domelementtype": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
-      "dev": true
-    },
-    "domutils": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
-      "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
-      "dev": true,
-      "requires": {
-        "dom-serializer": "0",
-        "domelementtype": "1"
-      }
-    },
-    "entities": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
-      "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==",
-      "dev": true
-    },
-    "es-abstract": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.14.0.tgz",
-      "integrity": "sha512-lri42nNq1tIohUuwFBYEM3wKwcrcJa78jukGDdWsuaNxTtxBFGFkKUQ15nc9J+ipje4mhbQR6JwABb4VvawR3A==",
-      "dev": true,
-      "requires": {
-        "es-to-primitive": "^1.2.0",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.0",
-        "is-callable": "^1.1.4",
-        "is-regex": "^1.0.4",
-        "object-inspect": "^1.6.0",
-        "object-keys": "^1.1.1",
-        "string.prototype.trimleft": "^2.0.0",
-        "string.prototype.trimright": "^2.0.0"
-      }
-    },
-    "es-to-primitive": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
-      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
-      "dev": true,
-      "requires": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
-      }
-    },
-    "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
-    },
-    "esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
-      "dev": true
-    },
-    "esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
-    },
-    "eventemitter3": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
-      "integrity": "sha1-teEHm1n7XhuidxwKmTvgYKWMmbo=",
-      "dev": true
-    },
-    "fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
-    },
-    "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
-    },
-    "get-own-enumerable-property-symbols": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.0.tgz",
-      "integrity": "sha512-CIJYJC4GGF06TakLg8z4GQKvDsx9EMspVxOYih7LerEL/WosUnFIww45CGfxfeKHqlg3twgUrYRT1O3WQqjGCg==",
-      "dev": true
-    },
-    "get-value": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
-      "dev": true
-    },
-    "glob": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-      "dev": true,
-      "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      }
-    },
-    "has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
-      "requires": {
-        "function-bind": "^1.1.1"
-      }
-    },
-    "has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
-    },
-    "has-symbols": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
-      "dev": true
-    },
-    "has-value": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
-      "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
-      "dev": true,
-      "requires": {
-        "get-value": "^2.0.3",
-        "has-values": "^0.1.4",
-        "isobject": "^2.0.0"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "dev": true,
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        }
-      }
-    },
-    "has-values": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-      "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
-      "dev": true
-    },
-    "inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
-      "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
-    },
-    "is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
-    },
-    "is-callable": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
-      "dev": true
-    },
-    "is-date-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-      "dev": true
-    },
-    "is-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-      "dev": true
-    },
-    "is-plain-object": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "dev": true,
-      "requires": {
-        "isobject": "^3.0.1"
-      }
-    },
-    "is-regex": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "dev": true,
-      "requires": {
-        "has": "^1.0.1"
-      }
-    },
-    "is-regexp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
-      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
-      "dev": true
-    },
-    "is-symbol": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
-      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
-      "dev": true,
-      "requires": {
-        "has-symbols": "^1.0.0"
-      }
-    },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
-    },
-    "isobject": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-      "dev": true
-    },
-    "js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-      "dev": true,
-      "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      }
-    },
-    "kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true,
-      "requires": {
-        "is-buffer": "^1.1.5"
-      }
-    },
-    "lodash.isempty": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
-      "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4=",
-      "dev": true
-    },
-    "lodash.isplainobject": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
-      "dev": true
-    },
-    "lodash.transform": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.transform/-/lodash.transform-4.6.0.tgz",
-      "integrity": "sha1-EjBkIvYzJK7YSD0/ODMrX2cFR6A=",
-      "dev": true
-    },
-    "mdn-data": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
-      "integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==",
-      "dev": true
-    },
-    "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
-      "requires": {
-        "brace-expansion": "^1.1.7"
-      }
-    },
-    "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
-    },
-    "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
-      "requires": {
-        "minimist": "0.0.8"
-      }
-    },
-    "nth-check": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
-      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
-      "dev": true,
-      "requires": {
-        "boolbase": "~1.0.0"
-      }
-    },
-    "object-inspect": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
-      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
-      "dev": true
-    },
-    "object-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
-    },
-    "object.getownpropertydescriptors": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
-      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.5.1"
-      }
-    },
-    "object.values": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
-      "integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.12.0",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3"
-      }
-    },
-    "omit-deep": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/omit-deep/-/omit-deep-0.3.0.tgz",
-      "integrity": "sha1-IcivNJm8rdKWUaIyy8rLxSRF6+w=",
-      "dev": true,
-      "requires": {
-        "is-plain-object": "^2.0.1",
-        "unset-value": "^0.1.1"
-      }
-    },
-    "once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
-      "requires": {
-        "wrappy": "1"
-      }
-    },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
-    },
-    "q": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
-      "dev": true
-    },
-    "rename-keys": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/rename-keys/-/rename-keys-1.2.0.tgz",
-      "integrity": "sha512-U7XpAktpbSgHTRSNRrjKSrjYkZKuhUukfoBlXWXUExCAqhzh1TU3BDRAfJmarcl5voKS+pbKU9MvyLWKZ4UEEg==",
-      "dev": true
-    },
-    "rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "dev": true,
-      "requires": {
-        "glob": "^7.1.3"
-      }
-    },
-    "sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
-    },
-    "source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true
-    },
-    "sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
-    },
-    "stable": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
-      "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
-      "dev": true
-    },
-    "string.prototype.trimleft": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.0.0.tgz",
-      "integrity": "sha1-aLaqjhYsaoDnbjqKDC50cYbicf8=",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.0.2"
-      }
-    },
-    "string.prototype.trimright": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.0.0.tgz",
-      "integrity": "sha1-q0pW2AKgH75yk+EehPJNyBZGYd0=",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.0.2"
-      }
-    },
-    "stringify-object": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
-      "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
-      "dev": true,
-      "requires": {
-        "get-own-enumerable-property-symbols": "^3.0.0",
-        "is-obj": "^1.0.1",
-        "is-regexp": "^1.0.0"
-      }
-    },
-    "supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "requires": {
-        "has-flag": "^3.0.0"
-      }
-    },
-    "svgo": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.0.tgz",
-      "integrity": "sha512-MLfUA6O+qauLDbym+mMZgtXCGRfIxyQoeH6IKVcFslyODEe/ElJNwr0FohQ3xG4C6HK6bk3KYPPXwHVJk3V5NQ==",
-      "dev": true,
-      "requires": {
-        "chalk": "^2.4.1",
-        "coa": "^2.0.2",
-        "css-select": "^2.0.0",
-        "css-select-base-adapter": "^0.1.1",
-        "css-tree": "1.0.0-alpha.33",
-        "csso": "^3.5.1",
-        "js-yaml": "^3.13.1",
-        "mkdirp": "~0.5.1",
-        "object.values": "^1.1.0",
-        "sax": "~1.2.4",
-        "stable": "^0.1.8",
-        "unquote": "~1.1.1",
-        "util.promisify": "~1.0.0"
-      }
-    },
-    "svgson": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/svgson/-/svgson-3.1.0.tgz",
-      "integrity": "sha512-7DbA8d02COOjp+BACdxrPJNaIrlKROhNloktJF6lbeVz4syVLAKv8ViwHScwXK0RSLeTFND4OuJFpRlrdoqRuw==",
-      "dev": true,
-      "requires": {
-        "clean-deep": "3.0.2",
-        "deep-rename-keys": "^0.2.1",
-        "omit-deep": "0.3.0",
-        "xml-reader": "2.4.3"
-      }
-    },
-    "unquote": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
-      "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=",
-      "dev": true
-    },
-    "unset-value": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-0.1.2.tgz",
-      "integrity": "sha1-UGgQuGfyfCpabpsEgzYx9t5Y0xA=",
-      "dev": true,
-      "requires": {
-        "has-value": "^0.3.1",
-        "isobject": "^3.0.0"
-      }
-    },
-    "util.promisify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
-      "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.2",
-        "object.getownpropertydescriptors": "^2.0.3"
-      }
-    },
-    "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
-    },
-    "xml-lexer": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/xml-lexer/-/xml-lexer-0.2.2.tgz",
-      "integrity": "sha1-UYGTpKozTVj8fSSLVJB5uJkH4EY=",
-      "dev": true,
-      "requires": {
-        "eventemitter3": "^2.0.0"
-      }
-    },
-    "xml-reader": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/xml-reader/-/xml-reader-2.4.3.tgz",
-      "integrity": "sha1-n4EMr3xCWlqvuEixxFEDyecddTA=",
-      "dev": true,
-      "requires": {
-        "eventemitter3": "^2.0.0",
-        "xml-lexer": "^0.2.2"
-      }
-    }
-  }
+	"name": "veui-theme-dls-icons",
+	"version": "1.0.0-alpha.30",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"@types/q": {
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
+			"integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==",
+			"dev": true
+		},
+		"ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"dev": true,
+			"requires": {
+				"color-convert": "^1.9.0"
+			}
+		},
+		"argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
+			"requires": {
+				"sprintf-js": "~1.0.2"
+			}
+		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
+		},
+		"boolbase": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
+			"dev": true
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"requires": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			}
+		},
+		"clean-deep": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/clean-deep/-/clean-deep-3.0.2.tgz",
+			"integrity": "sha512-sLUtFxYtHc3jM9pmwyYXOLln0nnQ1OhFrefQ7nqUlva1crHDbi4gVO+nnMSm5jztFXIRDMt+kMNh0mOscbARow==",
+			"dev": true,
+			"requires": {
+				"lodash.isempty": "^4.4.0",
+				"lodash.isplainobject": "^4.0.6",
+				"lodash.transform": "^4.6.0"
+			}
+		},
+		"coa": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/coa/-/coa-2.0.2.tgz",
+			"integrity": "sha512-q5/jG+YQnSy4nRTV4F7lPepBJZ8qBNJJDBuJdoejDyLXgmL7IEo+Le2JDZudFTFt7mrCqIRaSjws4ygRCTCAXA==",
+			"dev": true,
+			"requires": {
+				"@types/q": "^1.5.1",
+				"chalk": "^2.4.1",
+				"q": "^1.1.2"
+			}
+		},
+		"color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dev": true,
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
+		},
+		"css-select": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/css-select/-/css-select-2.0.2.tgz",
+			"integrity": "sha512-dSpYaDVoWaELjvZ3mS6IKZM/y2PMPa/XYoEfYNZePL4U/XgyxZNroHEHReDx/d+VgXh9VbCTtFqLkFbmeqeaRQ==",
+			"dev": true,
+			"requires": {
+				"boolbase": "^1.0.0",
+				"css-what": "^2.1.2",
+				"domutils": "^1.7.0",
+				"nth-check": "^1.0.2"
+			}
+		},
+		"css-select-base-adapter": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
+			"integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==",
+			"dev": true
+		},
+		"css-tree": {
+			"version": "1.0.0-alpha.33",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.33.tgz",
+			"integrity": "sha512-SPt57bh5nQnpsTBsx/IXbO14sRc9xXu5MtMAVuo0BaQQmyf0NupNPPSoMaqiAF5tDFafYsTkfeH4Q/HCKXkg4w==",
+			"dev": true,
+			"requires": {
+				"mdn-data": "2.0.4",
+				"source-map": "^0.5.3"
+			}
+		},
+		"css-what": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
+			"integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
+			"dev": true
+		},
+		"csso": {
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/csso/-/csso-3.5.1.tgz",
+			"integrity": "sha512-vrqULLffYU1Q2tLdJvaCYbONStnfkfimRxXNaGjxMldI0C7JPBC4rB1RyjhfdZ4m1frm8pM9uRPKH3d2knZ8gg==",
+			"dev": true,
+			"requires": {
+				"css-tree": "1.0.0-alpha.29"
+			},
+			"dependencies": {
+				"css-tree": {
+					"version": "1.0.0-alpha.29",
+					"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.29.tgz",
+					"integrity": "sha512-sRNb1XydwkW9IOci6iB2xmy8IGCj6r/fr+JWitvJ2JxQRPzN3T4AGGVWCMlVmVwM1gtgALJRmGIlWv5ppnGGkg==",
+					"dev": true,
+					"requires": {
+						"mdn-data": "~1.1.0",
+						"source-map": "^0.5.3"
+					}
+				},
+				"mdn-data": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
+					"integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA==",
+					"dev": true
+				}
+			}
+		},
+		"deep-rename-keys": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/deep-rename-keys/-/deep-rename-keys-0.2.1.tgz",
+			"integrity": "sha1-7eeFN9emaivmFRfir5Vtf1ij8dg=",
+			"dev": true,
+			"requires": {
+				"kind-of": "^3.0.2",
+				"rename-keys": "^1.1.2"
+			}
+		},
+		"define-properties": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+			"dev": true,
+			"requires": {
+				"object-keys": "^1.0.12"
+			}
+		},
+		"dom-serializer": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.1.tgz",
+			"integrity": "sha512-sK3ujri04WyjwQXVoK4PU3y8ula1stq10GJZpqHIUgoGZdsGzAGu65BnU3d08aTVSvO7mGPZUc0wTEDL+qGE0Q==",
+			"dev": true,
+			"requires": {
+				"domelementtype": "^2.0.1",
+				"entities": "^2.0.0"
+			},
+			"dependencies": {
+				"domelementtype": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
+					"integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==",
+					"dev": true
+				}
+			}
+		},
+		"domelementtype": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+			"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+			"dev": true
+		},
+		"domutils": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+			"integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+			"dev": true,
+			"requires": {
+				"dom-serializer": "0",
+				"domelementtype": "1"
+			}
+		},
+		"entities": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
+			"integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==",
+			"dev": true
+		},
+		"es-abstract": {
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.0.tgz",
+			"integrity": "sha512-xdQnfykZ9JMEiasTAJZJdMWCQ1Vm00NBw79/AWi7ELfZuuPCSOMDZbT9mkOfSctVtfhb+sAAzrm+j//GjjLHLg==",
+			"dev": true,
+			"requires": {
+				"es-to-primitive": "^1.2.0",
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3",
+				"has-symbols": "^1.0.0",
+				"is-callable": "^1.1.4",
+				"is-regex": "^1.0.4",
+				"object-inspect": "^1.6.0",
+				"object-keys": "^1.1.1",
+				"string.prototype.trimleft": "^2.1.0",
+				"string.prototype.trimright": "^2.1.0"
+			}
+		},
+		"es-to-primitive": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+			"integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+			"dev": true,
+			"requires": {
+				"is-callable": "^1.1.4",
+				"is-date-object": "^1.0.1",
+				"is-symbol": "^1.0.2"
+			}
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
+		},
+		"esm": {
+			"version": "3.2.25",
+			"resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+			"integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+			"dev": true
+		},
+		"esprima": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"dev": true
+		},
+		"eventemitter3": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
+			"integrity": "sha1-teEHm1n7XhuidxwKmTvgYKWMmbo=",
+			"dev": true
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
+		},
+		"function-bind": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"dev": true
+		},
+		"get-own-enumerable-property-symbols": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.1.tgz",
+			"integrity": "sha512-09/VS4iek66Dh2bctjRkowueRJbY1JDGR1L/zRxO1Qk8Uxs6PnqaNSqalpizPT+CDjre3hnEsuzvhgomz9qYrA==",
+			"dev": true
+		},
+		"get-value": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+			"dev": true
+		},
+		"glob": {
+			"version": "7.1.5",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+			"integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
+			"dev": true,
+			"requires": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			}
+		},
+		"has": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"dev": true,
+			"requires": {
+				"function-bind": "^1.1.1"
+			}
+		},
+		"has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true
+		},
+		"has-symbols": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+			"integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+			"dev": true
+		},
+		"has-value": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+			"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+			"dev": true,
+			"requires": {
+				"get-value": "^2.0.3",
+				"has-values": "^0.1.4",
+				"isobject": "^2.0.0"
+			},
+			"dependencies": {
+				"isobject": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+					"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+					"dev": true,
+					"requires": {
+						"isarray": "1.0.0"
+					}
+				}
+			}
+		},
+		"has-values": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+			"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+			"dev": true
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
+			"requires": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true
+		},
+		"is-buffer": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+			"dev": true
+		},
+		"is-callable": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+			"integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+			"dev": true
+		},
+		"is-date-object": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+			"dev": true
+		},
+		"is-obj": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+			"dev": true
+		},
+		"is-plain-object": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"dev": true,
+			"requires": {
+				"isobject": "^3.0.1"
+			}
+		},
+		"is-regex": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+			"dev": true,
+			"requires": {
+				"has": "^1.0.1"
+			}
+		},
+		"is-regexp": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+			"integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+			"dev": true
+		},
+		"is-symbol": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+			"integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+			"dev": true,
+			"requires": {
+				"has-symbols": "^1.0.0"
+			}
+		},
+		"isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"dev": true
+		},
+		"isobject": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+			"dev": true
+		},
+		"js-yaml": {
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+			"dev": true,
+			"requires": {
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			}
+		},
+		"kind-of": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"dev": true,
+			"requires": {
+				"is-buffer": "^1.1.5"
+			}
+		},
+		"lodash.isempty": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+			"integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4=",
+			"dev": true
+		},
+		"lodash.isplainobject": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+			"dev": true
+		},
+		"lodash.transform": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/lodash.transform/-/lodash.transform-4.6.0.tgz",
+			"integrity": "sha1-EjBkIvYzJK7YSD0/ODMrX2cFR6A=",
+			"dev": true
+		},
+		"mdn-data": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
+			"integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==",
+			"dev": true
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
+			"requires": {
+				"brace-expansion": "^1.1.7"
+			}
+		},
+		"minimist": {
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+			"dev": true
+		},
+		"mkdirp": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"dev": true,
+			"requires": {
+				"minimist": "0.0.8"
+			}
+		},
+		"nth-check": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+			"integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+			"dev": true,
+			"requires": {
+				"boolbase": "~1.0.0"
+			}
+		},
+		"object-inspect": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
+			"integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
+			"dev": true
+		},
+		"object-keys": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+			"dev": true
+		},
+		"object.getownpropertydescriptors": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+			"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.5.1"
+			}
+		},
+		"object.values": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
+			"integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.12.0",
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3"
+			}
+		},
+		"omit-deep": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/omit-deep/-/omit-deep-0.3.0.tgz",
+			"integrity": "sha1-IcivNJm8rdKWUaIyy8rLxSRF6+w=",
+			"dev": true,
+			"requires": {
+				"is-plain-object": "^2.0.1",
+				"unset-value": "^0.1.1"
+			}
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
+			"requires": {
+				"wrappy": "1"
+			}
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
+		},
+		"q": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+			"dev": true
+		},
+		"rename-keys": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/rename-keys/-/rename-keys-1.2.0.tgz",
+			"integrity": "sha512-U7XpAktpbSgHTRSNRrjKSrjYkZKuhUukfoBlXWXUExCAqhzh1TU3BDRAfJmarcl5voKS+pbKU9MvyLWKZ4UEEg==",
+			"dev": true
+		},
+		"rimraf": {
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+			"dev": true,
+			"requires": {
+				"glob": "^7.1.3"
+			}
+		},
+		"sax": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+			"dev": true
+		},
+		"source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+			"dev": true
+		},
+		"sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
+		},
+		"stable": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
+			"integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
+			"dev": true
+		},
+		"string.prototype.trimleft": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
+			"integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"function-bind": "^1.1.1"
+			}
+		},
+		"string.prototype.trimright": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
+			"integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"function-bind": "^1.1.1"
+			}
+		},
+		"stringify-object": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
+			"integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
+			"dev": true,
+			"requires": {
+				"get-own-enumerable-property-symbols": "^3.0.0",
+				"is-obj": "^1.0.1",
+				"is-regexp": "^1.0.0"
+			}
+		},
+		"supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"dev": true,
+			"requires": {
+				"has-flag": "^3.0.0"
+			}
+		},
+		"svgo": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.0.tgz",
+			"integrity": "sha512-MLfUA6O+qauLDbym+mMZgtXCGRfIxyQoeH6IKVcFslyODEe/ElJNwr0FohQ3xG4C6HK6bk3KYPPXwHVJk3V5NQ==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.4.1",
+				"coa": "^2.0.2",
+				"css-select": "^2.0.0",
+				"css-select-base-adapter": "^0.1.1",
+				"css-tree": "1.0.0-alpha.33",
+				"csso": "^3.5.1",
+				"js-yaml": "^3.13.1",
+				"mkdirp": "~0.5.1",
+				"object.values": "^1.1.0",
+				"sax": "~1.2.4",
+				"stable": "^0.1.8",
+				"unquote": "~1.1.1",
+				"util.promisify": "~1.0.0"
+			}
+		},
+		"svgson": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/svgson/-/svgson-3.1.0.tgz",
+			"integrity": "sha512-7DbA8d02COOjp+BACdxrPJNaIrlKROhNloktJF6lbeVz4syVLAKv8ViwHScwXK0RSLeTFND4OuJFpRlrdoqRuw==",
+			"dev": true,
+			"requires": {
+				"clean-deep": "3.0.2",
+				"deep-rename-keys": "^0.2.1",
+				"omit-deep": "0.3.0",
+				"xml-reader": "2.4.3"
+			}
+		},
+		"unquote": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
+			"integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=",
+			"dev": true
+		},
+		"unset-value": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-0.1.2.tgz",
+			"integrity": "sha1-UGgQuGfyfCpabpsEgzYx9t5Y0xA=",
+			"dev": true,
+			"requires": {
+				"has-value": "^0.3.1",
+				"isobject": "^3.0.0"
+			}
+		},
+		"util.promisify": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+			"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.2",
+				"object.getownpropertydescriptors": "^2.0.3"
+			}
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
+		},
+		"xml-lexer": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/xml-lexer/-/xml-lexer-0.2.2.tgz",
+			"integrity": "sha1-UYGTpKozTVj8fSSLVJB5uJkH4EY=",
+			"dev": true,
+			"requires": {
+				"eventemitter3": "^2.0.0"
+			}
+		},
+		"xml-reader": {
+			"version": "2.4.3",
+			"resolved": "https://registry.npmjs.org/xml-reader/-/xml-reader-2.4.3.tgz",
+			"integrity": "sha1-n4EMr3xCWlqvuEixxFEDyecddTA=",
+			"dev": true,
+			"requires": {
+				"eventemitter3": "^2.0.0",
+				"xml-lexer": "^0.2.2"
+			}
+		}
+	}
 }

--- a/packages/veui-theme-dls/components/region-picker.less
+++ b/packages/veui-theme-dls/components/region-picker.less
@@ -88,20 +88,16 @@
         content: "";
         display: block;
         position: absolute;
-        bottom: -5px;
-        left: -8px;
         width: ~"calc(100% + 8px)";
         height: 10px;
         background-color: #fff;
       }
 
-      &::after {
-        bottom: -10px;
-        left: 20px;
+      &-overlay {
+        margin-top: -16px;
       }
 
-      .tether-element-attached-bottom + &-overlay &,
-      .tether-element-attached-bottom + [data-tether-id] + &-overlay & {
+      [x-placement*="top"] + &-overlay & {
         &::before {
           top: -15px;
           bottom: auto;
@@ -109,7 +105,34 @@
 
         &::after {
           top: -20px;
-          bottom: auto;
+        }
+      }
+      [x-placement*="bottom"] + &-overlay & {
+        &::before {
+          bottom: -5px;
+        }
+        &::after {
+          bottom: -10px;
+        }
+      }
+
+      [x-placement*="start"] + &-overlay & {
+        &::before {
+          left: -8px;
+        }
+
+        &::after {
+          left: 20px;
+        }
+      }
+
+      [x-placement*="end"] + &-overlay & {
+        &::before {
+          right: 0;
+        }
+
+        &::after {
+          right: 20px;
         }
       }
     }
@@ -117,14 +140,29 @@
 
   &-units {
     display: table;
-    margin: 10px 0 0 -8px;
     background-color: #fff;
     border-top: 1px solid @veui-gray-color-8;
     z-index: 0;
     .veui-overlay-shadow();
 
-    .tether-element-attached-bottom & {
-      margin: 0 0 10px -8px;
+    [x-placement*="top"] & {
+      margin-top: 0;
+      margin-bottom: 10px;
+    }
+
+    [x-placement*="bottom"] & {
+      margin-top: 10px;
+      margin-bottom: 0;
+    }
+
+    [x-placement*="start"] & {
+      margin-right: 0;
+      margin-left: -8px;
+    }
+
+    [x-placement*="end"] & {
+      margin-right: -8px;
+      margin-left: 0;
     }
   }
 

--- a/packages/veui-theme-dls/components/tooltip.less
+++ b/packages/veui-theme-dls/components/tooltip.less
@@ -80,22 +80,22 @@
     }
   }
 
-  .tether-element-attached-top.tether-target-attached-bottom & {
+  [x-placement*="bottom"] & {
     margin-top: @gap;
     .make-direction(top);
   }
 
-  .tether-element-attached-right.tether-target-attached-left & {
+  [x-placement*="left"] & {
     margin-right: @gap;
     .make-direction(right);
   }
 
-  .tether-element-attached-bottom.tether-target-attached-top & {
+  [x-placement*="top"] & {
     margin-bottom: @gap;
     .make-direction(bottom);
   }
 
-  .tether-element-attached-left.tether-target-attached-right & {
+  [x-placement*="right"] & {
     margin-left: @gap;
     .make-direction(left);
   }
@@ -127,19 +127,23 @@
     }
   }
 
-  .tether-element-attached-top.tether-target-attached-top & {
+  [x-placement="right-start"] &,
+  [x-placement="left-start"] & {
     .make-align(top);
   }
 
-  .tether-element-attached-right.tether-target-attached-right & {
+  [x-placement="top-end"] &,
+  [x-placement="bottom-end"] & {
     .make-align(right);
   }
 
-  .tether-element-attached-bottom.tether-target-attached-bottom & {
+  [x-placement="right-end"] &,
+  [x-placement="left-end"] & {
     .make-align(bottom);
   }
 
-  .tether-element-attached-left.tether-target-attached-left & {
+  [x-placement="top-start"] &,
+  [x-placement="bottom-start"] & {
     .make-align(left);
   }
 

--- a/packages/veui-theme-dls/dropdown.less
+++ b/packages/veui-theme-dls/dropdown.less
@@ -42,8 +42,8 @@
     transform: scaleY(0);
   }
 
-  .tether-element-attached-bottom.@{veui-prefix}-overlay-enter-active &,
-  .tether-element-attached-bottom.@{veui-prefix}-overlay-leave-active & {
+  [x-placement*="top"].@{veui-prefix}-overlay-enter-active &,
+  [x-placement*="top"].@{veui-prefix}-overlay-leave-active & {
     transform-origin: 50% 100%;
   }
 

--- a/packages/veui-theme-dls/package-lock.json
+++ b/packages/veui-theme-dls/package-lock.json
@@ -14,9 +14,9 @@
 			}
 		},
 		"@babel/types": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
-			"integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
+			"integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
 			"dev": true,
 			"requires": {
 				"esutils": "^2.0.2",
@@ -798,9 +798,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30000989",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000989.tgz",
-			"integrity": "sha512-vrMcvSuMz16YY6GSVZ0dWDTJP8jqk3iFQ/Aq5iqblPwxSVVZI+zxDyTX0VPqtQsDnfdrBDcsmhgTEOh5R8Lbpw==",
+			"version": "1.0.30001002",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001002.tgz",
+			"integrity": "sha512-pRuxPE8wdrWmVPKcDmJJiGBxr6lFJq4ivdSeo9FTmGj5Rb8NX3Mby2pARG57MXF15hYAhZ0nHV5XxT2ig4bz3g==",
 			"dev": true
 		},
 		"chalk": {
@@ -828,9 +828,9 @@
 			"dev": true
 		},
 		"core-js": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-			"integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
+			"version": "2.6.10",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
+			"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==",
 			"dev": true
 		},
 		"debug": {
@@ -843,9 +843,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.3.251",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.251.tgz",
-			"integrity": "sha512-C5oOBdqJTYago4PBeew9duLqWZ3SlDnTRM+PMIgZd/ILFrT5AfaAGd3jRNEfuPklFHFqOjfwbCvXpyzEYb5sXg==",
+			"version": "1.3.293",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.293.tgz",
+			"integrity": "sha512-DQSBRuU2Z1vG+CEWUIfCEVMHtuaGlhVojzg39mX5dx7PLSFDJ7DSrGUWzaPFFgWR1jo26hj1nXXRQZvFwk7F8w==",
 			"dev": true
 		},
 		"escape-string-regexp": {
@@ -914,9 +914,9 @@
 			"dev": true
 		},
 		"glob": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-			"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+			"version": "7.1.5",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+			"integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
 			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",

--- a/packages/veui-theme-one-icons/package-lock.json
+++ b/packages/veui-theme-one-icons/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "veui-theme-one-icons",
-	"version": "1.0.0-alpha.30",
+	"version": "1.0.0-alpha.31",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -9,6 +9,15 @@
 			"resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
 			"integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==",
 			"dev": true
+		},
+		"ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"dev": true,
+			"requires": {
+				"color-convert": "^1.9.0"
+			}
 		},
 		"argparse": {
 			"version": "1.0.10",
@@ -41,6 +50,17 @@
 				"concat-map": "0.0.1"
 			}
 		},
+		"chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			}
+		},
 		"clean-deep": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/clean-deep/-/clean-deep-3.0.2.tgz",
@@ -61,37 +81,6 @@
 				"@types/q": "^1.5.1",
 				"chalk": "^2.4.1",
 				"q": "^1.1.2"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"color-convert": {
@@ -236,9 +225,9 @@
 			"dev": true
 		},
 		"es-abstract": {
-			"version": "1.14.0",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.14.0.tgz",
-			"integrity": "sha512-lri42nNq1tIohUuwFBYEM3wKwcrcJa78jukGDdWsuaNxTtxBFGFkKUQ15nc9J+ipje4mhbQR6JwABb4VvawR3A==",
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.0.tgz",
+			"integrity": "sha512-xdQnfykZ9JMEiasTAJZJdMWCQ1Vm00NBw79/AWi7ELfZuuPCSOMDZbT9mkOfSctVtfhb+sAAzrm+j//GjjLHLg==",
 			"dev": true,
 			"requires": {
 				"es-to-primitive": "^1.2.0",
@@ -249,8 +238,8 @@
 				"is-regex": "^1.0.4",
 				"object-inspect": "^1.6.0",
 				"object-keys": "^1.1.1",
-				"string.prototype.trimleft": "^2.0.0",
-				"string.prototype.trimright": "^2.0.0"
+				"string.prototype.trimleft": "^2.1.0",
+				"string.prototype.trimright": "^2.1.0"
 			}
 		},
 		"es-to-primitive": {
@@ -301,9 +290,9 @@
 			"dev": true
 		},
 		"get-own-enumerable-property-symbols": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.0.tgz",
-			"integrity": "sha512-CIJYJC4GGF06TakLg8z4GQKvDsx9EMspVxOYih7LerEL/WosUnFIww45CGfxfeKHqlg3twgUrYRT1O3WQqjGCg==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.1.tgz",
+			"integrity": "sha512-09/VS4iek66Dh2bctjRkowueRJbY1JDGR1L/zRxO1Qk8Uxs6PnqaNSqalpizPT+CDjre3hnEsuzvhgomz9qYrA==",
 			"dev": true
 		},
 		"get-value": {
@@ -313,9 +302,9 @@
 			"dev": true
 		},
 		"glob": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-			"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+			"version": "7.1.5",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+			"integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
 			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
@@ -641,23 +630,23 @@
 			"dev": true
 		},
 		"string.prototype.trimleft": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.0.0.tgz",
-			"integrity": "sha1-aLaqjhYsaoDnbjqKDC50cYbicf8=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
+			"integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"function-bind": "^1.0.2"
+				"define-properties": "^1.1.3",
+				"function-bind": "^1.1.1"
 			}
 		},
 		"string.prototype.trimright": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.0.0.tgz",
-			"integrity": "sha1-q0pW2AKgH75yk+EehPJNyBZGYd0=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
+			"integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"function-bind": "^1.0.2"
+				"define-properties": "^1.1.3",
+				"function-bind": "^1.1.1"
 			}
 		},
 		"stringify-object": {
@@ -669,6 +658,15 @@
 				"get-own-enumerable-property-symbols": "^3.0.0",
 				"is-obj": "^1.0.1",
 				"is-regexp": "^1.0.0"
+			}
+		},
+		"supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"dev": true,
+			"requires": {
+				"has-flag": "^3.0.0"
 			}
 		},
 		"svgo": {
@@ -690,37 +688,6 @@
 				"stable": "^0.1.8",
 				"unquote": "~1.1.1",
 				"util.promisify": "~1.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"svgson": {

--- a/packages/veui-theme-one/package-lock.json
+++ b/packages/veui-theme-one/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "veui-theme-one",
-	"version": "1.0.0-alpha.30",
+	"version": "1.0.0-alpha.31",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -14,9 +14,9 @@
 			}
 		},
 		"@babel/types": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
-			"integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
+			"integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
 			"dev": true,
 			"requires": {
 				"esutils": "^2.0.2",
@@ -783,9 +783,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30000989",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000989.tgz",
-			"integrity": "sha512-vrMcvSuMz16YY6GSVZ0dWDTJP8jqk3iFQ/Aq5iqblPwxSVVZI+zxDyTX0VPqtQsDnfdrBDcsmhgTEOh5R8Lbpw==",
+			"version": "1.0.30001002",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001002.tgz",
+			"integrity": "sha512-pRuxPE8wdrWmVPKcDmJJiGBxr6lFJq4ivdSeo9FTmGj5Rb8NX3Mby2pARG57MXF15hYAhZ0nHV5XxT2ig4bz3g==",
 			"dev": true
 		},
 		"chalk": {
@@ -881,9 +881,9 @@
 			"dev": true
 		},
 		"core-js": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-			"integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
+			"version": "2.6.10",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
+			"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==",
 			"dev": true
 		},
 		"css-select": {
@@ -1010,9 +1010,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.3.251",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.251.tgz",
-			"integrity": "sha512-C5oOBdqJTYago4PBeew9duLqWZ3SlDnTRM+PMIgZd/ILFrT5AfaAGd3jRNEfuPklFHFqOjfwbCvXpyzEYb5sXg==",
+			"version": "1.3.293",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.293.tgz",
+			"integrity": "sha512-DQSBRuU2Z1vG+CEWUIfCEVMHtuaGlhVojzg39mX5dx7PLSFDJ7DSrGUWzaPFFgWR1jo26hj1nXXRQZvFwk7F8w==",
 			"dev": true
 		},
 		"entities": {
@@ -1022,9 +1022,9 @@
 			"dev": true
 		},
 		"es-abstract": {
-			"version": "1.14.0",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.14.0.tgz",
-			"integrity": "sha512-lri42nNq1tIohUuwFBYEM3wKwcrcJa78jukGDdWsuaNxTtxBFGFkKUQ15nc9J+ipje4mhbQR6JwABb4VvawR3A==",
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.0.tgz",
+			"integrity": "sha512-xdQnfykZ9JMEiasTAJZJdMWCQ1Vm00NBw79/AWi7ELfZuuPCSOMDZbT9mkOfSctVtfhb+sAAzrm+j//GjjLHLg==",
 			"dev": true,
 			"requires": {
 				"es-to-primitive": "^1.2.0",
@@ -1035,8 +1035,8 @@
 				"is-regex": "^1.0.4",
 				"object-inspect": "^1.6.0",
 				"object-keys": "^1.1.1",
-				"string.prototype.trimleft": "^2.0.0",
-				"string.prototype.trimright": "^2.0.0"
+				"string.prototype.trimleft": "^2.1.0",
+				"string.prototype.trimright": "^2.1.0"
 			}
 		},
 		"es-to-primitive": {
@@ -1098,9 +1098,9 @@
 			"dev": true
 		},
 		"get-own-enumerable-property-symbols": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.0.tgz",
-			"integrity": "sha512-CIJYJC4GGF06TakLg8z4GQKvDsx9EMspVxOYih7LerEL/WosUnFIww45CGfxfeKHqlg3twgUrYRT1O3WQqjGCg==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.1.tgz",
+			"integrity": "sha512-09/VS4iek66Dh2bctjRkowueRJbY1JDGR1L/zRxO1Qk8Uxs6PnqaNSqalpizPT+CDjre3hnEsuzvhgomz9qYrA==",
 			"dev": true
 		},
 		"get-value": {
@@ -1110,9 +1110,9 @@
 			"dev": true
 		},
 		"glob": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-			"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+			"version": "7.1.5",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+			"integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
 			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
@@ -1567,23 +1567,23 @@
 			"dev": true
 		},
 		"string.prototype.trimleft": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.0.0.tgz",
-			"integrity": "sha1-aLaqjhYsaoDnbjqKDC50cYbicf8=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
+			"integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"function-bind": "^1.0.2"
+				"define-properties": "^1.1.3",
+				"function-bind": "^1.1.1"
 			}
 		},
 		"string.prototype.trimright": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.0.0.tgz",
-			"integrity": "sha1-q0pW2AKgH75yk+EehPJNyBZGYd0=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
+			"integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"function-bind": "^1.0.2"
+				"define-properties": "^1.1.3",
+				"function-bind": "^1.1.1"
 			}
 		},
 		"stringify-object": {

--- a/packages/veui/demo/cases/Tooltip.vue
+++ b/packages/veui/demo/cases/Tooltip.vue
@@ -21,7 +21,7 @@
             ui="aux"
             @mouseenter.native="
               show({
-                position: 'top left',
+                position: 'top-start',
                 target: 'topLeftHover'
               })
             "
@@ -45,7 +45,7 @@
             ui="aux"
             @mouseenter.native="
               show({
-                position: 'top right',
+                position: 'top-end',
                 target: 'topRightHover'
               })
             "
@@ -59,7 +59,7 @@
             ui="aux"
             @mouseenter.native="
               show({
-                position: 'left top',
+                position: 'left-start',
                 target: 'leftTopHover'
               })
             "
@@ -83,7 +83,7 @@
             ui="aux"
             @mouseenter.native="
               show({
-                position: 'left bottom',
+                position: 'left-end',
                 target: 'leftBottomHover'
               })
             "
@@ -97,7 +97,7 @@
             ui="aux"
             @mouseenter.native="
               show({
-                position: 'right top',
+                position: 'right-start',
                 target: 'rightTopHover'
               })
             "
@@ -121,7 +121,7 @@
             ui="aux"
             @mouseenter.native="
               show({
-                position: 'right bottom',
+                position: 'right-end',
                 target: 'rightBottomHover'
               })
             "
@@ -135,7 +135,7 @@
             ui="aux"
             @mouseenter.native="
               show({
-                position: 'bottom left',
+                position: 'bottom-start',
                 target: 'BottomLeftHover'
               })
             "
@@ -159,7 +159,7 @@
             ui="aux"
             @mouseenter.native="
               show({
-                position: 'bottom right',
+                position: 'bottom-end',
                 target: 'BottomRightHover'
               })
             "
@@ -192,7 +192,7 @@
             ui="aux"
             @click.native="
               clickShow({
-                clickPosition: 'top left',
+                clickPosition: 'top-start',
                 clickTarget: 'topLeftClick'
               })
             "
@@ -216,7 +216,7 @@
             ui="aux"
             @click.native="
               clickShow({
-                clickPosition: 'top right',
+                clickPosition: 'top-end',
                 clickTarget: 'topRightClick'
               })
             "
@@ -230,7 +230,7 @@
             ui="aux"
             @click.native="
               clickShow({
-                clickPosition: 'left top',
+                clickPosition: 'left-start',
                 clickTarget: 'leftTopClick'
               })
             "
@@ -254,7 +254,7 @@
             ui="aux"
             @click.native="
               clickShow({
-                clickPosition: 'left bottom',
+                clickPosition: 'left-end',
                 clickTarget: 'leftBottomClick'
               })
             "
@@ -268,7 +268,7 @@
             ui="aux"
             @click.native="
               clickShow({
-                clickPosition: 'right top',
+                clickPosition: 'right-start',
                 clickTarget: 'rightTopClick'
               })
             "
@@ -292,7 +292,7 @@
             ui="aux"
             @click.native="
               clickShow({
-                clickPosition: 'right bottom',
+                clickPosition: 'right-end',
                 clickTarget: 'rightBottomClick'
               })
             "
@@ -306,7 +306,7 @@
             ui="aux"
             @click.native="
               clickShow({
-                clickPosition: 'bottom left',
+                clickPosition: 'bottom-start',
                 clickTarget: 'BottomLeftClick'
               })
             "
@@ -330,7 +330,7 @@
             ui="aux"
             @click.native="
               clickShow({
-                clickPosition: 'bottom right',
+                clickPosition: 'bottom-end',
                 clickTarget: 'BottomRightClick'
               })
             "

--- a/packages/veui/package-lock.json
+++ b/packages/veui/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "veui",
-	"version": "1.0.0-alpha.30",
+	"version": "1.0.0-alpha.31",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -14,18 +14,18 @@
 			}
 		},
 		"@babel/core": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.5.5.tgz",
-			"integrity": "sha512-i4qoSr2KTtce0DmkuuQBV4AuQgGPUcPXMr9L5MyYAtk06z068lQ10a4O009fe5OB/DfNV+h+qqT7ddNV8UnRjg==",
+			"version": "7.6.4",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.4.tgz",
+			"integrity": "sha512-Rm0HGw101GY8FTzpWSyRbki/jzq+/PkNQJ+nSulrdY6gFGOsNseCqD6KHRYe2E+EdzuBdr2pxCp6s4Uk6eJ+XQ==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.5.5",
-				"@babel/generator": "^7.5.5",
-				"@babel/helpers": "^7.5.5",
-				"@babel/parser": "^7.5.5",
-				"@babel/template": "^7.4.4",
-				"@babel/traverse": "^7.5.5",
-				"@babel/types": "^7.5.5",
+				"@babel/generator": "^7.6.4",
+				"@babel/helpers": "^7.6.2",
+				"@babel/parser": "^7.6.4",
+				"@babel/template": "^7.6.0",
+				"@babel/traverse": "^7.6.3",
+				"@babel/types": "^7.6.3",
 				"convert-source-map": "^1.1.0",
 				"debug": "^4.1.0",
 				"json5": "^2.1.0",
@@ -36,16 +36,15 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz",
-			"integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
+			"version": "7.6.4",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.4.tgz",
+			"integrity": "sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.5.5",
+				"@babel/types": "^7.6.3",
 				"jsesc": "^2.5.1",
 				"lodash": "^4.17.13",
-				"source-map": "^0.5.0",
-				"trim-right": "^1.0.1"
+				"source-map": "^0.5.0"
 			}
 		},
 		"@babel/helper-annotate-as-pure": {
@@ -79,9 +78,9 @@
 			}
 		},
 		"@babel/helper-create-class-features-plugin": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.5.5.tgz",
-			"integrity": "sha512-ZsxkyYiRA7Bg+ZTRpPvB6AbOFKTFFK4LrvTet8lInm0V468MWCaSYJE+I7v2z2r8KNLtYiV+K5kTCnR7dvyZjg==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.6.0.tgz",
+			"integrity": "sha512-O1QWBko4fzGju6VoVvrZg0RROCVifcLxiApnGP3OWfWzvxRZFCoBD81K5ur5e3bVY2Vf/5rIJm8cqPKn8HUJng==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-function-name": "^7.1.0",
@@ -255,14 +254,14 @@
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.5.5.tgz",
-			"integrity": "sha512-nRq2BUhxZFnfEn/ciJuhklHvFOqjJUD5wpx+1bxUF2axL9C+v4DE/dmp5sT2dKnpOs4orZWzpAZqlCy8QqE/7g==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.6.2.tgz",
+			"integrity": "sha512-3/bAUL8zZxYs1cdX2ilEE0WobqbCmKWr/889lf2SS0PpDcpEIY8pb1CCyz0pEcX3pEb+MCbks1jIokz2xLtGTA==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.4.4",
-				"@babel/traverse": "^7.5.5",
-				"@babel/types": "^7.5.5"
+				"@babel/template": "^7.6.0",
+				"@babel/traverse": "^7.6.2",
+				"@babel/types": "^7.6.0"
 			}
 		},
 		"@babel/highlight": {
@@ -277,9 +276,9 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
-			"integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
+			"version": "7.6.4",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.4.tgz",
+			"integrity": "sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==",
 			"dev": true
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
@@ -304,12 +303,12 @@
 			}
 		},
 		"@babel/plugin-proposal-decorators": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.4.4.tgz",
-			"integrity": "sha512-z7MpQz3XC/iQJWXH9y+MaWcLPNSMY9RQSthrLzak8R8hCj0fuyNk+Dzi9kfNe/JxxlWQ2g7wkABbgWjW36MTcw==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.6.0.tgz",
+			"integrity": "sha512-ZSyYw9trQI50sES6YxREXKu+4b7MAg6Qx2cvyDDYjP2Hpzd3FleOUwC9cqn1+za8d0A2ZU8SHujxFao956efUg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-create-class-features-plugin": "^7.4.4",
+				"@babel/helper-create-class-features-plugin": "^7.6.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/plugin-syntax-decorators": "^7.2.0"
 			}
@@ -325,9 +324,9 @@
 			}
 		},
 		"@babel/plugin-proposal-object-rest-spread": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.5.5.tgz",
-			"integrity": "sha512-F2DxJJSQ7f64FyTVl5cw/9MWn6naXGdk3Q3UhDbFEEHv+EilCPoeRD3Zh/Utx1CJz4uyKlQ4uH+bJPbEhMV7Zw==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.6.2.tgz",
+			"integrity": "sha512-LDBXlmADCsMZV1Y9OQwMc0MyGZ8Ta/zlD9N67BfQT8uYwkRswiu2hU6nJKrjrt/58aH/vqfQlR/9yId/7A2gWw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -345,14 +344,14 @@
 			}
 		},
 		"@babel/plugin-proposal-unicode-property-regex": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.4.tgz",
-			"integrity": "sha512-j1NwnOqMG9mFUOH58JTFsA/+ZYzQLUZ/drqWUqxCYLGeu2JFZL8YrNC9hBxKmWtAuOCHPcRpgv7fhap09Fb4kA==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.6.2.tgz",
+			"integrity": "sha512-NxHETdmpeSCtiatMRYWVJo7266rrvAC3DTeG5exQBIH/fMIUK7ejDNznBbn3HQl/o9peymRRg7Yqkx6PdUXmMw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-regex": "^7.4.4",
-				"regexpu-core": "^4.5.4"
+				"regexpu-core": "^4.6.0"
 			}
 		},
 		"@babel/plugin-syntax-async-generators": {
@@ -448,9 +447,9 @@
 			}
 		},
 		"@babel/plugin-transform-block-scoping": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.5.5.tgz",
-			"integrity": "sha512-82A3CLRRdYubkG85lKwhZB0WZoHxLGsJdux/cOVaJCJpvYFl1LVzAIFyRsa7CvXqW8rBM4Zf3Bfn8PHt5DP0Sg==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.6.3.tgz",
+			"integrity": "sha512-7hvrg75dubcO3ZI2rjYTzUrEuh1E9IyDEhhB6qfcooxhDA33xx2MasuLVgdxzcP6R/lipAC6n9ub9maNW6RKdw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -483,23 +482,23 @@
 			}
 		},
 		"@babel/plugin-transform-destructuring": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.5.0.tgz",
-			"integrity": "sha512-YbYgbd3TryYYLGyC7ZR+Tq8H/+bCmwoaxHfJHupom5ECstzbRLTch6gOQbhEY9Z4hiCNHEURgq06ykFv9JZ/QQ==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.6.0.tgz",
+			"integrity": "sha512-2bGIS5P1v4+sWTCnKNDZDxbGvEqi0ijeqM/YqHtVGrvG2y0ySgnEEhXErvE9dA0bnIzY9bIzdFK0jFA46ASIIQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-dotall-regex": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.4.tgz",
-			"integrity": "sha512-P05YEhRc2h53lZDjRPk/OektxCVevFzZs2Gfjd545Wde3k+yFDbXORgl2e0xpbq8mLcKJ7Idss4fAg0zORN/zg==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.6.2.tgz",
+			"integrity": "sha512-KGKT9aqKV+9YMZSkowzYoYEiHqgaDhGmPNZlZxX6UeHC4z30nC1J9IrZuGqbYFB1jaIGdv91ujpze0exiVK8bA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-regex": "^7.4.4",
-				"regexpu-core": "^4.5.4"
+				"regexpu-core": "^4.6.0"
 			}
 		},
 		"@babel/plugin-transform-duplicate-keys": {
@@ -561,9 +560,9 @@
 			}
 		},
 		"@babel/plugin-transform-modules-commonjs": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.5.0.tgz",
-			"integrity": "sha512-xmHq0B+ytyrWJvQTc5OWAC4ii6Dhr0s22STOoydokG51JjWhyYo5mRPXoi+ZmtHQhZZwuXNN+GG5jy5UZZJxIQ==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.6.0.tgz",
+			"integrity": "sha512-Ma93Ix95PNSEngqomy5LSBMAQvYKVe3dy+JlVJSHEXZR5ASL9lQBedMiCyVtmTLraIDVRE3ZjTZvmXXD2Ozw3g==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-transforms": "^7.4.4",
@@ -594,12 +593,12 @@
 			}
 		},
 		"@babel/plugin-transform-named-capturing-groups-regex": {
-			"version": "7.4.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.4.5.tgz",
-			"integrity": "sha512-z7+2IsWafTBbjNsOxU/Iv5CvTJlr5w4+HGu1HovKYTtgJ362f7kBcQglkfmlspKKZ3bgrbSGvLfNx++ZJgCWsg==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.6.3.tgz",
+			"integrity": "sha512-jTkk7/uE6H2s5w6VlMHeWuH+Pcy2lmdwFoeWCVnvIrDUnB5gQqTVI8WfmEAhF2CDEarGrknZcmSFg1+bkfCoSw==",
 			"dev": true,
 			"requires": {
-				"regexp-tree": "^0.1.6"
+				"regexpu-core": "^4.6.0"
 			}
 		},
 		"@babel/plugin-transform-new-target": {
@@ -642,9 +641,9 @@
 			}
 		},
 		"@babel/plugin-transform-runtime": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.5.5.tgz",
-			"integrity": "sha512-6Xmeidsun5rkwnGfMOp6/z9nSzWpHFNVr2Jx7kwoq4mVatQfQx5S56drBgEHF+XQbKOdIaOiMIINvp/kAwMN+w==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.6.2.tgz",
+			"integrity": "sha512-cqULw/QB4yl73cS5Y0TZlQSjDvNkzDbu0FurTZyHlJpWE5T3PCMdnyV+xXoH1opr1ldyHODe3QAX3OMAii5NxA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
@@ -663,9 +662,9 @@
 			}
 		},
 		"@babel/plugin-transform-spread": {
-			"version": "7.2.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.2.2.tgz",
-			"integrity": "sha512-KWfky/58vubwtS0hLqEnrWJjsMGaOeSBn90Ezn5Jeg9Z8KKHmELbP1yGylMlm5N6TPKeY9A2+UaSYLdxahg01w==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.6.2.tgz",
+			"integrity": "sha512-DpSvPFryKdK1x+EDJYCy28nmAaIMdxmhot62jAXF/o99iA33Zj2Lmcp3vDmz+MUh0LNYVPvfj5iC3feb3/+PFg==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
@@ -701,14 +700,14 @@
 			}
 		},
 		"@babel/plugin-transform-unicode-regex": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.4.tgz",
-			"integrity": "sha512-il+/XdNw01i93+M9J9u4T7/e/Ue/vWfNZE4IRUQjplu2Mqb/AFTDimkw2tdEdSH50wuQXZAbXSql0UphQke+vA==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.6.2.tgz",
+			"integrity": "sha512-orZI6cWlR3nk2YmYdb0gImrgCUwb5cBUwjf6Ks6dvNVvXERkwtJWOQaEOjPiu0Gu1Tq6Yq/hruCZZOOi9F34Dw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-regex": "^7.4.4",
-				"regexpu-core": "^4.5.4"
+				"regexpu-core": "^4.6.0"
 			}
 		},
 		"@babel/preset-env": {
@@ -763,18 +762,18 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
-			"integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.3.tgz",
+			"integrity": "sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==",
 			"dev": true,
 			"requires": {
 				"regenerator-runtime": "^0.13.2"
 			}
 		},
 		"@babel/runtime-corejs2": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.5.5.tgz",
-			"integrity": "sha512-FYATQVR00NSNi7mUfpPDp7E8RYMXDuO8gaix7u/w3GekfUinKgX1AcTxs7SoiEmoEW9mbpjrwqWSW6zCmw5h8A==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.6.3.tgz",
+			"integrity": "sha512-nuA2o+rgX2+PrNTZ063ehncVcg7sn+tU71BB81SaWRVUbGwCOlb0+yQA1e0QqmzOfRSYOxfvf8cosYqFbJEiwQ==",
 			"dev": true,
 			"requires": {
 				"core-js": "^2.6.5",
@@ -782,37 +781,37 @@
 			}
 		},
 		"@babel/template": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
-			"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
+			"integrity": "sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"@babel/parser": "^7.4.4",
-				"@babel/types": "^7.4.4"
+				"@babel/parser": "^7.6.0",
+				"@babel/types": "^7.6.0"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.5.tgz",
-			"integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.3.tgz",
+			"integrity": "sha512-unn7P4LGsijIxaAJo/wpoU11zN+2IaClkQAxcJWBNCMS6cmVh802IyLHNkAjQ0iYnRS3nnxk5O3fuXW28IMxTw==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.5.5",
-				"@babel/generator": "^7.5.5",
+				"@babel/generator": "^7.6.3",
 				"@babel/helper-function-name": "^7.1.0",
 				"@babel/helper-split-export-declaration": "^7.4.4",
-				"@babel/parser": "^7.5.5",
-				"@babel/types": "^7.5.5",
+				"@babel/parser": "^7.6.3",
+				"@babel/types": "^7.6.3",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0",
 				"lodash": "^4.17.13"
 			}
 		},
 		"@babel/types": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
-			"integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
+			"integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
 			"dev": true,
 			"requires": {
 				"esutils": "^2.0.2",
@@ -821,9 +820,9 @@
 			}
 		},
 		"@hapi/address": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.0.0.tgz",
-			"integrity": "sha512-mV6T0IYqb0xL1UALPFplXYQmR0twnXG0M6jUswpquqT2sD12BOiCiLy3EvMp/Fy7s3DZElC4/aPjEjo2jeZpvw==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.2.tgz",
+			"integrity": "sha512-O4QDrx+JoGKZc6aN64L04vqa7e41tIiLU+OvKdcYaEMP97UttL0f9GIi9/0A4WAMx0uBd6SidDIhktZhgOcN8Q==",
 			"dev": true
 		},
 		"@hapi/bourne": {
@@ -833,9 +832,9 @@
 			"dev": true
 		},
 		"@hapi/hoek": {
-			"version": "8.2.2",
-			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.2.2.tgz",
-			"integrity": "sha512-18P3VwngjNEcmvPj1mmiHLPyUPjhPAxIyJKDj4PRIY0F5ac3P0Vd0hkASPyWXHK0rfY3P9N2FoxV8ZuYaRBZ1g==",
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.2.tgz",
+			"integrity": "sha512-NP5SG4bzix+EtSMtcudp8TvI0lB46mXNo8uFpTDw6tqxGx4z5yx+giIunEFA0Z7oUO4DuWrOJV9xqR2tJVEdyA==",
 			"dev": true
 		},
 		"@hapi/joi": {
@@ -851,12 +850,12 @@
 			}
 		},
 		"@hapi/topo": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.3.tgz",
-			"integrity": "sha512-JmS9/vQK6dcUYn7wc2YZTqzIKubAQcJKu2KCKAru6es482U5RT5fP1EXCPtlXpiK7PR0On/kpQKI4fRKkzpZBQ==",
+			"version": "3.1.6",
+			"resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
+			"integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
 			"dev": true,
 			"requires": {
-				"@hapi/hoek": "8.x.x"
+				"@hapi/hoek": "^8.3.0"
 			}
 		},
 		"@intervolga/optimize-cssnano-plugin": {
@@ -905,9 +904,9 @@
 			}
 		},
 		"@sinonjs/formatio": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.1.tgz",
-			"integrity": "sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==",
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.2.tgz",
+			"integrity": "sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==",
 			"dev": true,
 			"requires": {
 				"@sinonjs/commons": "^1",
@@ -1008,9 +1007,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "12.7.3",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.3.tgz",
-			"integrity": "sha512-3SiLAIBkDWDg6vFo0+5YJyHPWU9uwu40Qe+v+0MH8wRKYBimHvvAOyk3EzMrD/TrIlLYfXrqDqrg913PynrMJQ==",
+			"version": "12.11.5",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.5.tgz",
+			"integrity": "sha512-LC8ALj/24PhByn39nr5jnTvpE7MujK8y7LQmV74kHYF5iQ0odCPkMH4IZNZw+cobKfSXqaC8GgegcbIsQpffdA==",
 			"dev": true
 		},
 		"@types/normalize-package-data": {
@@ -1046,9 +1045,9 @@
 			}
 		},
 		"@vue/babel-preset-app": {
-			"version": "3.11.0",
-			"resolved": "https://registry.npmjs.org/@vue/babel-preset-app/-/babel-preset-app-3.11.0.tgz",
-			"integrity": "sha512-fcCq9nuGGx1WGnyaKHvIC8RnWjISXGf1rJH4mN9+bymDfosgDbwnfV4TYvTZlyK1/aTHEEpIoO3XimTXBo7QBw==",
+			"version": "3.12.1",
+			"resolved": "https://registry.npmjs.org/@vue/babel-preset-app/-/babel-preset-app-3.12.1.tgz",
+			"integrity": "sha512-Zjy5jQaikV1Pz+ri0YgXFS7q4/5wCxB5tRkDOEIt5+4105u0Feb/pvH20nVL6nx9GyXrECFfcm7Yxr/z++OaPQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
@@ -1067,16 +1066,16 @@
 			}
 		},
 		"@vue/babel-preset-jsx": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@vue/babel-preset-jsx/-/babel-preset-jsx-1.1.0.tgz",
-			"integrity": "sha512-EeZ9gwEmu79B4A6LMLAw5cPCVYIcbKWgJgJafWtLzh1S+SgERUmTkVQ9Vx4k8zYBiCuxHK3XziZ3VJIMau7THA==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@vue/babel-preset-jsx/-/babel-preset-jsx-1.1.1.tgz",
+			"integrity": "sha512-SeyndwQZc8MAOkhbJaC34ocTwcKekKkwrwnTMC3YF8VmGp5IQWW5gPIU66bqO9WFBXFA3J3ANsUbP2pj8q8KdQ==",
 			"dev": true,
 			"requires": {
 				"@vue/babel-helper-vue-jsx-merge-props": "^1.0.0",
 				"@vue/babel-plugin-transform-vue-jsx": "^1.0.0",
 				"@vue/babel-sugar-functional-vue": "^1.0.0",
 				"@vue/babel-sugar-inject-h": "^1.0.0",
-				"@vue/babel-sugar-v-model": "^1.0.0",
+				"@vue/babel-sugar-v-model": "^1.1.1",
 				"@vue/babel-sugar-v-on": "^1.1.0"
 			}
 		},
@@ -1099,9 +1098,9 @@
 			}
 		},
 		"@vue/babel-sugar-v-model": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@vue/babel-sugar-v-model/-/babel-sugar-v-model-1.0.0.tgz",
-			"integrity": "sha512-Pfg2Al0io66P1eO6zUbRIgpyKCU2qTnumiE0lao/wA/uNdb7Dx5Tfd1W6tO5SsByETPnEs8i8+gawRIXX40rFw==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@vue/babel-sugar-v-model/-/babel-sugar-v-model-1.1.1.tgz",
+			"integrity": "sha512-qiPbdUTiqNQdhXzvWQMVfrYGHCiMmscY7j/cudLxdxWZ8AFhgPRVlniVgaWIT7A1iOjs92e8U6qVyqkf0d4ZrA==",
 			"dev": true,
 			"requires": {
 				"@babel/plugin-syntax-jsx": "^7.2.0",
@@ -1124,31 +1123,31 @@
 			}
 		},
 		"@vue/cli-overlay": {
-			"version": "3.11.0",
-			"resolved": "https://registry.npmjs.org/@vue/cli-overlay/-/cli-overlay-3.11.0.tgz",
-			"integrity": "sha512-yYZP27vjioWmohwXQ9mTPHHxktfAaTM6RDehyG83yvY07wcdxhwrNNCMm8eE9My/K2F8oAPf8uoDZZmkr/EXBw==",
+			"version": "3.12.1",
+			"resolved": "https://registry.npmjs.org/@vue/cli-overlay/-/cli-overlay-3.12.1.tgz",
+			"integrity": "sha512-Bym92EN+lj+cNRN2ozbYyH+V8DMXWGbCDUk+hiJ4EYDBZfBkZKvalk1/mOBFwyxiopnnbOEBAAhL/UuMQ1xARg==",
 			"dev": true
 		},
 		"@vue/cli-plugin-babel": {
-			"version": "3.11.0",
-			"resolved": "https://registry.npmjs.org/@vue/cli-plugin-babel/-/cli-plugin-babel-3.11.0.tgz",
-			"integrity": "sha512-RSq9goefilvUMYxbeQS8cZxt6zZnvBIb1xK4NWX0NBtqKzJmIjtJzDAQvKgjnZ/USRu6p6X2IRj4Wum8UCUqow==",
+			"version": "3.12.1",
+			"resolved": "https://registry.npmjs.org/@vue/cli-plugin-babel/-/cli-plugin-babel-3.12.1.tgz",
+			"integrity": "sha512-Zetvz8PikLCGomeKOKu8pC9YQ7cfxs7pGpvEOzaxGdhMnebhjAYR6i6dOB57A6N5lhxQksXCtYTv26QgfiIpdg==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.0.0",
-				"@vue/babel-preset-app": "^3.11.0",
-				"@vue/cli-shared-utils": "^3.11.0",
+				"@vue/babel-preset-app": "^3.12.1",
+				"@vue/cli-shared-utils": "^3.12.1",
 				"babel-loader": "^8.0.5",
 				"webpack": "^4.0.0"
 			}
 		},
 		"@vue/cli-plugin-eslint": {
-			"version": "3.11.0",
-			"resolved": "https://registry.npmjs.org/@vue/cli-plugin-eslint/-/cli-plugin-eslint-3.11.0.tgz",
-			"integrity": "sha512-cZWTXFbMu7/Ha6uAyvFsOxjC82afmHk0M9ye2MyeXmkvdL+tB2rcIITbd9HZypPaky1qv46Mp5l/lSd9W4PVCA==",
+			"version": "3.12.1",
+			"resolved": "https://registry.npmjs.org/@vue/cli-plugin-eslint/-/cli-plugin-eslint-3.12.1.tgz",
+			"integrity": "sha512-tVTZlEZsy3sQbO4LLWFK11yzlWwqVAqaM+IY+BeWHITBzEJKh2KmouG+x6x/reXiU3qROsMJ4Ej3Hs8buSMWyQ==",
 			"dev": true,
 			"requires": {
-				"@vue/cli-shared-utils": "^3.11.0",
+				"@vue/cli-shared-utils": "^3.12.1",
 				"babel-eslint": "^10.0.1",
 				"eslint": "^4.19.1",
 				"eslint-loader": "^2.1.2",
@@ -1313,15 +1312,15 @@
 			}
 		},
 		"@vue/cli-service": {
-			"version": "3.11.0",
-			"resolved": "https://registry.npmjs.org/@vue/cli-service/-/cli-service-3.11.0.tgz",
-			"integrity": "sha512-HSU4wHlYKQt8O968JUz/AeYvFSokxJjMkr7dgVNVb6rpBn859Emkr960plWGr1z1hc3qNOwLuSUGk5OSfq1inA==",
+			"version": "3.12.1",
+			"resolved": "https://registry.npmjs.org/@vue/cli-service/-/cli-service-3.12.1.tgz",
+			"integrity": "sha512-PDxNrTGnSKzeV1ruFlsRIAO8JcPizwT0EJXq9GeyooU+p+sOkv7aKkCBJQVYNjZapD1NOGWx6CvAAC/wAW+gew==",
 			"dev": true,
 			"requires": {
 				"@intervolga/optimize-cssnano-plugin": "^1.0.5",
 				"@soda/friendly-errors-webpack-plugin": "^1.7.1",
-				"@vue/cli-overlay": "^3.11.0",
-				"@vue/cli-shared-utils": "^3.11.0",
+				"@vue/cli-overlay": "^3.12.1",
+				"@vue/cli-shared-utils": "^3.12.1",
 				"@vue/component-compiler-utils": "^3.0.0",
 				"@vue/preload-webpack-plugin": "^1.1.0",
 				"@vue/web-component-wrapper": "^1.2.0",
@@ -1354,7 +1353,7 @@
 				"lodash.defaultsdeep": "^4.6.1",
 				"lodash.mapvalues": "^4.6.0",
 				"lodash.transform": "^4.6.0",
-				"mini-css-extract-plugin": "^0.6.0",
+				"mini-css-extract-plugin": "^0.8.0",
 				"minimist": "^1.2.0",
 				"ora": "^3.4.0",
 				"portfinder": "^1.0.20",
@@ -1385,9 +1384,9 @@
 			}
 		},
 		"@vue/cli-shared-utils": {
-			"version": "3.11.0",
-			"resolved": "https://registry.npmjs.org/@vue/cli-shared-utils/-/cli-shared-utils-3.11.0.tgz",
-			"integrity": "sha512-D7pst/4v9H1DD66fLxlZOwRR09R03MV0ROdKxBHmh3FmnApCA/RiaolFA/8w+B3CnevYMlV3SJ5fOAgedbswbA==",
+			"version": "3.12.1",
+			"resolved": "https://registry.npmjs.org/@vue/cli-shared-utils/-/cli-shared-utils-3.12.1.tgz",
+			"integrity": "sha512-jFblzRFjutGwu5utOKdVlPlsbA1lBUNNQlAThzNqej+JtTKJjnvjlhjKX0Gq0oOny5FjKWhoyfQ74p9h1qE6JQ==",
 			"dev": true,
 			"requires": {
 				"@hapi/joi": "^15.0.1",
@@ -2013,10 +2012,13 @@
 			"dev": true
 		},
 		"async": {
-			"version": "1.5.2",
-			"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-			"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-			"dev": true
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+			"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+			"dev": true,
+			"requires": {
+				"lodash": "^4.17.14"
+			}
 		},
 		"async-each": {
 			"version": "1.0.3",
@@ -2043,18 +2045,18 @@
 			"dev": true
 		},
 		"autoprefixer": {
-			"version": "9.6.1",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.6.1.tgz",
-			"integrity": "sha512-aVo5WxR3VyvyJxcJC3h4FKfwCQvQWb1tSI5VHNibddCVWrcD1NvlxEweg3TSgiPztMnWfjpy2FURKA2kvDE+Tw==",
+			"version": "9.6.5",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.6.5.tgz",
+			"integrity": "sha512-rGd50YV8LgwFQ2WQp4XzOTG69u1qQsXn0amww7tjqV5jJuNazgFKYEVItEBngyyvVITKOg20zr2V+9VsrXJQ2g==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^4.6.3",
-				"caniuse-lite": "^1.0.30000980",
+				"browserslist": "^4.7.0",
+				"caniuse-lite": "^1.0.30000999",
 				"chalk": "^2.4.2",
 				"normalize-range": "^0.1.2",
 				"num2fraction": "^1.2.2",
-				"postcss": "^7.0.17",
-				"postcss-value-parser": "^4.0.0"
+				"postcss": "^7.0.18",
+				"postcss-value-parser": "^4.0.2"
 			},
 			"dependencies": {
 				"postcss-value-parser": {
@@ -2418,9 +2420,9 @@
 			"dev": true
 		},
 		"bluebird": {
-			"version": "3.5.5",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
-			"integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
+			"integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg==",
 			"dev": true
 		},
 		"bn.js": {
@@ -2621,14 +2623,14 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.0.tgz",
-			"integrity": "sha512-9rGNDtnj+HaahxiVV38Gn8n8Lr8REKsel68v1sPFfIGEK6uSXTY3h9acgiT1dZVtOOUtifo/Dn8daDQ5dUgVsA==",
+			"version": "4.7.1",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.1.tgz",
+			"integrity": "sha512-QtULFqKIAtiyNx7NhZ/p4rB8m3xDozVo/pi5VgTlADLF2tNigz/QH+v0m5qhn7XfHT7u+607NcCNOnC0HZAlMg==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30000989",
-				"electron-to-chromium": "^1.3.247",
-				"node-releases": "^1.1.29"
+				"caniuse-lite": "^1.0.30000999",
+				"electron-to-chromium": "^1.3.284",
+				"node-releases": "^1.1.36"
 			}
 		},
 		"buffer": {
@@ -2821,9 +2823,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30000989",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000989.tgz",
-			"integrity": "sha512-vrMcvSuMz16YY6GSVZ0dWDTJP8jqk3iFQ/Aq5iqblPwxSVVZI+zxDyTX0VPqtQsDnfdrBDcsmhgTEOh5R8Lbpw==",
+			"version": "1.0.30001002",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001002.tgz",
+			"integrity": "sha512-pRuxPE8wdrWmVPKcDmJJiGBxr6lFJq4ivdSeo9FTmGj5Rb8NX3Mby2pARG57MXF15hYAhZ0nHV5XxT2ig4bz3g==",
 			"dev": true
 		},
 		"case-sensitive-paths-webpack-plugin": {
@@ -2903,9 +2905,9 @@
 			}
 		},
 		"chownr": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz",
-			"integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
+			"integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
 			"dev": true
 		},
 		"chrome-trace-event": {
@@ -3183,9 +3185,9 @@
 			}
 		},
 		"colors": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
-			"integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+			"integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
 			"dev": true
 		},
 		"combined-stream": {
@@ -3198,9 +3200,9 @@
 			}
 		},
 		"commander": {
-			"version": "2.20.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-			"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+			"version": "2.20.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
 			"dev": true
 		},
 		"commondir": {
@@ -3567,9 +3569,9 @@
 			}
 		},
 		"core-js": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-			"integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
+			"version": "2.6.10",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
+			"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==",
 			"dev": true
 		},
 		"core-util-is": {
@@ -3946,9 +3948,9 @@
 			"dev": true
 		},
 		"cyclist": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
-			"integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
+			"integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
 			"dev": true
 		},
 		"d": {
@@ -4056,25 +4058,37 @@
 			"dev": true
 		},
 		"default-gateway": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-5.0.3.tgz",
-			"integrity": "sha512-zW+ld9xtN0+q48wIwhitUzhfERJN7BPgvijPhuCKG6bfWqnoqtSNSnrXfvAME2ZJLpgYpz6UorpBddGfLzrJBw==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-5.0.4.tgz",
+			"integrity": "sha512-RncYZFuHZlB69pT3aAZK/YUjOpllMc3pKm/dIxHR0AyJlhRKSFbLIQbZia1WOrNoY0F1UsqadrHW9mx/lAWAgg==",
 			"dev": true,
 			"requires": {
-				"execa": "^2.0.3"
+				"execa": "^3.0.0"
 			},
 			"dependencies": {
-				"execa": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-2.0.4.tgz",
-					"integrity": "sha512-VcQfhuGD51vQUQtKIq2fjGDLDbL6N1DTQVpYzxZ7LPIXw3HqTuIz6uxRmpV1qf8i31LHf2kjiaGI+GdHwRgbnQ==",
+				"cross-spawn": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
+					"integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
 					"dev": true,
 					"requires": {
-						"cross-spawn": "^6.0.5",
+						"path-key": "^3.1.0",
+						"shebang-command": "^2.0.0",
+						"which": "^2.0.1"
+					}
+				},
+				"execa": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-3.2.0.tgz",
+					"integrity": "sha512-kJJfVbI/lZE1PZYDI5VPxp8zXPO9rtxOkhpZ0jMKha56AI9y2gGVC6bkukStQf0ka5Rh15BA5m7cCCH4jmHqkw==",
+					"dev": true,
+					"requires": {
+						"cross-spawn": "^7.0.0",
 						"get-stream": "^5.0.0",
+						"human-signals": "^1.1.1",
 						"is-stream": "^2.0.0",
 						"merge-stream": "^2.0.0",
-						"npm-run-path": "^3.0.0",
+						"npm-run-path": "^4.0.0",
 						"onetime": "^5.1.0",
 						"p-finally": "^2.0.0",
 						"signal-exit": "^3.0.2",
@@ -4103,9 +4117,9 @@
 					"dev": true
 				},
 				"npm-run-path": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
-					"integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.0.tgz",
+					"integrity": "sha512-8eyAOAH+bYXFPSnNnKr3J+yoybe8O87Is5rtAQ8qRczJz1ajcsjg8l2oZqP+Ppx15Ii3S1vUTjQN2h4YO2tWWQ==",
 					"dev": true,
 					"requires": {
 						"path-key": "^3.0.0"
@@ -4131,6 +4145,30 @@
 					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.0.tgz",
 					"integrity": "sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg==",
 					"dev": true
+				},
+				"shebang-command": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+					"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+					"dev": true,
+					"requires": {
+						"shebang-regex": "^3.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+					"dev": true
+				},
+				"which": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.1.tgz",
+					"integrity": "sha512-N7GBZOTswtB9lkQBZA4+zAXrjEIWAUOB93AvzUiudRzRxhUdLURQ7D/gAIMY1gatT/LTbmbcv8SiYazy3eYB7w==",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
 				}
 			}
 		},
@@ -4485,9 +4523,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.3.251",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.251.tgz",
-			"integrity": "sha512-C5oOBdqJTYago4PBeew9duLqWZ3SlDnTRM+PMIgZd/ILFrT5AfaAGd3jRNEfuPklFHFqOjfwbCvXpyzEYb5sXg==",
+			"version": "1.3.293",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.293.tgz",
+			"integrity": "sha512-DQSBRuU2Z1vG+CEWUIfCEVMHtuaGlhVojzg39mX5dx7PLSFDJ7DSrGUWzaPFFgWR1jo26hj1nXXRQZvFwk7F8w==",
 			"dev": true
 		},
 		"elegant-spinner": {
@@ -4497,9 +4535,9 @@
 			"dev": true
 		},
 		"elliptic": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.0.tgz",
-			"integrity": "sha512-eFOJTMyCYb7xtE/caJ6JJu+bhi67WCYNbkGSknu20pmM8Ke/bqOfdnZWxyoGN26JgfxTbXrsCkEw4KheCT/KGg==",
+			"version": "6.5.1",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.1.tgz",
+			"integrity": "sha512-xvJINNLbTeWQjrl6X+7eQCrIy/YPv5XCpKW6kB5mKvtnGILoLDcySuwomfdzt0BMdLNVnuRNTuzKNHj0bva1Cg==",
 			"dev": true,
 			"requires": {
 				"bn.js": "^4.4.0",
@@ -4530,9 +4568,9 @@
 			"dev": true
 		},
 		"end-of-stream": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
 			"dev": true,
 			"requires": {
 				"once": "^1.4.0"
@@ -4653,14 +4691,26 @@
 			}
 		},
 		"enhanced-resolve": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz",
-			"integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.1.tgz",
+			"integrity": "sha512-98p2zE+rL7/g/DzMHMTF4zZlCgeVdJ7yr6xzEpJRYwFYrGi9ANdn5DnJURg6RpBkyk60XYDnWIv51VfIhfNGuA==",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
-				"memory-fs": "^0.4.0",
+				"memory-fs": "^0.5.0",
 				"tapable": "^1.0.0"
+			},
+			"dependencies": {
+				"memory-fs": {
+					"version": "0.5.0",
+					"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
+					"integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
+					"dev": true,
+					"requires": {
+						"errno": "^0.1.3",
+						"readable-stream": "^2.0.1"
+					}
+				}
 			}
 		},
 		"ent": {
@@ -4694,18 +4744,18 @@
 			}
 		},
 		"error-stack-parser": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.3.tgz",
-			"integrity": "sha512-vRC4rKv87twMZy92X4+TmUdv3iYMsmePbpG/YguHsfzmZ8bYJZYYep7yrXH09yFUaCEPKgNK5X79+Yq7hwLVOA==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.4.tgz",
+			"integrity": "sha512-fZ0KkoxSjLFmhW5lHbUT3tLwy3nX1qEzMYo8koY1vrsAco53CMT1djnBSeC/wUjTEZRhZl9iRw7PaMaxfJ4wzQ==",
 			"dev": true,
 			"requires": {
-				"stackframe": "^1.0.4"
+				"stackframe": "^1.1.0"
 			}
 		},
 		"es-abstract": {
-			"version": "1.14.0",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.14.0.tgz",
-			"integrity": "sha512-lri42nNq1tIohUuwFBYEM3wKwcrcJa78jukGDdWsuaNxTtxBFGFkKUQ15nc9J+ipje4mhbQR6JwABb4VvawR3A==",
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.0.tgz",
+			"integrity": "sha512-xdQnfykZ9JMEiasTAJZJdMWCQ1Vm00NBw79/AWi7ELfZuuPCSOMDZbT9mkOfSctVtfhb+sAAzrm+j//GjjLHLg==",
 			"dev": true,
 			"requires": {
 				"es-to-primitive": "^1.2.0",
@@ -4716,8 +4766,8 @@
 				"is-regex": "^1.0.4",
 				"object-inspect": "^1.6.0",
 				"object-keys": "^1.1.1",
-				"string.prototype.trimleft": "^2.0.0",
-				"string.prototype.trimright": "^2.0.0"
+				"string.prototype.trimleft": "^2.1.0",
+				"string.prototype.trimright": "^2.1.0"
 			}
 		},
 		"es-to-primitive": {
@@ -4754,13 +4804,13 @@
 			}
 		},
 		"es6-symbol": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-			"integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.2.tgz",
+			"integrity": "sha512-/ZypxQsArlv+KHpGvng52/Iz8by3EQPxhmbuz8yFG89N/caTFBSbcXONDw0aMjy827gQg26XAjP4uXFvnfINmQ==",
 			"dev": true,
 			"requires": {
-				"d": "1",
-				"es5-ext": "~0.10.14"
+				"d": "^1.0.1",
+				"es5-ext": "^0.10.51"
 			}
 		},
 		"escape-html": {
@@ -4820,9 +4870,9 @@
 			},
 			"dependencies": {
 				"acorn-jsx": {
-					"version": "5.0.2",
-					"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.2.tgz",
-					"integrity": "sha512-tiNTrP1MP0QrChmD2DdupCr6HWSFeKVw5d/dHTu4Y7rkAkRhU/Dt7dphAfIUyxtHpl/eBVip5uTNSpQJHylpAw==",
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
+					"integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==",
 					"dev": true
 				},
 				"chardet": {
@@ -5223,9 +5273,9 @@
 			},
 			"dependencies": {
 				"acorn-jsx": {
-					"version": "5.0.2",
-					"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.2.tgz",
-					"integrity": "sha512-tiNTrP1MP0QrChmD2DdupCr6HWSFeKVw5d/dHTu4Y7rkAkRhU/Dt7dphAfIUyxtHpl/eBVip5uTNSpQJHylpAw==",
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
+					"integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==",
 					"dev": true
 				},
 				"espree": {
@@ -5266,12 +5316,12 @@
 			}
 		},
 		"eslint-utils": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
-			"integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+			"integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
 			"dev": true,
 			"requires": {
-				"eslint-visitor-keys": "^1.0.0"
+				"eslint-visitor-keys": "^1.1.0"
 			}
 		},
 		"eslint-visitor-keys": {
@@ -5349,9 +5399,9 @@
 			"dev": true
 		},
 		"eventemitter3": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-			"integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
+			"integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg==",
 			"dev": true
 		},
 		"events": {
@@ -5817,9 +5867,9 @@
 			},
 			"dependencies": {
 				"is-buffer": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
-					"integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+					"integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
 					"dev": true
 				}
 			}
@@ -5878,9 +5928,9 @@
 			"dev": true
 		},
 		"follow-redirects": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.8.1.tgz",
-			"integrity": "sha512-micCIbldHioIegeKs41DoH0KS3AXfFzgS30qVkM6z/XOE/GJgvmsoc839NUqa1B9udYe9dQxgv7KFwng6+p/dw==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.9.0.tgz",
+			"integrity": "sha512-CRcPzsSIbXyVDl0QI01muNDu69S8trU4jArW9LpOt2WtC6LyUJetcIrmfHsRBx7/Jb6GHJUiuqyYxPooFfNt6A==",
 			"dev": true,
 			"requires": {
 				"debug": "^3.0.0"
@@ -6573,9 +6623,9 @@
 			"dev": true
 		},
 		"get-own-enumerable-property-symbols": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.0.tgz",
-			"integrity": "sha512-CIJYJC4GGF06TakLg8z4GQKvDsx9EMspVxOYih7LerEL/WosUnFIww45CGfxfeKHqlg3twgUrYRT1O3WQqjGCg==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.1.tgz",
+			"integrity": "sha512-09/VS4iek66Dh2bctjRkowueRJbY1JDGR1L/zRxO1Qk8Uxs6PnqaNSqalpizPT+CDjre3hnEsuzvhgomz9qYrA==",
 			"dev": true
 		},
 		"get-stdin": {
@@ -6609,9 +6659,9 @@
 			}
 		},
 		"glob": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-			"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+			"version": "7.1.5",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+			"integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
 			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
@@ -6708,9 +6758,9 @@
 			"dev": true
 		},
 		"handlebars": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-			"integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+			"version": "4.4.5",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.5.tgz",
+			"integrity": "sha512-0Ce31oWVB7YidkaTq33ZxEbN+UDxMMgThvCe8ptgQViymL5DPis9uLdTA13MiRPhgvqyxIegugrP97iK3JeBHg==",
 			"dev": true,
 			"requires": {
 				"neo-async": "^2.6.0",
@@ -6898,9 +6948,9 @@
 			"dev": true
 		},
 		"hosted-git-info": {
-			"version": "2.8.4",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
-			"integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==",
+			"version": "2.8.5",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
+			"integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
 			"dev": true
 		},
 		"hpack.js": {
@@ -7076,12 +7126,12 @@
 			"dev": true
 		},
 		"http-proxy": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
-			"integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
+			"version": "1.18.0",
+			"resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.0.tgz",
+			"integrity": "sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==",
 			"dev": true,
 			"requires": {
-				"eventemitter3": "^3.0.0",
+				"eventemitter3": "^4.0.0",
 				"follow-redirects": "^1.0.0",
 				"requires-port": "^1.0.0"
 			}
@@ -7113,6 +7163,12 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
 			"integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
+			"dev": true
+		},
+		"human-signals": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+			"integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
 			"dev": true
 		},
 		"iconv-lite": {
@@ -7744,17 +7800,6 @@
 				"make-dir": "^2.1.0",
 				"minimatch": "^3.0.4",
 				"once": "^1.4.0"
-			},
-			"dependencies": {
-				"async": {
-					"version": "2.6.3",
-					"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-					"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-					"dev": true,
-					"requires": {
-						"lodash": "^4.17.14"
-					}
-				}
 			}
 		},
 		"istanbul-lib-coverage": {
@@ -7939,9 +7984,9 @@
 			"dev": true
 		},
 		"json5": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
-			"integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
+			"integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
 			"dev": true,
 			"requires": {
 				"minimist": "^1.2.0"
@@ -7975,9 +8020,9 @@
 			"dev": true
 		},
 		"karma": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/karma/-/karma-4.3.0.tgz",
-			"integrity": "sha512-NSPViHOt+RW38oJklvYxQC4BSQsv737oQlr/r06pCM+slDOr4myuI1ivkRmp+3dVpJDfZt2DmaPJ2wkx+ZZuMQ==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/karma/-/karma-4.4.1.tgz",
+			"integrity": "sha512-L5SIaXEYqzrh6b1wqYC42tNsFMx2PWuxky84pK9coK09MvmL7mxii3G3bZBh/0rvD27lqDd0le9jyhzvwif73A==",
 			"dev": true,
 			"requires": {
 				"bluebird": "^3.3.0",
@@ -7986,7 +8031,6 @@
 				"chokidar": "^3.0.0",
 				"colors": "^1.1.0",
 				"connect": "^3.6.0",
-				"core-js": "^3.1.3",
 				"di": "^0.0.1",
 				"dom-serialize": "^2.2.0",
 				"flatted": "^2.0.0",
@@ -8010,9 +8054,9 @@
 			},
 			"dependencies": {
 				"anymatch": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.0.tgz",
-					"integrity": "sha512-Ozz7l4ixzI7Oxj2+cw+p0tVUt27BpaJ+1+q1TCeANWxHpvyn2+Un+YamBdfKu0uh8xLodGhoa1v7595NhKDAuA==",
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+					"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
 					"dev": true,
 					"requires": {
 						"normalize-path": "^3.0.0",
@@ -8035,26 +8079,20 @@
 					}
 				},
 				"chokidar": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.0.2.tgz",
-					"integrity": "sha512-c4PR2egjNjI1um6bamCQ6bUNPDiyofNQruHvKgHQ4gDUP/ITSVSzNsiI5OWtHOsX323i5ha/kk4YmOZ1Ktg7KA==",
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.2.2.tgz",
+					"integrity": "sha512-bw3pm7kZ2Wa6+jQWYP/c7bAZy3i4GwiIiMO2EeRjrE48l8vBqC/WvFhSF0xyM8fQiPEGvwMY/5bqDG7sSEOuhg==",
 					"dev": true,
 					"requires": {
-						"anymatch": "^3.0.1",
-						"braces": "^3.0.2",
-						"fsevents": "^2.0.6",
-						"glob-parent": "^5.0.0",
-						"is-binary-path": "^2.1.0",
-						"is-glob": "^4.0.1",
-						"normalize-path": "^3.0.0",
-						"readdirp": "^3.1.1"
+						"anymatch": "~3.1.1",
+						"braces": "~3.0.2",
+						"fsevents": "~2.1.1",
+						"glob-parent": "~5.1.0",
+						"is-binary-path": "~2.1.0",
+						"is-glob": "~4.0.1",
+						"normalize-path": "~3.0.0",
+						"readdirp": "~3.2.0"
 					}
-				},
-				"core-js": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz",
-					"integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw==",
-					"dev": true
 				},
 				"fill-range": {
 					"version": "7.0.1",
@@ -8066,16 +8104,16 @@
 					}
 				},
 				"fsevents": {
-					"version": "2.0.7",
-					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.0.7.tgz",
-					"integrity": "sha512-a7YT0SV3RB+DjYcppwVDLtn13UQnmg0SWZS7ezZD0UjnLwXmy8Zm21GMVGLaFGimIqcvyMQaOJBrop8MyOp1kQ==",
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.1.tgz",
+					"integrity": "sha512-4FRPXWETxtigtJW/gxzEDsX1LVbPAM93VleB83kZB+ellqbHMkyt2aJfuzNLRvFPnGi6bcE5SvfxgbXPeKteJw==",
 					"dev": true,
 					"optional": true
 				},
 				"glob-parent": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.0.0.tgz",
-					"integrity": "sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==",
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+					"integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
 					"dev": true,
 					"requires": {
 						"is-glob": "^4.0.1"
@@ -8097,9 +8135,9 @@
 					"dev": true
 				},
 				"readdirp": {
-					"version": "3.1.2",
-					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.1.2.tgz",
-					"integrity": "sha512-8rhl0xs2cxfVsqzreYCvs8EwBfn/DhVdqtoLmw19uI3SC5avYX9teCurlErfpPXGmYtMHReGaP2RsLnFvz/lnw==",
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
+					"integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
 					"dev": true,
 					"requires": {
 						"picomatch": "^2.0.4"
@@ -8189,15 +8227,6 @@
 				"webpack-dev-middleware": "^2.0.6"
 			},
 			"dependencies": {
-				"async": {
-					"version": "2.6.3",
-					"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-					"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-					"dev": true,
-					"requires": {
-						"lodash": "^4.17.14"
-					}
-				},
 				"webpack-dev-middleware": {
 					"version": "2.0.6",
 					"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-2.0.6.tgz",
@@ -8799,9 +8828,9 @@
 			}
 		},
 		"loglevel": {
-			"version": "1.6.3",
-			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.3.tgz",
-			"integrity": "sha512-LoEDv5pgpvWgPF4kNYuIp0qqSJVWak/dML0RY74xlzMZiT9w77teNAwKYKWBTYjlokMirg+o3jBwp+vlLrcfAA==",
+			"version": "1.6.4",
+			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.4.tgz",
+			"integrity": "sha512-p0b6mOGKcGa+7nnmKbpzR6qloPbrgLcnio++E+14Vo/XffOGwZtRpUhr8dTH/x2oCMmEoIU0Zwm3ZauhvYD17g==",
 			"dev": true
 		},
 		"loglevelnext": {
@@ -8985,9 +9014,9 @@
 			"dev": true
 		},
 		"merge2": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.4.tgz",
-			"integrity": "sha512-FYE8xI+6pjFOhokZu0We3S5NKCirLbCzSh2Usf3qEyr4X8U+0jNg9P8RZ4qz+V2UoECLVwSyzU3LxXBaLGtD3A==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
+			"integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
 			"dev": true
 		},
 		"methods": {
@@ -9055,26 +9084,27 @@
 			"dev": true
 		},
 		"mini-css-extract-plugin": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.6.0.tgz",
-			"integrity": "sha512-79q5P7YGI6rdnVyIAV4NXpBQJFWdkzJxCim3Kog4078fM0piAaFlwocqbejdWtLW1cEzCexPrh6EdyFsPgVdAw==",
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.8.0.tgz",
+			"integrity": "sha512-MNpRGbNA52q6U92i0qbVpQNsgk7LExy41MdAlG84FeytfDOtRIf/mCHdEgG8rpTKOaNKiqUnZdlptF469hxqOw==",
 			"dev": true,
 			"requires": {
 				"loader-utils": "^1.1.0",
-				"normalize-url": "^2.0.1",
+				"normalize-url": "1.9.1",
 				"schema-utils": "^1.0.0",
 				"webpack-sources": "^1.1.0"
 			},
 			"dependencies": {
 				"normalize-url": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
-					"integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
+					"version": "1.9.1",
+					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
+					"integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
 					"dev": true,
 					"requires": {
-						"prepend-http": "^2.0.0",
-						"query-string": "^5.0.1",
-						"sort-keys": "^2.0.0"
+						"object-assign": "^4.0.1",
+						"prepend-http": "^1.0.0",
+						"query-string": "^4.1.0",
+						"sort-keys": "^1.0.0"
 					}
 				}
 			}
@@ -9163,9 +9193,9 @@
 			}
 		},
 		"mocha": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.0.tgz",
-			"integrity": "sha512-qwfFgY+7EKAAUAdv7VYMZQknI7YJSGesxHyhn6qD52DV8UcSZs5XwCifcZGMVIE4a5fbmhvbotxC0DLQ0oKohQ==",
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.2.tgz",
+			"integrity": "sha512-FgDS9Re79yU1xz5d+C4rv1G7QagNGHZ+iXF81hO8zY35YZZcLEsJVfFolfsqKFWunATEvNzMK0r/CwWd/szO9A==",
 			"dev": true,
 			"requires": {
 				"ansi-colors": "3.2.3",
@@ -9188,9 +9218,9 @@
 				"supports-color": "6.0.0",
 				"which": "1.3.1",
 				"wide-align": "1.1.3",
-				"yargs": "13.2.2",
-				"yargs-parser": "13.0.0",
-				"yargs-unparser": "1.5.0"
+				"yargs": "13.3.0",
+				"yargs-parser": "13.1.1",
+				"yargs-unparser": "1.6.0"
 			},
 			"dependencies": {
 				"ansi-colors": {
@@ -9198,35 +9228,6 @@
 					"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
 					"integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
 					"dev": true
-				},
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
-				},
-				"cliui": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
-					"dev": true,
-					"requires": {
-						"string-width": "^2.1.1",
-						"strip-ansi": "^4.0.0",
-						"wrap-ansi": "^2.0.0"
-					},
-					"dependencies": {
-						"string-width": {
-							"version": "2.1.1",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-							"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-							"dev": true,
-							"requires": {
-								"is-fullwidth-code-point": "^2.0.0",
-								"strip-ansi": "^4.0.0"
-							}
-						}
-					}
 				},
 				"debug": {
 					"version": "3.2.6",
@@ -9300,43 +9301,6 @@
 					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 					"dev": true
 				},
-				"string-width": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^7.0.1",
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^5.1.0"
-					},
-					"dependencies": {
-						"ansi-regex": {
-							"version": "4.1.0",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-							"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-							"dev": true
-						},
-						"strip-ansi": {
-							"version": "5.2.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-							"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-							"dev": true,
-							"requires": {
-								"ansi-regex": "^4.1.0"
-							}
-						}
-					}
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				},
 				"supports-color": {
 					"version": "6.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
@@ -9344,82 +9308,6 @@
 					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
-					}
-				},
-				"wrap-ansi": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-					"dev": true,
-					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1"
-					},
-					"dependencies": {
-						"ansi-regex": {
-							"version": "2.1.1",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-							"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-							"dev": true
-						},
-						"is-fullwidth-code-point": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-							"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-							"dev": true,
-							"requires": {
-								"number-is-nan": "^1.0.0"
-							}
-						},
-						"string-width": {
-							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-							"dev": true,
-							"requires": {
-								"code-point-at": "^1.0.0",
-								"is-fullwidth-code-point": "^1.0.0",
-								"strip-ansi": "^3.0.0"
-							}
-						},
-						"strip-ansi": {
-							"version": "3.0.1",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-							"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-							"dev": true,
-							"requires": {
-								"ansi-regex": "^2.0.0"
-							}
-						}
-					}
-				},
-				"yargs": {
-					"version": "13.2.2",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.2.tgz",
-					"integrity": "sha512-WyEoxgyTD3w5XRpAQNYUB9ycVH/PQrToaTXdYXRdOXvEy1l19br+VJsc0vcO8PTGg5ro/l/GY7F/JMEBmI0BxA==",
-					"dev": true,
-					"requires": {
-						"cliui": "^4.0.0",
-						"find-up": "^3.0.0",
-						"get-caller-file": "^2.0.1",
-						"os-locale": "^3.1.0",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^2.0.0",
-						"set-blocking": "^2.0.0",
-						"string-width": "^3.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^4.0.0",
-						"yargs-parser": "^13.0.0"
-					}
-				},
-				"yargs-parser": {
-					"version": "13.0.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.0.0.tgz",
-					"integrity": "sha512-w2LXjoL8oRdRQN+hOyppuXs+V/fVAYtpcrRxZuF7Kt/Oc+Jr2uAcVntaUTNT6w5ihoWfFDpNY8CPx1QskxZ/pw==",
-					"dev": true,
-					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
 					}
 				}
 			}
@@ -9598,9 +9486,9 @@
 			}
 		},
 		"node-forge": {
-			"version": "0.7.5",
-			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.5.tgz",
-			"integrity": "sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ==",
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
+			"integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==",
 			"dev": true
 		},
 		"node-ipc": {
@@ -9654,12 +9542,20 @@
 			}
 		},
 		"node-releases": {
-			"version": "1.1.29",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.29.tgz",
-			"integrity": "sha512-R5bDhzh6I+tpi/9i2hrrvGJ3yKPYzlVOORDkXhnZuwi5D3q1I5w4vYy24PJXTcLk9Q0kws9TO77T75bcK8/ysQ==",
+			"version": "1.1.38",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.38.tgz",
+			"integrity": "sha512-/5NZAaOyTj134Oy5Cp/J8mso8OD/D9CSuL+6TOXXsTKO8yjc5e4up75SRPCganCjwFKMj2jbp5tR0dViVdox7g==",
 			"dev": true,
 			"requires": {
-				"semver": "^5.3.0"
+				"semver": "^6.3.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
 			}
 		},
 		"normalize-package-data": {
@@ -10084,12 +9980,12 @@
 			"dev": true
 		},
 		"parallel-transform": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
-			"integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.2.0.tgz",
+			"integrity": "sha512-P2vSmIu38uIlvdcU7fDkyrxj33gTUy/ABO5ZUbGowxNCopBq/OoD42bP4UmMrJoPyk4Uqf0mu3mtWBhHCZD8yg==",
 			"dev": true,
 			"requires": {
-				"cyclist": "~0.2.2",
+				"cyclist": "^1.0.1",
 				"inherits": "^2.0.3",
 				"readable-stream": "^2.1.5"
 			}
@@ -10121,9 +10017,9 @@
 			}
 		},
 		"parse-asn1": {
-			"version": "5.1.4",
-			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.4.tgz",
-			"integrity": "sha512-Qs5duJcuvNExRfFZ99HDD3z4mAi3r9Wl/FOjEOijlxwCZs7E7mW2vjTpgQ4J8LpTF8x5v+1Vn5UQFejmWT11aw==",
+			"version": "5.1.5",
+			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
+			"integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
 			"dev": true,
 			"requires": {
 				"asn1.js": "^4.0.0",
@@ -10376,31 +10272,30 @@
 			"dev": true,
 			"optional": true
 		},
+		"popper.js": {
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.0.tgz",
+			"integrity": "sha512-+G+EkOPoE5S/zChTpmBSSDYmhXJ5PsW8eMhH8cP/CQHMFPBG/kC9Y5IIw6qNYgdJ+/COf0ddY2li28iHaZRSjw=="
+		},
 		"portfinder": {
-			"version": "1.0.23",
-			"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.23.tgz",
-			"integrity": "sha512-B729mL/uLklxtxuiJKfQ84WPxNw5a7Yhx3geQZdcA4GjNjZSTSSMMWyoennMVnTWSmAR0lMdzWYN0JLnHrg1KQ==",
+			"version": "1.0.25",
+			"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.25.tgz",
+			"integrity": "sha512-6ElJnHBbxVA1XSLgBp7G1FiCkQdlqGzuF7DswL5tcea+E8UpuvPU7beVAjjRwCioTS9ZluNbu+ZyRvgTsmqEBg==",
 			"dev": true,
 			"requires": {
-				"async": "^1.5.2",
-				"debug": "^2.2.0",
-				"mkdirp": "0.5.x"
+				"async": "^2.6.2",
+				"debug": "^3.1.1",
+				"mkdirp": "^0.5.1"
 			},
 			"dependencies": {
 				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
 					"dev": true,
 					"requires": {
-						"ms": "2.0.0"
+						"ms": "^2.1.1"
 					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
 				}
 			}
 		},
@@ -10411,9 +10306,9 @@
 			"dev": true
 		},
 		"postcss": {
-			"version": "7.0.17",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.17.tgz",
-			"integrity": "sha512-546ZowA+KZ3OasvQZHsbuEpysvwTZNGJv9EfyCQdsIDltPSWHAeTQ5fQy/Npi2ZDtLI3zs7Ps/p6wThErhm9fQ==",
+			"version": "7.0.18",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.18.tgz",
+			"integrity": "sha512-/7g1QXXgegpF+9GJj4iN7ChGF40sYuGYJ8WZu8DZWnmhQ/G36hfdk3q9LBJmoK+lZ+yzZ5KYpOoxq7LF1BxE8g==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.4.2",
@@ -10927,9 +10822,9 @@
 			"dev": true
 		},
 		"prepend-http": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-			"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
 			"dev": true
 		},
 		"prettier": {
@@ -11023,9 +10918,9 @@
 			"dev": true
 		},
 		"psl": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.3.1.tgz",
-			"integrity": "sha512-2KLd5fKOdAfShtY2d/8XDWVRnmp3zp40Qt6ge2zBPFARLXOGUf2fHD5eg+TV/5oxBtQKVhjUaKFsAaE4HnwfSA==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
+			"integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw==",
 			"dev": true
 		},
 		"public-encrypt": {
@@ -11100,12 +10995,11 @@
 			"dev": true
 		},
 		"query-string": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
-			"integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+			"integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
 			"dev": true,
 			"requires": {
-				"decode-uri-component": "^0.2.0",
 				"object-assign": "^4.1.0",
 				"strict-uri-encode": "^1.0.0"
 			}
@@ -11295,12 +11189,6 @@
 				"safe-regex": "^1.1.0"
 			}
 		},
-		"regexp-tree": {
-			"version": "0.1.13",
-			"resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.13.tgz",
-			"integrity": "sha512-hwdV/GQY5F8ReLZWO+W1SRoN5YfpOKY6852+tBFcma72DKBIcHjPRIlIvQN35bCOljuAfP2G2iB0FC/w236mUw==",
-			"dev": true
-		},
 		"regexp.prototype.flags": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
@@ -11318,9 +11206,9 @@
 			"optional": true
 		},
 		"regexpu-core": {
-			"version": "4.5.5",
-			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.5.tgz",
-			"integrity": "sha512-FpI67+ky9J+cDizQUJlIlNZFKual/lUkFr1AG6zOCpwZ9cLrg8UUVakyUQJD7fCDIe9Z2nwTQJNPyonatNmDFQ==",
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.6.0.tgz",
+			"integrity": "sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==",
 			"dev": true,
 			"requires": {
 				"regenerate": "^1.4.0",
@@ -11332,9 +11220,9 @@
 			}
 		},
 		"regjsgen": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
-			"integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==",
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.1.tgz",
+			"integrity": "sha512-5qxzGZjDs9w4tzT3TPhCJqWdCc3RLYwy9J2NB0nm5Lz+S273lvWcpjaTGHsT1dc6Hhfq41uSEOw8wBmxrKOuyg==",
 			"dev": true
 		},
 		"regjsparser": {
@@ -11658,9 +11546,9 @@
 			}
 		},
 		"rxjs": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
-			"integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
+			"integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.9.0"
@@ -11711,12 +11599,12 @@
 			"dev": true
 		},
 		"selfsigned": {
-			"version": "1.10.4",
-			"resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.4.tgz",
-			"integrity": "sha512-9AukTiDmHXGXWtWjembZ5NDmVvP2695EtpgbCsxCa68w3c88B+alqbmZ4O3hZ4VWGXeGWzEVdvqgAJD8DQPCDw==",
+			"version": "1.10.7",
+			"resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.7.tgz",
+			"integrity": "sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==",
 			"dev": true,
 			"requires": {
-				"node-forge": "0.7.5"
+				"node-forge": "0.9.0"
 			}
 		},
 		"semver": {
@@ -11784,9 +11672,9 @@
 			}
 		},
 		"serialize-javascript": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.0.tgz",
-			"integrity": "sha512-UkGlcYMtw4d9w7YfCtJFgdRTps8N4L0A48R+SmcGL57ki1+yHwJXnalk5bjgrw+ljv6SfzjzPjhohod2qllg/Q==",
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
+			"integrity": "sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==",
 			"dev": true
 		},
 		"serve-index": {
@@ -11962,9 +11850,9 @@
 			}
 		},
 		"sinon": {
-			"version": "7.4.2",
-			"resolved": "https://registry.npmjs.org/sinon/-/sinon-7.4.2.tgz",
-			"integrity": "sha512-pY5RY99DKelU3pjNxcWo6XqeB1S118GBcVIIdDi6V+h6hevn1izcg2xv1hTHW/sViRXU7sUOxt4wTUJ3gsW2CQ==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/sinon/-/sinon-7.5.0.tgz",
+			"integrity": "sha512-AoD0oJWerp0/rY9czP/D6hDTTUYGpObhZjMpd7Cl/A6+j0xBE+ayL/ldfggkBXUs0IkvIiM1ljM8+WkOc5k78Q==",
 			"dev": true,
 			"requires": {
 				"@sinonjs/commons": "^1.4.0",
@@ -12247,9 +12135,9 @@
 			}
 		},
 		"sockjs-client": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.3.0.tgz",
-			"integrity": "sha512-R9jxEzhnnrdxLCNln0xg5uGHqMnkhPSTzUZH2eXcR03S/On9Yvoq2wyUZILRUhZCNVu2PmwWVoyuiPz8th8zbg==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.4.0.tgz",
+			"integrity": "sha512-5zaLyO8/nri5cua0VtOrFXBPK1jbL4+1cebT/mmKA1E1ZXOvJrII75bPu0l0k843G/+iAbhEqzyKr0w/eCCj7g==",
 			"dev": true,
 			"requires": {
 				"debug": "^3.2.5",
@@ -12281,9 +12169,9 @@
 			}
 		},
 		"sort-keys": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
-			"integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+			"integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
 			"dev": true,
 			"requires": {
 				"is-plain-obj": "^1.0.0"
@@ -12458,9 +12346,9 @@
 			"dev": true
 		},
 		"stackframe": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.0.4.tgz",
-			"integrity": "sha512-to7oADIniaYwS3MhtCa/sQhrxidCCQiF/qp4/m5iN3ipf0Y7Xlri0f6eG29r08aL7JYl8n32AF3Q5GYBZ7K8vw==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.1.0.tgz",
+			"integrity": "sha512-Vx6W1Yvy+AM1R/ckVwcHQHV147pTPBKWCRLrXMuPrFVfvBUc3os7PR1QLIWCMhPpRg5eX9ojzbQIMLGBwyLjqg==",
 			"dev": true
 		},
 		"staged-git-files": {
@@ -12554,15 +12442,6 @@
 				"lodash": "^4.17.14"
 			},
 			"dependencies": {
-				"async": {
-					"version": "2.6.3",
-					"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-					"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-					"dev": true,
-					"requires": {
-						"lodash": "^4.17.14"
-					}
-				},
 				"debug": {
 					"version": "3.2.6",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -12636,23 +12515,23 @@
 			}
 		},
 		"string.prototype.trimleft": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.0.0.tgz",
-			"integrity": "sha1-aLaqjhYsaoDnbjqKDC50cYbicf8=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
+			"integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"function-bind": "^1.0.2"
+				"define-properties": "^1.1.3",
+				"function-bind": "^1.1.1"
 			}
 		},
 		"string.prototype.trimright": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.0.0.tgz",
-			"integrity": "sha1-q0pW2AKgH75yk+EehPJNyBZGYd0=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
+			"integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"function-bind": "^1.0.2"
+				"define-properties": "^1.1.3",
+				"function-bind": "^1.1.1"
 			}
 		},
 		"string_decoder": {
@@ -12781,9 +12660,9 @@
 			"dev": true
 		},
 		"synchronous-promise": {
-			"version": "2.0.9",
-			"resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.9.tgz",
-			"integrity": "sha512-LO95GIW16x69LuND1nuuwM4pjgFGupg7pZ/4lU86AmchPKrhk0o2tpMU2unXRrqo81iAFe1YJ0nAGEVwsrZAgg==",
+			"version": "2.0.10",
+			"resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.10.tgz",
+			"integrity": "sha512-6PC+JRGmNjiG3kJ56ZMNWDPL8hjyghF5cMXIFOKg+NiwwEZZIvxTWd0pinWKyD227odg9ygF8xVhhz7gb8Uq7A==",
 			"dev": true
 		},
 		"table": {
@@ -12844,9 +12723,9 @@
 			"dev": true
 		},
 		"terser": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-4.2.1.tgz",
-			"integrity": "sha512-cGbc5utAcX4a9+2GGVX4DsenG6v0x3glnDi5hx8816X1McEAwPlPgRtXPJzSBsbpILxZ8MQMT0KvArLuE0HP5A==",
+			"version": "4.3.9",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-4.3.9.tgz",
+			"integrity": "sha512-NFGMpHjlzmyOtPL+fDw3G7+6Ueh/sz4mkaUYa4lJCxOPTNzd0Uj0aZJOmsDYoSQyfuVoWDMSWTPU3huyOm2zdA==",
 			"dev": true,
 			"requires": {
 				"commander": "^2.20.0",
@@ -12983,11 +12862,6 @@
 				}
 			}
 		},
-		"tether": {
-			"version": "1.4.7",
-			"resolved": "https://registry.npmjs.org/tether/-/tether-1.4.7.tgz",
-			"integrity": "sha512-Z0J1aExjoFU8pybVkQAo/vD2wfSO63r+XOPfWQMC5qtf1bI7IWqNk4MiyBcgvvnY8kqnY06dVdvwTK2S3PU/Fw=="
-		},
 		"text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -13040,9 +12914,9 @@
 			}
 		},
 		"thunky": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/thunky/-/thunky-1.0.3.tgz",
-			"integrity": "sha512-YwT8pjmNcAXBZqrubu22P4FYsh2D4dxRmnWBOL8Jk8bUcRUtc5326kx32tuTmFDAZtLOGEVNl8POAR8j896Iow==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
+			"integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
 			"dev": true
 		},
 		"timers-browserify": {
@@ -13159,12 +13033,6 @@
 				}
 			}
 		},
-		"trim-right": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-			"dev": true
-		},
 		"tryer": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
@@ -13199,9 +13067,9 @@
 			"dev": true
 		},
 		"type": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/type/-/type-1.0.3.tgz",
-			"integrity": "sha512-51IMtNfVcee8+9GJvj0spSuFcZHe9vSib6Xtgsny1Km9ugyz2mbS08I3rsUIRYgJohFRFU1160sgRodYz378Hg==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+			"integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
 			"dev": true
 		},
 		"type-check": {
@@ -13656,9 +13524,9 @@
 			}
 		},
 		"vue-hot-reload-api": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.3.3.tgz",
-			"integrity": "sha512-KmvZVtmM26BQOMK1rwUZsrqxEGeKiYSZGA7SNWE6uExx8UX/cj9hq2MRV/wWC3Cq6AoeDGk57rL9YMFRel/q+g==",
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz",
+			"integrity": "sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog==",
 			"dev": true
 		},
 		"vue-loader": {
@@ -13736,9 +13604,9 @@
 			}
 		},
 		"webpack": {
-			"version": "4.39.3",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.39.3.tgz",
-			"integrity": "sha512-BXSI9M211JyCVc3JxHWDpze85CvjC842EvpRsVTc/d15YJGlox7GIDd38kJgWrb3ZluyvIjgenbLDMBQPDcxYQ==",
+			"version": "4.41.2",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.2.tgz",
+			"integrity": "sha512-Zhw69edTGfbz9/8JJoyRQ/pq8FYUoY0diOXqW0T6yhgdhCv6wr0hra5DwwWexNRns2Z2+gsnrNcbe9hbGBgk/A==",
 			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.8.5",
@@ -13767,9 +13635,9 @@
 			}
 		},
 		"webpack-bundle-analyzer": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.4.1.tgz",
-			"integrity": "sha512-Bs8D/1zF+17lhqj2OYmzi7HEVYqEVxu7lCO9Ff8BwajenOU0vAwEoV8e4ICCPNZAcqR1PCR/7o2SkW+cnCmF0A==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.6.0.tgz",
+			"integrity": "sha512-orUfvVYEfBMDXgEKAKVvab5iQ2wXneIEorGNsyuOyVYpjYrI7CUOhhXNDd3huMwQ3vNNWWlGP+hzflMFYNzi2g==",
 			"dev": true,
 			"requires": {
 				"acorn": "^6.0.7",
@@ -13798,53 +13666,54 @@
 			}
 		},
 		"webpack-dev-middleware": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.0.tgz",
-			"integrity": "sha512-qvDesR1QZRIAZHOE3iQ4CXLZZSQ1lAUsSpnQmlB1PBfoN/xdRjmge3Dok0W4IdaVLJOGJy3sGI4sZHwjRU0PCA==",
+			"version": "3.7.2",
+			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.2.tgz",
+			"integrity": "sha512-1xC42LxbYoqLNAhV6YzTYacicgMZQTqRd27Sim9wn5hJrX3I5nxYy1SxSd4+gjUFsz1dQFj+yEe6zEVmSkeJjw==",
 			"dev": true,
 			"requires": {
 				"memory-fs": "^0.4.1",
-				"mime": "^2.4.2",
+				"mime": "^2.4.4",
+				"mkdirp": "^0.5.1",
 				"range-parser": "^1.2.1",
 				"webpack-log": "^2.0.0"
 			}
 		},
 		"webpack-dev-server": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.8.0.tgz",
-			"integrity": "sha512-Hs8K9yI6pyMvGkaPTeTonhD6JXVsigXDApYk9JLW4M7viVBspQvb1WdAcWxqtmttxNW4zf2UFLsLNe0y87pIGQ==",
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.9.0.tgz",
+			"integrity": "sha512-E6uQ4kRrTX9URN9s/lIbqTAztwEPdvzVrcmHE8EQ9YnuT9J8Es5Wrd8n9BKg1a0oZ5EgEke/EQFgUsp18dSTBw==",
 			"dev": true,
 			"requires": {
 				"ansi-html": "0.0.7",
 				"bonjour": "^3.5.0",
-				"chokidar": "^2.1.6",
+				"chokidar": "^2.1.8",
 				"compression": "^1.7.4",
 				"connect-history-api-fallback": "^1.6.0",
 				"debug": "^4.1.1",
 				"del": "^4.1.1",
 				"express": "^4.17.1",
 				"html-entities": "^1.2.1",
-				"http-proxy-middleware": "^0.19.1",
+				"http-proxy-middleware": "0.19.1",
 				"import-local": "^2.0.0",
 				"internal-ip": "^4.3.0",
 				"ip": "^1.1.5",
-				"is-absolute-url": "^3.0.0",
+				"is-absolute-url": "^3.0.3",
 				"killable": "^1.0.1",
-				"loglevel": "^1.6.3",
+				"loglevel": "^1.6.4",
 				"opn": "^5.5.0",
 				"p-retry": "^3.0.1",
-				"portfinder": "^1.0.21",
+				"portfinder": "^1.0.25",
 				"schema-utils": "^1.0.0",
-				"selfsigned": "^1.10.4",
+				"selfsigned": "^1.10.7",
 				"semver": "^6.3.0",
 				"serve-index": "^1.9.1",
 				"sockjs": "0.3.19",
-				"sockjs-client": "1.3.0",
+				"sockjs-client": "1.4.0",
 				"spdy": "^4.0.1",
 				"strip-ansi": "^3.0.1",
 				"supports-color": "^6.1.0",
 				"url": "^0.11.0",
-				"webpack-dev-middleware": "^3.7.0",
+				"webpack-dev-middleware": "^3.7.2",
 				"webpack-log": "^2.0.0",
 				"ws": "^6.2.1",
 				"yargs": "12.0.5"
@@ -13900,9 +13769,9 @@
 					"dev": true
 				},
 				"is-absolute-url": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.1.tgz",
-					"integrity": "sha512-c2QjUwuMxLsld90sj3xYzpFYWJtuxkIn1f5ua9RTEYJt/vV2IsM+Py00/6qjV7qExgifUvt7qfyBGBBKm+2iBg==",
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.3.tgz",
+					"integrity": "sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q==",
 					"dev": true
 				},
 				"is-fullwidth-code-point": {
@@ -14194,9 +14063,9 @@
 			"dev": true
 		},
 		"yallist": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-			"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
 			"dev": true
 		},
 		"yargs": {
@@ -14284,174 +14153,14 @@
 			}
 		},
 		"yargs-unparser": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.5.0.tgz",
-			"integrity": "sha512-HK25qidFTCVuj/D1VfNiEndpLIeJN78aqgR23nL3y4N0U/91cOAzqfHlF8n2BvoNDcZmJKin3ddNSvOxSr8flw==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
+			"integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
 			"dev": true,
 			"requires": {
 				"flat": "^4.1.0",
-				"lodash": "^4.17.11",
-				"yargs": "^12.0.5"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
-				},
-				"cliui": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
-					"dev": true,
-					"requires": {
-						"string-width": "^2.1.1",
-						"strip-ansi": "^4.0.0",
-						"wrap-ansi": "^2.0.0"
-					}
-				},
-				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
-				"get-caller-file": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-					"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
-					"dev": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
-					"integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
-					"dev": true,
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.0.0"
-					}
-				},
-				"p-try": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-					"dev": true
-				},
-				"require-main-filename": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-					"dev": true
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				},
-				"wrap-ansi": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-					"dev": true,
-					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1"
-					},
-					"dependencies": {
-						"ansi-regex": {
-							"version": "2.1.1",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-							"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-							"dev": true
-						},
-						"string-width": {
-							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-							"dev": true,
-							"requires": {
-								"code-point-at": "^1.0.0",
-								"is-fullwidth-code-point": "^1.0.0",
-								"strip-ansi": "^3.0.0"
-							}
-						},
-						"strip-ansi": {
-							"version": "3.0.1",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-							"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-							"dev": true,
-							"requires": {
-								"ansi-regex": "^2.0.0"
-							}
-						}
-					}
-				},
-				"yargs": {
-					"version": "12.0.5",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-					"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
-					"dev": true,
-					"requires": {
-						"cliui": "^4.0.0",
-						"decamelize": "^1.2.0",
-						"find-up": "^3.0.0",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^3.0.0",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^2.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^3.2.1 || ^4.0.0",
-						"yargs-parser": "^11.1.1"
-					}
-				},
-				"yargs-parser": {
-					"version": "11.1.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-					"integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
-					"dev": true,
-					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
-					}
-				}
+				"lodash": "^4.17.15",
+				"yargs": "^13.3.0"
 			}
 		},
 		"yeast": {

--- a/packages/veui/package.json
+++ b/packages/veui/package.json
@@ -19,8 +19,8 @@
     "bytes": "^3.0.0",
     "date-fns": "^1.29.0",
     "lodash": "^4.17.4",
+    "popper.js": "^1.16.0",
     "resize-detector": "^0.1.6",
-    "tether": "^1.4.5",
     "vue-awesome": "^3.3.1",
     "vue-directive-normalizer": "^0.1.0"
   },

--- a/packages/veui/src/components/Autocomplete/Autocomplete.vue
+++ b/packages/veui/src/components/Autocomplete/Autocomplete.vue
@@ -62,7 +62,7 @@
                 <mark
                   v-if="matched"
                   :key="`${idx}-${index}`"
-                  :class="$c('autocomplete-suggestion-matched')"
+                  :class="$c('option-matched')"
                 >{{ text }}</mark>
                 <span
                   v-else

--- a/packages/veui/src/components/RegionPicker.vue
+++ b/packages/veui/src/components/RegionPicker.vue
@@ -141,12 +141,8 @@
                 v-if="group.children && group.active"
                 :open.sync="group.active"
                 :overlay-class="overlayClass"
-                :target="`node-${si}-${bi}-${gi}`"
-                :options="{
-                  attachment: 'top left',
-                  targetAttachment: 'bottom left',
-                  constraints
-                }"
+                :target="`shadow-checker-${si}-${bi}-${gi}`"
+                position="bottom-start"
               >
                 <div
                   :id="`${id}-units`"
@@ -214,10 +210,7 @@
                   mergeOverlayClass($c('region-picker-group-shadow-overlay'))
                 "
                 :target="`node-${si}-${bi}-${gi}`"
-                :options="{
-                  attachment: 'top left',
-                  targetAttachment: 'top left'
-                }"
+                position="bottom-start"
               >
                 <div
                   :id="`${id}-shadow`"

--- a/packages/veui/src/components/Select/OptionGroup.vue
+++ b/packages/veui/src/components/Select/OptionGroup.vue
@@ -57,13 +57,7 @@ const OptionGroup = {
       items: [],
       expanded: false,
       localOverlayOptions: {
-        position: 'right-start',
-        constraints: [
-          {
-            to: 'window',
-            attachment: 'together'
-          }
-        ]
+        position: 'right-start'
       },
       outsideRefs: ['button'],
       popupId: uniqueId('veui-option-group-popup-')

--- a/packages/veui/src/components/Tooltip.vue
+++ b/packages/veui/src/components/Tooltip.vue
@@ -59,13 +59,7 @@ export default {
     return {
       localOpen: this.open,
       localOverlayOptions: {
-        position: this.position,
-        constraints: [
-          {
-            to: 'window',
-            attachment: 'together'
-          }
-        ]
+        position: this.position
       }
     }
   },

--- a/packages/veui/src/mixins/dropdown.js
+++ b/packages/veui/src/mixins/dropdown.js
@@ -11,13 +11,7 @@ export default {
     return {
       expanded: false,
       localOverlayOptions: {
-        position: 'bottom left',
-        constraints: [
-          {
-            to: 'window',
-            attachment: 'together'
-          }
-        ]
+        position: 'bottom-start'
       },
       dropdownId: uniqueId('veui-dropdown-')
     }

--- a/packages/veui/src/mixins/overlay.js
+++ b/packages/veui/src/mixins/overlay.js
@@ -1,9 +1,4 @@
-import {
-  mergeClasses,
-  getClassPropDef,
-  resolveOverlayPosition
-} from '../utils/helper'
-import { omit } from 'lodash'
+import { mergeClasses, getClassPropDef } from '../utils/helper'
 
 export default {
   props: {
@@ -22,15 +17,7 @@ export default {
   },
   computed: {
     realOverlayOptions () {
-      let options = { ...this.localOverlayOptions, ...this.overlayOptions }
-      let { position } = options
-      return omit(
-        {
-          ...options,
-          ...resolveOverlayPosition(position)
-        },
-        'position'
-      )
+      return { ...this.localOverlayOptions, ...this.overlayOptions }
     }
   },
   methods: {

--- a/packages/veui/src/utils/helper.js
+++ b/packages/veui/src/utils/helper.js
@@ -130,49 +130,6 @@ export function getClassPropDef () {
   return { ...CLASS_PROP_DEF }
 }
 
-const OPPOSITE = {
-  top: 'bottom',
-  right: 'left',
-  bottom: 'top',
-  left: 'right'
-}
-
-const ALIGN_HORIZONTAL = {
-  left: 'left',
-  start: 'left',
-  right: 'right',
-  end: 'right'
-}
-
-const ALIGN_VERTICAL = {
-  top: 'top',
-  start: 'top',
-  bottom: 'bottom',
-  end: 'bottom'
-}
-
-export function resolveOverlayPosition (position) {
-  if (!position) {
-    return {}
-  }
-
-  let [side, align] = position.split(/[-\s]+/)
-  side = side === 'auto' ? 'bottom' : side
-  let targetAttachment
-  let attachment
-  if (side === 'top' || side === 'bottom') {
-    targetAttachment = `${side} ${ALIGN_HORIZONTAL[align] || 'center'}`
-    attachment = `${OPPOSITE[side]} ${ALIGN_HORIZONTAL[align] || 'center'}`
-  } else {
-    targetAttachment = `${ALIGN_VERTICAL[align] || 'middle'} ${side}`
-    attachment = `${ALIGN_VERTICAL[align] || 'middle'} ${OPPOSITE[side]}`
-  }
-  return {
-    targetAttachment,
-    attachment
-  }
-}
-
 const RE_INDEX = /\d+/
 export function deepSet (obj, path, val) {
   let segments = path

--- a/packages/veui/test/unit/specs/utils/helper.spec.js
+++ b/packages/veui/test/unit/specs/utils/helper.spec.js
@@ -1,35 +1,8 @@
 import { mount } from '@vue/test-utils'
 import Button from '@/components/Button'
-import { resolveOverlayPosition, hasClass } from '@/utils/helper'
+import { hasClass } from '@/utils/helper'
 
 describe('utils/helper', () => {
-  it('should resolve Popper-style overlay position to Tether-style correctly', () => {
-    expect(resolveOverlayPosition('top-end')).to.deep.equal({
-      targetAttachment: 'top right',
-      attachment: 'bottom right'
-    })
-
-    expect(resolveOverlayPosition('right-start')).to.deep.equal({
-      targetAttachment: 'top right',
-      attachment: 'top left'
-    })
-
-    expect(resolveOverlayPosition('bottom')).to.deep.equal({
-      targetAttachment: 'bottom center',
-      attachment: 'top center'
-    })
-
-    expect(resolveOverlayPosition('auto-right')).to.deep.equal({
-      targetAttachment: 'bottom right',
-      attachment: 'top right'
-    })
-
-    expect(resolveOverlayPosition('right')).to.deep.equal({
-      targetAttachment: 'middle right',
-      attachment: 'middle left'
-    })
-  })
-
   it('should support checking class existence on vnodes', () => {
     let wrapper = mount({
       components: {


### PR DESCRIPTION
使用 Popper.js 替换 Tether。

- Tether 已经官宣不再维护，虽然 Popper.js 也没有得到太好的频繁维护，但是它仍然是 Bootstrap 依赖的浮层定位库，相比之下可靠性更可控一些。
- 因为 Popper.js 在前一个版本实现了 `flipVariationsByContent` 这个配置功能，使得浮层可以在次级方向上超出视窗时自动翻转方向，这样可以使 `RegionPicker`、`DatePicker` 这样的组件不需要用户来指定定位参数了。
- Tether 有一些初始化时定位的 bug，在 VEUI 之前版本的 Tooltip 等组件第一次展现时都遇到过定位不对的问题，切换后目测已经不再有此问题。
- DLS 版本的目标浏览器已经可以抛弃 IE10-，所以不再有 blocker issue 了。

### ⚠️ BREAKING CHANGE ⚠️

`Overlay` 组件的 `options` prop（以及多个组件的 `overlay-options` prop）现在都对应于[Popper.js 的 `options` 参数](https://popper.js.org/popper-documentation.html#new_Popper_new).

> 此 PR 将代替 #418。

---

#### Refs:

https://github.com/FezVrasta/popper.js/issues/512
https://github.com/FezVrasta/popper.js/pull/754
