### PR TITLE
refactor: rewrite overlay manager

### DIFF
--- a/packages/veui/src/managers/overlay.js
+++ b/packages/veui/src/managers/overlay.js
@@ -1,631 +1,246 @@
-import { remove, uniqueId, last, findLast, find, noop } from 'lodash'
+import { uniqueId, pull, findLastIndex } from 'lodash'
+import { walk } from '../utils/datasource'
+
+let nodeIndex = {}
 
 /**
- * 节点，每一个节点会拥有自己的 order 值
+ * Retrieve a node by id if given a string, otherwise return the given value
+ *
+ * @param {OverlayNode|string} node the node or its id
  */
-class Node {
+function getNode (node) {
+  if (typeof node === 'string') {
+    node = nodeIndex[node]
+
+    if (!node) {
+      throw new Error(`The given node id doesn't exist!`)
+    }
+  }
+
+  return node
+}
+
+class OverlayNode {
+  id = uniqueId('overlay-node-id-')
+
   /**
-   * 父节点
+   * Parent node
    *
    * @public
-   * @type Node
+   * @type {?OverlayNode}
    */
   parent = null
 
   /**
-   * 在前序遍历中的前一个节点
+   * Child nodes
    *
    * @public
-   * @type Node
+   * @type {Array<OverlayNode>}
    */
-  previous = null
+  children = []
 
   /**
-   * 在前序遍历中的后一个节点
-   *
-   * @public
-   * @type Node
-   */
-  next = null
-
-  /**
-   * 子节点按照 priority 的分组，结构示例：
-   * [
-   *   {
-   *     priority: 1,
-   *     children: [node1, node2, ...]
-   *   },
-   *   {
-   *     priority: 2,
-   *     children: [node3, node4, ...]
-   *   }
-   * ]
+   * Order
    *
    * @private
-   * @type Array
+   * @type {?number}
    */
-  childrenGroup = []
+  _order = null
 
   /**
-   * 节点的唯一标识
+   * Priority
    *
    * @public
-   * @readonly
-   * @type string
+   * @type {?number}
    */
-  id = null
+  priority = null
 
   /**
-   * order 值
+   * Order change callback
    *
    * @public
-   * @type number
+   * @type {function(number)}
    */
-  order = null
+  onOrderChange = null
 
-  constructor () {
-    this.id = uniqueId('overlay-node-id-')
+  /**
+   * Reference to the root node
+   *
+   * @public
+   * @type {OverlayNode}
+   */
+  root = null
+
+  /**
+   * Constructing a node
+   *
+   * @constructor
+   */
+  constructor (root = null, parent = root, priority = 1) {
+    this.root = root
+    this.parent = parent
+    this.priority = priority
+    nodeIndex[this.id] = this
   }
 
   /**
-   * 找到第一个 children 不为空的分组
+   * Order
    *
    * @public
-   * @param {boolean} [fromLast] 是否倒着找
-   * @param {number} [fromGroupIndex] 从指定索引处开始找
-   * @return {Object}
+   * @type {?number}
    */
-  findFirstNotEmptyGroup (
-    fromLast = false,
-    fromGroupIndex = fromLast ? this.childrenGroup.length - 1 : 0
-  ) {
-    let callback = group => {
-      if (group.children.length) {
-        return true
+  get order () {
+    return this._order
+  }
+
+  /**
+   * Order
+   *
+   * @public
+   * @type {?number}
+   */
+  set order (val) {
+    if (this._order !== val) {
+      this._order = val
+
+      if (typeof this.onOrderChange === 'function') {
+        this.onOrderChange(val)
       }
     }
-    return fromLast
-      ? findLast(this.childrenGroup, callback, fromGroupIndex)
-      : find(this.childrenGroup, callback, fromGroupIndex)
   }
 
   /**
-   * 所有 children 的头部
+   * Append current node into the children of another node
    *
-   * @public
-   * @type {Node}
+   * @param {OverlayNode} parent the parent overlay node
    */
-  get head () {
-    let group = this.findFirstNotEmptyGroup()
-    return group && group.children[0]
+  appendTo (parent) {
+    parent = getNode(parent) || this.root
+
+    parent.append(this)
+    this.root.reorder()
   }
 
   /**
-   * 所有 children 的尾部
+   * Append the given node into the children of current node
    *
-   * @public
-   * @type {Node}
+   * @param {OverlayNode} node the node to be appended
    */
-  get tail () {
-    let group = this.findFirstNotEmptyGroup(true)
-    return group && last(group.children)
-  }
+  append (node) {
+    node = getNode(node)
 
-  /**
-   * 根据 priority 追加子节点。
-   *
-   * @public
-   * @param {Node} child 待追加的子节点
-   * @param {number} priority 优先级顺序值，越大，相应的子节点就分配在越靠后的 children group 中。
-   * @return {Object} 新插入位置的索引信息
-   */
-  appendChild (child, priority = 1) {
-    let groupIndex = -1
-    let isInserted = false
-    let childIndex = 0
-    find(this.childrenGroup, (group, i) => {
-      if (group.priority === priority) {
-        group.children.push(child)
-        isInserted = true
-        childIndex = group.children.length - 1
-        groupIndex = i
-        return true
-      }
+    let { children } = this
 
-      if (group.priority > priority) {
-        groupIndex = i
-        return true
-      }
-    })
-
-    if (!isInserted) {
-      if (groupIndex === -1) {
-        this.childrenGroup.push({
-          children: [child],
-          priority
-        })
-        groupIndex = this.childrenGroup.length - 1
-      } else {
-        this.childrenGroup.splice(groupIndex, 0, {
-          children: [child],
-          priority
-        })
-      }
+    if (node.parent) {
+      pull(node.parent.children, node)
     }
 
-    child.parent = this
+    let index = findLastIndex(
+      children,
+      ({ priority }) => priority <= node.priority
+    )
 
-    return { groupIndex, childIndex }
+    // not found: -1 so insert at 0
+    children.splice(index + 1, 0, node)
+    node.parent = this
   }
 
   /**
-   * 根据节点 id 从当前节点的子级中移除节点
-   *
-   * @private
-   * @param {string} id 节点 id
-   * @return {Object} 被移除的节点的索引信息
+   * Move current node to the end of siblings with the same priority
    */
-  removeChildById (id) {
-    let groupIndex
-    let childIndex
-
-    for (let i = 0, il = this.childrenGroup.length; i < il; i++) {
-      let group = this.childrenGroup[i]
-
-      let removedNodes = remove(group.children, (child, index) => {
-        if (child.id === id) {
-          child.parent = null
-          child.previous = null
-
-          groupIndex = i
-          childIndex = index
-
-          return true
-        }
-      })
-
-      if (removedNodes.length === 1) {
-        break
-      }
-    }
-
-    return {
-      groupIndex,
-      childIndex
-    }
+  toTop () {
+    this.appendTo(this.parent)
   }
 
   /**
-   * 从父级节点移除当前节点
-   *
-   * @public
-   * @return {Object} 索引信息
+   * Remove current node
    */
   remove () {
-    if (!this.parent) {
-      return
+    if (this.parent) {
+      pull(this.parent.children, this)
     }
-
-    return this.parent.removeChildById(this.id)
-  }
-
-  /**
-   * 获取当前节点的直接子节点数量
-   *
-   * @public
-   */
-  getChildrenCount () {
-    return this.childrenGroup.reduce((count, group) => {
-      return count + group.children.length
-    }, 0)
-  }
-
-  /**
-   * 获取指定 child 节点的索引信息
-   *
-   * @param {string} targetChildId child id
-   * @return {Object}
-   */
-  getChildIndex (targetChildId) {
-    for (let i = 0, il = this.childrenGroup.length; i < il; i++) {
-      let group = this.childrenGroup[i]
-      for (let j = 0, jl = group.children.length; j < jl; j++) {
-        let child = group.children[j]
-        if (child.id === targetChildId) {
-          return { groupIndex: i, childIndex: j }
-        }
-      }
-    }
+    this.children.forEach(node => node.remove())
+    this.root = this.parent = null
+    delete nodeIndex[this.id]
   }
 }
 
-/**
- * 用于计算 order 的树
- */
-export class Tree {
+export class OverlayManager {
   /**
-   * 数据结构：
+   * The root node
    *
-   * root: {
-   *   parent: null,
-   *   previous: null,
-   *   childrenGroup: [
-   *     {
-   *        priority: 1,
-   *        children: [...]
-   *     }
-   *   ],
-   *   id: 'overlay-node-id-1',
-   *   order: 200
-   * }
-   *
-   * @type Node
+   * @type {OverlayNode}
    */
-  root = new Node()
+  root = new OverlayNode()
 
   /**
-   * 节点 id 到节点实例和节点句柄的映射，主要方便根据节点 id 获取到节点的详细内容。
+   * The base order
    *
-   * @private
-   * @type Object
-   */
-  nodeMap = {
-    [this.root.id]: {
-      node: this.root,
-      instance: null,
-      orderChangeCallback: noop
-    }
-  }
-
-  /**
-   * 基准 order
-   *
-   * @private
-   * @type number
+   * @type {number}
    */
   baseOrder = 100
 
   /**
-   * 设置基准 order
+   * Constructing a manager
    *
-   * @public
-   * @param {number} [order] 基准 order
+   * @constructor
+   */
+  constructor () {
+    this.root.reorder = this.reorder.bind(this)
+  }
+
+  /**
+   * Sets the base order
+   *
+   * @param {number} order the base order
    */
   setBaseOrder (order) {
     this.baseOrder = order
+    this.reorder()
   }
 
   /**
-   * 从指定节点开始按顺序迭代树中的节点，如果迭代回调函数返回真值，就会终止迭代。
+   * Create an overlay node and attach it to a given parent
    *
-   * @private
-   * @param {Node} curNode 起始节点
-   * @param {Function} callback 迭代回调
+   * @param {Object} options the option bag
+   * @param {number} priority the priority of the node
+   * @param {OverlayManager} options.parent the parent node
+   * @param {function(number)} options.onOrderChange the callback called after order is changed
+   * @param {string} options.parentId the id of parent node if `parent` isn't specified (for backward-compatibility only, not recommended)
+   * @param {function(number)} options.orderChangeCallback the alias for `onOrderChange` (for backward-compatibility only, not recommended)
    */
-  iterate ({ curNode = this.root, callback } = {}) {
-    let cur = curNode
-    do {
-      if (callback(cur)) {
-        break
-      }
-      cur = cur.next
-    } while (cur)
+  createNode (options = {}) {
+    let {
+      parent,
+      parentId,
+      priority,
+      onOrderChange,
+      orderChangeCallback
+    } = options
+
+    let node = new OverlayNode(this.root, this.root, priority)
+
+    node.onOrderChange = onOrderChange || orderChangeCallback
+    node.appendTo(parent || parentId || this.root)
+
+    return node
   }
 
   /**
-   * 修复指定节点的 previous 和 next 信息
-   *
-   * @private
-   * @param {Node} [node] 待修复的节点
-   * @param {number} [groupIndex] 待修复节点所在的分组，在父节点的 childrenGroup 中的索引位置
-   * @param {number} [childIndex] 待修复节点在自身分组中的索引位置
-   * @param {number} [fixDirection] 修复方向，1 -> 只修复 previous ，2 -> 只修复 next ，3 -> 都修复
+   * Update the order of the whole tree
    */
-  fixLink ({ node, groupIndex, childIndex, fixDirection = 3 } = {}) {
-    if (fixDirection === 1 || fixDirection === 3) {
-      let previous = this.findPreviousNode(node, groupIndex, childIndex)
-      previous.next = node
-      node.previous = previous
-    }
+  reorder () {
+    let nodes = []
 
-    if (fixDirection === 2 || fixDirection === 3) {
-      let next = this.findNextNode(node, groupIndex, childIndex)
-      if (next) {
-        next.previous = node
-      }
-      node.next = next
-    }
-  }
+    walk(this.root.children, node => {
+      nodes.push(node)
+    })
 
-  /**
-   * 包裹一层 Node#appendChild 方法，加上了修复前后节点的功能。
-   *
-   * @private
-   * @param {Node} [parent] 父节点
-   * @param {Node} [node] 待插入节点
-   * @param {number} [priority] priority
-   * @return {Object} 插入节点的索引信息
-   */
-  appendChild (parent, node, priority) {
-    let { groupIndex, childIndex } = parent.appendChild(node, priority)
-    this.fixLink({ node, groupIndex, childIndex })
-
-    let tail = node.tail
-    while (tail) {
-      let nextTail = tail.tail
-      if (!nextTail) {
-        this.fixLink({
-          node: tail,
-          groupIndex: tail.parent.childrenGroup.length - 1,
-          childIndex: last(tail.parent.childrenGroup).children.length - 1,
-          fixDirection: 2
-        })
-      }
-      tail = nextTail
-    }
-
-    return { groupIndex, childIndex }
-  }
-
-  /**
-   * 包一层 Node#remove ，提供清除前后节点信息的功能
-   *
-   * @private
-   * @param {Node} [node] 待移除节点
-   * @return {Object} 索引信息
-   */
-  remove (node) {
-    let previousBrokenNode = node.previous
-    let nextBrokenNode = node.next
-
-    let { groupIndex, childIndex } = node.remove()
-
-    if (previousBrokenNode) {
-      this.fixLink({ node: previousBrokenNode, fixDirection: 2 })
-    }
-    if (nextBrokenNode && nextBrokenNode.parent !== node) {
-      this.fixLink({ node: nextBrokenNode, fixDirection: 1 })
-    }
-
-    return { groupIndex, childIndex }
-  }
-
-  /**
-   * 在指定父级节点中插入子节点
-   *
-   * @private
-   * @param {string} parentId 父节点 id
-   * @param {Node} node 待插入子节点
-   * @param {number} priority 优先级顺序值
-   * @return {Object} “句柄”
-   */
-  insertNode (parentId, node, priority) {
-    let parent = this.nodeMap[parentId]
-    if (!parent) {
-      return
-    }
-
-    let parentNode = parent.node
-    this.appendChild(parentNode, node, priority)
-
-    this.generateTreeOrder(node)
-  }
-
-  /**
-   * 创建一个节点，并将其插入到树中
-   *
-   * @public
-   * @param {string} parentId 父节点 id
-   * @param {number} priority 优先级顺序值
-   */
-  createNode ({
-    parentId = this.root.id,
-    priority,
-    orderChangeCallback = noop
-  } = {}) {
-    let node = new Node()
-
-    let id = node.id
-    let instance = {
-      id,
-      remove: () => {
-        this.remove(node)
-        this.nodeMap[id] = null
-      },
-      appendTo: (parentId, priority) => {
-        this.nodeMap[node.id] = { node, instance, orderChangeCallback }
-        this.moveNode(node, parentId, priority)
-      },
-      toTop: () => {
-        let { groupIndex } = node.parent.getChildIndex(node.id)
-        let targetGroup = node.parent.childrenGroup[groupIndex]
-        let priority = targetGroup.priority
-        let parent = node.parent
-
-        let previous = node.previous
-        this.remove(node)
-        this.appendChild(parent, node, priority)
-
-        this.generateTreeOrder(previous)
-      }
-    }
-
-    this.nodeMap[id] = { node, instance, orderChangeCallback }
-    this.insertNode(parentId, node, priority)
-    orderChangeCallback(node.order)
-
-    return instance
-  }
-
-  /**
-   * 将节点移动到树中 `指定父节点下` 的 `指定优先级分组下` 的 children 中的最后一个位置
-   *
-   * @private
-   * @param {Node} node 待移动的节点
-   * @param {string} parentId 父节点 id
-   * @param {number} priority 优先级顺序值
-   */
-  moveNode (node, parentId, priority) {
-    let realParentId = parentId || this.root.id
-    let parent = this.nodeMap[realParentId].node
-    let curParent = node.parent
-    if (parent === curParent) {
-      return
-    }
-
-    this.remove(node)
-    this.appendChild(parent, node, priority)
-
-    // 这里不知道是往前移动了，还是往后移动了，不好做判断，干脆整个跑一遍生成 order
-    this.generateTreeOrder(this.root)
-  }
-
-  /**
-   * normalize 一下 index 信息
-   *
-   * @private
-   * @param {Node} node
-   * @param {number=} groupIndex
-   * @param {number=} childIndex
-   * @return {Object}
-   */
-  normalizeIndex (node, groupIndex, childIndex) {
-    if (groupIndex === undefined) {
-      ;({ groupIndex, childIndex } = node.parent.getChildIndex(node.id))
-    }
-
-    let children = node.parent.childrenGroup[groupIndex].children
-    if (childIndex === undefined) {
-      childIndex = children.indexOf(node)
-    }
-
-    return { groupIndex, childIndex }
-  }
-
-  /**
-   * 找到指定节点的前一个节点
-   *
-   * @private
-   * @param {Node} [node] 当前节点
-   * @param {number=} [groupIndex] 当前节点的分组索引
-   * @param {number=} [childIndex] 当前节点在分组中的位置
-   * @return {Node}
-   */
-  findPreviousNode (node, groupIndex, childIndex = -1) {
-    if (node === this.root || !node.parent) {
-      return
-    }
-
-    ;({ groupIndex, childIndex } = this.normalizeIndex(
-      node,
-      groupIndex,
-      childIndex
-    ))
-
-    let targetNode
-    if (childIndex > 0) {
-      let previousSibling =
-        node.parent.childrenGroup[groupIndex].children[childIndex - 1]
-      let curTail = previousSibling
-      do {
-        targetNode = curTail
-        curTail = curTail.tail
-      } while (curTail)
-
-      return targetNode
-    }
-
-    // 到前面的分组看看
-    if (groupIndex > 0) {
-      findLast(node.parent.childrenGroup.slice(0, groupIndex), group => {
-        if (group.children.length) {
-          let lastChild = last(group.children)
-          targetNode = lastChild.tail || lastChild
-          return true
-        }
-      })
-    }
-
-    return targetNode || node.parent
-  }
-
-  /**
-   * 找到指定节点的下一个节点
-   *
-   * @private
-   * @param {Node} [node] 当前节点
-   * @param {number=} [groupIndex] 当前节点的分组索引
-   * @param {number=} [childIndex] 当前节点在分组中的位置
-   * @return {Node}
-   */
-  findNextNode (node, groupIndex, childIndex) {
-    let head = node.head
-    if (head) {
-      return head
-    }
-
-    if (node === this.root || !node.parent) {
-      return null
-    }
-
-    ;({ groupIndex, childIndex } = this.normalizeIndex(
-      node,
-      groupIndex,
-      childIndex
-    ))
-
-    let children = node.parent.childrenGroup[groupIndex].children
-    if (childIndex < children.length - 1) {
-      return children[childIndex + 1]
-    }
-
-    let cur = node
-    while (cur.parent) {
-      let { groupIndex, childIndex } = cur.parent.getChildIndex(cur.id)
-      let loopChildren = cur.parent.childrenGroup[groupIndex].children
-      if (childIndex < loopChildren.length - 1) {
-        return loopChildren[childIndex + 1]
-      }
-
-      let group = cur.parent.findFirstNotEmptyGroup(false, groupIndex + 1)
-      if (group && group.children.length) {
-        return group.children[0]
-      }
-
-      cur = cur.parent
-    }
-
-    return null
-  }
-
-  /**
-   * 从指定节点开始，刷一遍 order 值
-   *
-   * @param {Node} node 当前指定的节点
-   * @private
-   */
-  generateTreeOrder (node) {
-    let previous = node ? this.findPreviousNode(node) : this.root
-    let baseOrder =
-      previous && previous.order ? previous.order + 1 : this.baseOrder
-
-    this.iterate({
-      curNode: node,
-      callback: cur => {
-        if (cur === this.root) {
-          return
-        }
-
-        let order = baseOrder++
-        let isEqual = cur.order === order
-        cur.order = order
-
-        if (!isEqual) {
-          this.nodeMap[cur.id].orderChangeCallback(cur.order)
-        }
-      }
+    let { baseOrder } = this
+    nodes.forEach((node, i) => {
+      node.order = baseOrder + i
     })
   }
 }
 
-export default new Tree()
+export default new OverlayManager()

--- a/packages/veui/test/unit/specs/managers/overlay.spec.js
+++ b/packages/veui/test/unit/specs/managers/overlay.spec.js
@@ -1,464 +1,171 @@
-import { Tree } from '@/managers/overlay'
-import { isFunction } from 'lodash'
+import { OverlayManager } from '@/managers/overlay'
 
 describe('managers/overlay', () => {
   describe('Node', () => {
-    describe('#constructor', () => {
-      it('should create an instance of Node', () => {
-        let node = new Tree().root
-
-        expect(node.hasOwnProperty('parent')).to.equal(true)
-        expect(node.hasOwnProperty('childrenGroup')).to.equal(true)
-        expect(node.hasOwnProperty('id')).to.equal(true)
-        expect(node.hasOwnProperty('order')).to.equal(true)
-      })
-    })
-
     describe('#appendChild', () => {
       it('should append child', () => {
-        let node = new Tree().root
-        expect(node.childrenGroup.length).to.be.equal(0)
-        node.appendChild(new Tree().root)
-        expect(node.childrenGroup.length).to.be.equal(1)
-        expect(node.childrenGroup[0].children.length).to.be.equal(1)
+        let mgr = new OverlayManager()
+        let parent = mgr.createNode()
+        let child = mgr.createNode({ parent })
+        expect(mgr.root.children.length).to.equal(1)
+        expect(parent.children.length).to.equal(1)
+        expect(child.children.length).to.equal(0)
       })
 
       it("should append the current node to the last position of the group's last children", () => {
-        let node = new Tree().root
-        let child1 = new Tree().root
-        let child2 = new Tree().root
-        node.appendChild(child1)
-        node.appendChild(child2)
-        expect(node.childrenGroup[0].children[0]).to.be.equal(child1)
-        expect(node.childrenGroup[0].children[1]).to.be.equal(child2)
+        let mgr = new OverlayManager()
+        let child1 = mgr.createNode()
+        let child2 = mgr.createNode()
+        expect(mgr.root.children[0]).to.equal(child1)
+        expect(mgr.root.children[1]).to.equal(child2)
       })
 
-      it('should place the node with different priority in different group', () => {
-        let node = new Tree().root
-        let child1 = new Tree().root
-        let child2 = new Tree().root
-        node.appendChild(child1, 1)
-        node.appendChild(child2, 2)
-        expect(node.childrenGroup[0].children[0]).to.be.equal(child1)
-        expect(node.childrenGroup[1].children[0]).to.be.equal(child2)
-      })
-
-      it('should insert the node with bigger priority at the right position', () => {
-        let node = new Tree().root
-        let child1 = new Tree().root
-        let child2 = new Tree().root
-        node.appendChild(child1, 1)
-        node.appendChild(child2, 2)
-        expect(node.childrenGroup[0].children[0]).to.be.equal(child1)
-        expect(node.childrenGroup[1].children[0]).to.be.equal(child2)
-      })
-
-      it('should insert the node with smaller priority at the left position', () => {
-        let node = new Tree().root
-        let child1 = new Tree().root
-        let child2 = new Tree().root
-        node.appendChild(child1, 2)
-        node.appendChild(child2, 1)
-        expect(node.childrenGroup[1].children[0]).to.be.equal(child1)
-        expect(node.childrenGroup[0].children[0]).to.be.equal(child2)
-      })
-
-      it("should record the group's priority", () => {
-        let node = new Tree().root
-        let child1 = new Tree().root
-        let child2 = new Tree().root
-        node.appendChild(child1, 1)
-        node.appendChild(child2, 2)
-        expect(node.childrenGroup[0].priority).to.be.equal(1)
-        expect(node.childrenGroup[1].priority).to.be.equal(2)
-      })
-    })
-
-    describe('#removeChildById', () => {
-      it('should remove child by id', () => {
-        let node = new Tree().root
-        let child1 = new Tree().root
-
-        expect(node.getChildrenCount()).to.be.equal(0)
-        node.appendChild(child1)
-        expect(node.getChildrenCount()).to.be.equal(1)
-        node.removeChildById(child1.id)
-        expect(node.getChildrenCount()).to.be.equal(0)
+      it('should sort nodes with different priority correctly', () => {
+        let mgr = new OverlayManager()
+        let child1 = mgr.createNode({ priority: 3 })
+        let child2 = mgr.createNode({ priority: 1 })
+        expect(mgr.root.children[0]).to.equal(child2)
+        expect(mgr.root.children[1]).to.equal(child1)
       })
     })
 
     describe('#remove', () => {
       it('should remove self from parent', () => {
-        let node = new Tree().root
-        let child1 = new Tree().root
+        let mgr = new OverlayManager()
+        let parent = mgr.createNode()
+        let child = mgr.createNode()
 
-        expect(node.getChildrenCount()).to.be.equal(0)
-        node.appendChild(child1)
-        expect(node.getChildrenCount()).to.be.equal(1)
-        child1.remove()
-        expect(node.getChildrenCount()).to.be.equal(0)
-      })
+        expect(parent.children.length).to.equal(0)
+        parent.append(child)
+        expect(parent.children.length).to.equal(1)
+        child.remove()
+        expect(parent.children.length).to.equal(0)
 
-      it('should remove a node in subtree that is not under the root.', () => {
-        let tree = new Tree()
+        child = mgr.createNode({ parent })
+        parent.remove()
 
-        let nodeHandle1 = tree.createNode({ priority: 1 })
-        let nodeHandle2 = tree.createNode({
-          priority: 1,
-          parentId: nodeHandle1.id
-        })
-        let nodeHandle3 = tree.createNode({
-          priority: 1,
-          parentId: nodeHandle2.id
-        })
+        let node = mgr.createNode({ parent: null })
+        expect(mgr.root.children[mgr.root.children.length - 1]).to.equal(node)
 
-        nodeHandle2.remove()
-        expect(() => nodeHandle3.remove()).to.not.throw()
+        expect(() => {
+          mgr.createNode({ parentId: child.id })
+        }).to.throw(Error, `The given node id doesn't exist!`)
       })
     })
 
-    describe('#getChildrenCount', () => {
-      it('should get children count', () => {
-        let node = new Tree().root
-        let child1 = new Tree().root
-        let child2 = new Tree().root
+    describe('#toTop', () => {
+      it('should move node to the last among nodes with the same priority', () => {
+        let mgr = new OverlayManager()
+        mgr.createNode({ priority: 2 })
+        mgr.createNode({ priority: 2 })
+        let node = mgr.createNode({ priority: 1 })
+        mgr.createNode({ priority: 1 })
 
-        expect(node.getChildrenCount()).to.be.equal(0)
-        node.appendChild(child1)
-        expect(node.getChildrenCount()).to.be.equal(1)
-        node.appendChild(child2, 1)
-        expect(node.getChildrenCount()).to.be.equal(2)
+        expect(mgr.root.children[0]).to.equal(node)
+        node.toTop()
+        expect(mgr.root.children[1]).to.equal(node)
       })
     })
   })
 
-  describe('Tree', () => {
+  describe('OverlayManager', () => {
     describe('#constructor', () => {
-      it('should create a Tree instance', () => {
-        let tree = new Tree()
-        expect(tree.hasOwnProperty('root')).to.equal(true)
-        expect(tree.hasOwnProperty('nodeMap')).to.equal(true)
-        expect(tree.hasOwnProperty('baseOrder')).to.equal(true)
+      it('should create an OverlayManager instance', () => {
+        let mgr = new OverlayManager()
+        expect(typeof mgr.createNode).to.equal('function')
+        expect(typeof mgr.setBaseOrder).to.equal('function')
       })
     })
 
     describe('#createNode', () => {
-      it('should create a `Node` handle', () => {
-        let tree = new Tree()
-        let nodeHandle = tree.createNode()
+      it('should create a `Node` correctly', () => {
+        let mgr = new OverlayManager()
+        let node = mgr.createNode()
 
-        expect(nodeHandle.hasOwnProperty('id')).to.equal(true)
-        expect(isFunction(nodeHandle.remove)).to.equal(true)
-        expect(isFunction(nodeHandle.appendTo)).to.equal(true)
-        expect(isFunction(nodeHandle.toTop)).to.equal(true)
+        expect('id' in node).to.equal(true)
+        expect('order' in node).to.equal(true)
+        expect(typeof node.remove).to.equal('function')
+        expect(typeof node.appendTo).to.equal('function')
+        expect(typeof node.toTop).to.equal('function')
       })
     })
 
     describe('#setBaseOrder', () => {
       it('should set the base order of the tree', () => {
-        let tree = new Tree()
-        tree.setBaseOrder(201)
-        expect(tree.baseOrder).to.be.equal(201)
-        tree.setBaseOrder(202)
-        expect(tree.baseOrder).to.be.equal(202)
-      })
-    })
-
-    describe('#iterate', () => {
-      it('should iterate children in order', () => {
-        let tree = new Tree()
-        let childIdList = []
-        childIdList[0] = tree.root.id
-        childIdList[1] = tree.createNode().id
-        childIdList[2] = tree.createNode({ parentId: childIdList[0] }).id
-        childIdList[4] = tree.createNode({
-          parentId: childIdList[0],
-          priority: 10
-        }).id
-        childIdList[3] = tree.createNode({
-          parentId: childIdList[0],
-          priority: 8
-        }).id
-
-        let counter = 0
-        let total = childIdList.length
-        tree.iterate({
-          callback (child) {
-            counter++
-            expect(childIdList.shift()).to.be.equal(child.id)
-          }
-        })
-        expect(counter).to.be.equal(total)
-      })
-
-      it('should stop iteration white return true in callback', () => {
-        let tree = new Tree()
-        let childIdList = []
-        childIdList[0] = tree.root.id
-        childIdList[1] = tree.createNode().id
-        childIdList[2] = tree.createNode({ parentId: childIdList[0] }).id
-        childIdList[4] = tree.createNode({
-          parentId: childIdList[0],
-          priority: 10
-        }).id
-        childIdList[3] = tree.createNode({
-          parentId: childIdList[0],
-          priority: 8
-        }).id
-
-        let counter = 0
-        tree.iterate({
-          callback (child) {
-            counter++
-            return counter === 1
-          }
-        })
-        expect(counter).to.be.equal(1)
+        let mgr = new OverlayManager()
+        mgr.setBaseOrder(201)
+        expect(mgr.baseOrder).to.equal(201)
+        mgr.setBaseOrder(202)
+        expect(mgr.baseOrder).to.equal(202)
       })
     })
 
     describe('#createNode', () => {
       it('should create a node and append it to parent', () => {
-        let tree = new Tree()
-        expect(tree.nodeMap[tree.root.id].node.getChildrenCount()).to.be.equal(0)
+        let mgr = new OverlayManager()
+        expect(mgr.root.children.length).to.equal(0)
 
-        tree.createNode()
-        expect(tree.nodeMap[tree.root.id].node.getChildrenCount()).to.be.equal(1)
+        mgr.createNode()
+        expect(mgr.root.children.length).to.equal(1)
 
-        tree.createNode()
-        expect(tree.nodeMap[tree.root.id].node.getChildrenCount()).to.be.equal(2)
+        mgr.createNode()
+        expect(mgr.root.children.length).to.equal(2)
 
-        tree.createNode({ priority: 5 })
-        expect(tree.nodeMap[tree.root.id].node.getChildrenCount()).to.be.equal(3)
+        mgr.createNode({ priority: 5 })
+        expect(mgr.root.children.length).to.equal(3)
 
-        let nodeHandle = tree.createNode({ priority: 2 })
-        expect(tree.nodeMap[tree.root.id].node.getChildrenCount()).to.be.equal(4)
+        let parent = mgr.createNode({ priority: 2 })
+        expect(mgr.root.children.length).to.equal(4)
 
-        tree.createNode({ priority: 5, parentId: nodeHandle.id })
-        expect(tree.nodeMap[tree.root.id].node.getChildrenCount()).to.be.equal(4)
+        mgr.createNode({ priority: 5, parentId: parent.id })
+        expect(mgr.root.children.length).to.equal(4)
+        expect(parent.children.length).to.equal(1)
+
+        mgr.createNode({ priority: 5, parent })
+        expect(mgr.root.children.length).to.equal(4)
+        expect(parent.children.length).to.equal(2)
       })
 
-      it('should receive `orderchange` event', done => {
-        let tree = new Tree()
-        let nodeHandle = tree.createNode({
+      it('should respect `orderChangeCallback` and `onOrderChange`', done => {
+        let mgr = new OverlayManager()
+        let parent = mgr.createNode({
           orderChangeCallback: order => {
-            if (order !== 100) {
-              return done(new Error('expect order to be 100'))
-            }
+            expect(order).to.equal(100)
+          }
+        })
+
+        mgr.createNode({
+          parent,
+          onOrderChange: order => {
+            expect(order).to.equal(101)
             done()
           }
         })
-
-        tree
-          .createNode({
-            parentId: nodeHandle.id,
-            orderChangeCallback: order => {
-              if (order !== 101) {
-                return done(new Error('expect order to be 101'))
-              }
-              done()
-            }
-          })
       })
     })
 
-    describe('#generateTreeOrder', () => {
-      it('should generate order for tree', () => {
-        let tree = new Tree()
-        let nodeHandle = tree.createNode()
-        expect(tree.nodeMap[nodeHandle.id].node.order).to.be.equal(tree.baseOrder)
-      })
-
+    describe('#reorder', () => {
       it('should generate bigger order for the latter node', () => {
-        let tree = new Tree()
-        let nodeHandle = tree.createNode({ parentId: tree.root.id })
-        expect(tree.nodeMap[nodeHandle.id].node.order).to.be.equal(tree.baseOrder)
+        let mgr = new OverlayManager()
+        let node = mgr.createNode()
+        expect(node.order).to.equal(mgr.baseOrder)
 
-        let nodeHandle1 = tree.createNode({ parentId: nodeHandle.id })
-        expect(tree.nodeMap[nodeHandle1.id].node.order).to.be.equal(
-          tree.baseOrder + 1
-        )
+        let node1 = mgr.createNode({ parent: node })
+        expect(node1.order).to.equal(mgr.baseOrder + 1)
 
-        let nodeHandle2 = tree.createNode({ parentId: nodeHandle.id })
-        expect(tree.nodeMap[nodeHandle2.id].node.order).to.be.equal(
-          tree.baseOrder + 2
-        )
+        let node2 = mgr.createNode({ parent: node })
+        expect(node2.order).to.equal(mgr.baseOrder + 2)
 
-        let nodeHandle3 = tree.createNode({
-          parentId: nodeHandle.id,
-          priority: 2
-        })
-        expect(tree.nodeMap[nodeHandle3.id].node.order).to.be.equal(
-          tree.baseOrder + 3
-        )
+        let node3 = mgr.createNode({ parent: node, priority: 2 })
+        expect(node3.order).to.equal(mgr.baseOrder + 3)
 
-        let nodeHandle4 = tree.createNode({
-          parentId: nodeHandle.id,
-          priority: 6
-        })
-        expect(tree.nodeMap[nodeHandle4.id].node.order).to.be.equal(
-          tree.baseOrder + 4
-        )
+        let node4 = mgr.createNode({ parent: node, priority: 6 })
+        expect(node4.order).to.equal(mgr.baseOrder + 4)
 
-        let nodeHandle5 = tree.createNode({
-          parentId: nodeHandle.id,
-          priority: 3
-        })
-        expect(tree.nodeMap[nodeHandle5.id].node.order).to.be.equal(
-          tree.baseOrder + 4
-        )
-        expect(tree.nodeMap[nodeHandle4.id].node.order).to.be.equal(
-          tree.baseOrder + 5
-        )
+        let node5 = mgr.createNode({ parent: node, priority: 3 })
+        expect(node5.order).to.equal(mgr.baseOrder + 4)
+        expect(node4.order).to.equal(mgr.baseOrder + 5)
       })
-    })
-  })
-
-  describe('NodeHandle', () => {
-    describe('#remove', () => {
-      it('should remove self from parent', () => {
-        let tree = new Tree()
-        expect(tree.root.getChildrenCount()).to.be.equal(0)
-        let nodeHandle = tree.createNode()
-        expect(tree.root.getChildrenCount()).to.be.equal(1)
-        nodeHandle.remove()
-        expect(tree.root.getChildrenCount()).to.be.equal(0)
-      })
-    })
-
-    describe('#appendTo', () => {
-      it('should append self to specified parent', () => {
-        let tree = new Tree()
-        let nodeHandles1 = [tree.root, tree.createNode(), tree.createNode()]
-        let nodeHandles2 = [nodeHandles1[0], nodeHandles1[2], nodeHandles1[1]]
-
-        let index = 0
-        tree.iterate({
-          callback (cur) {
-            expect(cur.id).to.be.equal(nodeHandles1[index].id)
-            index++
-          }
-        })
-        expect(index).to.be.equal(nodeHandles1.length)
-
-        nodeHandles1[1].appendTo(nodeHandles1[2].id)
-        index = 0
-        tree.iterate({
-          callback (cur) {
-            expect(cur.id).to.be.equal(nodeHandles2[index].id)
-            index++
-          }
-        })
-        expect(index).to.be.equal(nodeHandles2.length)
-      })
-    })
-
-    describe('#toTop', () => {
-      it("should bring the current node to the current group's last position", () => {
-        let tree = new Tree()
-        let nodeHandle1 = tree.createNode({ priority: 1 })
-        let nodeHandle2 = tree.createNode({ priority: 1 })
-
-        expect(tree.root.childrenGroup[0].children[0].id).to.be.equal(
-          nodeHandle1.id
-        )
-        expect(tree.root.childrenGroup[0].children[1].id).to.be.equal(
-          nodeHandle2.id
-        )
-
-        nodeHandle1.toTop()
-        expect(tree.root.childrenGroup[0].children[1].id).to.be.equal(
-          nodeHandle1.id
-        )
-        expect(tree.root.childrenGroup[0].children[0].id).to.be.equal(
-          nodeHandle2.id
-        )
-      })
-
-      it('should generate the correct order value', () => {
-        let tree = new Tree()
-        tree.setBaseOrder(200)
-
-        let nodeHandle1 = tree.createNode({ priority: 1 })
-        let nodeHandle2 = tree.createNode({ priority: 1 })
-        let nodeHandle3 = tree.createNode({ priority: 1 })
-
-        nodeHandle3.appendTo(nodeHandle1.id)
-        expect(tree.nodeMap[nodeHandle1.id].node.order).to.be.equal(200)
-        expect(tree.nodeMap[nodeHandle2.id].node.order).to.be.equal(202)
-        expect(tree.nodeMap[nodeHandle3.id].node.order).to.be.equal(201)
-
-        nodeHandle1.toTop()
-        expect(tree.nodeMap[nodeHandle1.id].node.order).to.be.equal(201)
-        expect(tree.nodeMap[nodeHandle2.id].node.order).to.be.equal(200)
-        expect(tree.nodeMap[nodeHandle3.id].node.order).to.be.equal(202)
-      })
-
-      it('should fix the tail.', () => {
-        let tree = new Tree()
-
-        let nodeHandle1 = tree.createNode({ priority: 1 })
-        let nodeHandle2 = tree.createNode({ priority: 1 })
-        let nodeHandle3 = tree.createNode({
-          parentId: nodeHandle1.id,
-          priority: 1
-        })
-        let nodeHandle4 = tree.createNode({
-          parentId: nodeHandle1.id,
-          priority: 1
-        })
-        let nodeHandle5 = tree.createNode({
-          parentId: nodeHandle4.id,
-          priority: 1
-        })
-        let nodeHandle6 = tree.createNode({
-          parentId: nodeHandle4.id,
-          priority: 1
-        })
-
-        nodeHandle1.toTop()
-        expect(tree.nodeMap[nodeHandle2.id].node.order).to.be.equal(100)
-        expect(tree.nodeMap[nodeHandle1.id].node.order).to.be.equal(101)
-        expect(tree.nodeMap[nodeHandle3.id].node.order).to.be.equal(102)
-        expect(tree.nodeMap[nodeHandle4.id].node.order).to.be.equal(103)
-        expect(tree.nodeMap[nodeHandle5.id].node.order).to.be.equal(104)
-        expect(tree.nodeMap[nodeHandle6.id].node.order).to.be.equal(105)
-      })
-
-      it('should properly set the tail node\'s next node.', () => {
-        let tree = new Tree()
-
-        let nodeHandle2 = tree.createNode()
-        let nodeHandle3 = tree.createNode({ parentId: nodeHandle2.id })
-        let nodeHandle4 = tree.createNode({ parentId: nodeHandle3.id })
-        tree.createNode({
-          parentId: nodeHandle4.id,
-          priority: 1
-        })
-        tree.createNode({
-          parentId: nodeHandle4.id,
-          priority: 1
-        })
-        let nodeHandle7 = tree.createNode({
-          parentId: nodeHandle4.id,
-          priority: 1
-        })
-
-        nodeHandle2.toTop()
-        expect(tree.nodeMap[nodeHandle7.id].node.next).to.be.equal(null)
-      })
-    })
-
-    it('should properly fix the broken nodes\' previous node.', () => {
-      let tree = new Tree()
-
-      let nodeHandle2 = tree.createNode()
-      tree.createNode({ parentId: nodeHandle2.id })
-      tree.createNode({ parentId: nodeHandle2.id })
-      let nodeHandle3 = tree.createNode({ parentId: nodeHandle2.id })
-      let nodeHandle4 = tree.createNode({ priority: 100 })
-
-      expect(tree.nodeMap[nodeHandle4.id].node.previous).to.be.equal(tree.nodeMap[nodeHandle3.id].node)
     })
   })
 })


### PR DESCRIPTION
重写 OverlayManager，为了可以注入老的 manager，必须保留以下接口（为 #567 作记录）：

```ts
interface OverlayNode {
  id: string
  appendTo: (parent: string|OverlayNode, priority: number) => void
  toTop: () => void
}

interface CreateNodeOptions {
  parentId: number
  priority: number
  orderChangeCallback: (order: number) => void
}

interface OverlayManager {
  setBaseOrder: (order: number) => void
  createNode: (options: CreateNodeOptions) => OverlayNode
}

```
