### PR TITLE
feat: adjust how a coupled child is registered into its coupled paren…

### DIFF
--- a/packages/veui/src/components/Table/Column.vue
+++ b/packages/veui/src/components/Table/Column.vue
@@ -30,7 +30,7 @@ export default {
     }
   },
   created () {
-    let index = getIndexOfType(this, 'table-column')
+    let index = getIndexOfType(this, 'table')
 
     const props = ['title', 'field', 'sortable', 'width', 'align', 'span']
 

--- a/packages/veui/src/components/Tabs/Tab.vue
+++ b/packages/veui/src/components/Tabs/Tab.vue
@@ -81,7 +81,7 @@ export default {
     }
   },
   created () {
-    let index = getIndexOfType(this, 'tab')
+    let index = getIndexOfType(this, 'tabs')
 
     const props = ['label', 'disabled', 'to', 'native', 'removable', 'status']
 

--- a/packages/veui/src/mixins/coupled.js
+++ b/packages/veui/src/mixins/coupled.js
@@ -18,7 +18,7 @@ export function makeCoupledChild ({ direct = false, type, parentType, fields }) 
       if (!this[parentRef]) {
         return
       }
-      let index = getIndexOfType(this, type)
+      let index = getIndexOfType(this, parentType)
       this[parentRef].add(index, {
         id: this.id,
         ...pick(this, fields)

--- a/packages/veui/src/mixins/key-select.js
+++ b/packages/veui/src/mixins/key-select.js
@@ -16,7 +16,7 @@ const focusElement = (focusableList, index, focusClass) => {
 }
 
 config.defaults({
-  'keySelect.focusClass': 'focus-visible'
+  'keyselect.focusClass': 'focus-visible'
 })
 
 const createKeySelect = ({ useNativeFocus, handlers }) => ({
@@ -29,7 +29,7 @@ const createKeySelect = ({ useNativeFocus, handlers }) => ({
           : useNativeFocus
     },
     focusClass () {
-      return this.focusMode ? null : config.get('keySelect.focusClass')
+      return this.focusMode ? null : config.get('keyselect.focusClass')
     }
   },
   methods: {

--- a/packages/veui/src/mixins/menu.js
+++ b/packages/veui/src/mixins/menu.js
@@ -15,7 +15,7 @@ export default {
     if (!this.menu) {
       return
     }
-    let index = getIndexOfType(this, 'menu-item')
+    let index = getIndexOfType(this, 'menu')
     let label = this.label || this.getLabelNaive()
     this.menu.add({
       ...pick(this, ['value', 'items', 'id', 'position', 'trigger']),

--- a/packages/veui/test/unit/specs/components/Table.spec.js
+++ b/packages/veui/test/unit/specs/components/Table.spec.js
@@ -538,4 +538,78 @@ describe('components/Table', () => {
     ).to.equal('2')
     wrapper.destroy()
   })
+
+  it('should support wrapping column component', () => {
+    let AwesomeColumn = {
+      components: {
+        'veui-table-column': Column
+      },
+      props: {
+        field: String,
+        title: String
+      },
+      template: `
+        <veui-table-column :field="field" :title="title" align="center">
+          <template slot-scope="{ name }">
+            <b>{{ name }}</b>
+          </template>
+        </veui-table-column>`
+    }
+    let wrapper = mount(
+      {
+        components: {
+          'veui-table': Table,
+          'veui-table-column': Column,
+          AwesomeColumn
+        },
+        data () {
+          return {
+            data: [
+              {
+                id: 1,
+                type: 'fruits',
+                name: 'apple'
+              },
+              {
+                id: 2,
+                type: 'fruits',
+                name: 'cherry'
+              },
+              {
+                id: 3,
+                type: 'veggie',
+                name: 'tomato'
+              },
+              {
+                id: 4,
+                type: 'veggie',
+                name: 'potato'
+              }
+            ],
+            groupSpan (i) {
+              return {
+                row: i % 2 ? 0 : 2
+              }
+            }
+          }
+        },
+        template: `
+          <veui-table :data="data">
+            <veui-table-column field="id" title="id"/>
+            <awesome-column field="type" title="type"/>
+            <veui-table-column field="name" title="name"/>
+          </veui-table>
+        `
+      },
+      {
+        sync: false
+      }
+    )
+
+    let td = wrapper.findAll('tbody td').at(1)
+    expect(td.classes()).to.include('veui-table-column-center')
+    expect(td.find('.veui-table-cell').html()).to.include('<b>apple</b>')
+
+    wrapper.destroy()
+  })
 })


### PR DESCRIPTION
…t, allow wrapping parent components around such child

调整了计算耦合子组件计算在耦合父组件中 index 的逻辑。现在计算方式调整为从子组件向上查找，找到对应父组件 default slot 中的顶层组件，计算其所在的 index。这样就使得子组件可以被再次封装（当然，无法支持额外的渲染逻辑比如一个父组件封装两个 Column）。