### PR TITLE
Rewrite Tabs & Tab

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,3 @@
-// http://eslint.org/docs/user-guide/configuring
-
 module.exports = {
   root: true,
   parserOptions: {
@@ -20,24 +18,24 @@ module.exports = {
   // add your custom rules here
   rules: {
     // allow paren-less arrow functions
-    'arrow-parens': 0,
+    'arrow-parens': 'off',
     quotes: [
       'error',
       'single',
       { allowTemplateLiterals: true, avoidEscape: true }
     ],
-    'prefer-const': 0,
+    'prefer-const': 'off',
     // allow async-await
-    'generator-star-spacing': 0,
+    'generator-star-spacing': 'off',
     // allow debugger during development
-    'no-debugger': process.env.NODE_ENV === 'production' ? 2 : 0,
+    'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
     'no-multi-spaces': ['error', { ignoreEOLComments: true }],
-    'no-template-curly-in-string': 0,
+    'no-template-curly-in-string': 'off',
     // to many false positives
-    'vue/no-side-effects-in-computed-properties': 0,
+    'vue/no-side-effects-in-computed-properties': 'off',
     // fix unused var error for JSX custom tags
-    'vue/jsx-uses-vars': 2,
-    'vue/require-default-prop': 0,
+    'vue/jsx-uses-vars': 'error',
+    'vue/require-default-prop': 'off',
     'vue/name-property-casing': ['error', 'kebab-case'],
     'vue/component-name-in-template-casing': ['error', 'kebab-case'],
     'vue/html-indent': [
@@ -70,8 +68,29 @@ module.exports = {
         selfClosingTag: 'never'
       }
     ],
-    'vue/no-v-html': 0,
-    'vue/singleline-html-element-content-newline': 0,
-    'vue/multiline-html-element-content-newline': 0
+    'vue/no-v-html': 'off',
+    'vue/singleline-html-element-content-newline': 'off',
+    'vue/multiline-html-element-content-newline': 'off',
+    'vue/array-bracket-spacing': ['error', 'never'],
+    'vue/arrow-spacing': ['error', { 'before': true, 'after': true }],
+    'vue/block-spacing': ['error', 'always'],
+    'vue/brace-style': ['error', '1tbs', { 'allowSingleLine': true }],
+    'vue/camelcase': ['error', { 'properties': 'never' }],
+    'vue/comma-dangle': ['error', {
+      'arrays': 'never',
+      'objects': 'never',
+      'imports': 'never',
+      'exports': 'never',
+      'functions': 'never'
+    }],
+    'vue/dot-location': ['error', 'property'],
+    'vue/eqeqeq': ['error', 'always', { 'null': 'ignore' }],
+    'vue/key-spacing': ['error', { 'beforeColon': false, 'afterColon': true }],
+    'vue/keyword-spacing': ['error', { 'before': true, 'after': true }],
+    'vue/no-empty-pattern': 'error',
+    'vue/no-irregular-whitespace': 'error',
+    'vue/object-curly-spacing': ['error', 'always'],
+    'vue/space-infix-ops': 'error',
+    'vue/space-unary-ops': ['error', { 'words': true, 'nonwords': false }],
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,75 @@
 ## 2.0.0-alpha.11
 
+### ⚠️ 非兼容性变更
+
+- [^] 对 `Tabs` 组件进行了重写，其中引入的非兼容性变更如下：
+
+  - [-] 移除了 `index` prop，现在控制激活标签页只能使用 `active` prop。
+  - [^] `tabs-extra` slot 更名为 `extra`，且仅包括提示区域的内容，不包括添加按钮。
+  - [-] 移除了 `tabs-extra-label` 与 `tabs-extra-tip` slot。
+  - [^] `tab-item` scoped slot 现在包含整个按钮/链接，方便替换为自定义实现。
+  - [-] 移除了 `tab-item-extra` scoped slot，`removable` 的 `Tab` 组件始终显示移除按钮。
+  - [^] 在路由模式下，不再自动输出 `<router-view>` 组件，需要通过 `Tab` 的 `default` slot 或 `Tabs` 新增的 `panel` slot 中进行输出。
+
+  其余变更：
+
+  - [+] 新增 `panel` slot，用于指定标签下方面板内的自定义内容。
+  - [+] 新增 `change` 事件，回调参数为 `tab` 对像，包含 `name`、`label`、`to`、`status` 等字段。
+
+    > #### 使用指南
+    >
+    > ##### 使用 `active` prop 与 `change` 事件完全外部控制激活状态
+    >
+    > ```html
+    > <veui-tabs :active="active" @change="tab => active = tab.name">
+    >   <veui-tab label="A" name="a">Content A</veui-tab>
+    >   <veui-tab label="B" name="b">Content B</veui-tab>
+    >   <veui-tab label="C" name="c">Content C</veui-tab>
+    > </veui-tabs>
+    > ```
+    > ##### 使用 `active.sync` 双向同步激活状态
+    >
+    > ```html
+    > <veui-tabs :active.sync="active">
+    >   <veui-tab label="A" name="a">Content A</veui-tab>
+    >   <veui-tab label="B" name="b">Content B</veui-tab>
+    >   <veui-tab label="C" name="c">Content C</veui-tab>
+    > </veui-tabs>
+    > ```
+    > ##### 激活状态完全由组件内部控制
+    >
+    > ```html
+    > <veui-tabs>
+    >   <veui-tab label="A">Content A</veui-tab>
+    >   <veui-tab label="B">Content B</veui-tab>
+    >   <veui-tab label="C">Content C</veui-tab>
+    > </veui-tabs>
+    > ```
+    >
+    > ##### （嵌套）路由模式
+    >
+    > 在之前的版本，如果 `Tab` 组件的 `default` slot 未传入任何内容，路由模式下 VEUI 会自动在标签内容容器内渲染 `<router-view>`。这导致在不使用嵌套路由时或是希望灵活控制 `<router-view>` 位置时产生额外的问题。所以在这个版本中移除了这个逻辑，用户可以使用 `Tabs` 的 `panel` slot 来统一在标签内容容器中输出 `<router-view>`，也可以在某些 `Tab` 的 `default` slot 中输出 `<router-view>` 及额外内容来覆盖全局的 `panel` slot，甚至可以将 `<router-view>` 输出到其它任意合适的位置。
+    >
+    > ```html
+    > <veui-tabs>
+    >   <veui-tab label="A" to="content/a"/>
+    >   <veui-tab label="B" to="content/b"/>
+    >   <veui-tab label="C" to="content/c">
+    >     <h3>Content C</h3>
+    >     <router-view/>
+    >   </veui-tab>
+    >   <template #panel>
+    >     <router-view/>
+    >   </template>
+    > </veui-tabs>
+    > ```
+
 ### 🐞 问题修复
 
-- [^] 修复 `Transfer` 组件删除已选项时报错的问题。
-- [^] 修复 `Transfer` 组件和 `Tree` 组件在被禁用状态下依然可以添加已选项的问题。
+- [^] 修复了 `Transfer` 组件删除已选项时报错的问题。
+- [^] 修复了 `Transfer` 组件和 `Tree` 组件在被禁用状态下依然可以添加已选项的问题。
+- [^] 修复了在局部输出全局样式时没有正确处理 `Anchor` 浮层的问题。
+- [^] 修复了 `Overlay` 组件没有响应 `inline` prop 变化的问题。
 
 ## 2.0.0-alpha.10
 

--- a/packages/veui-theme-dls/components/Tabs.js
+++ b/packages/veui-theme-dls/components/Tabs.js
@@ -29,6 +29,11 @@ config.defaults(
       style: {
         values: ['block']
       }
+    },
+    parts: {
+      remove: 'icon',
+      add: 'text',
+      nav: 'icon'
     }
   },
   'tabs'

--- a/packages/veui-theme-dls/components/tabs.less
+++ b/packages/veui-theme-dls/components/tabs.less
@@ -5,122 +5,85 @@
   @veui-tabs-height-l: @dls-tab-height-l;
   @veui-tabs-height-s: @dls-tab-height-s;
 
-  // TODO delete
-  @veui-tabs-height-large: @dls-tab-height-l;
-  @veui-tabs-block-height-large: @dls-tab-height-l;
-
-  overflow: hidden;
+  .make-margin-left(@dls-tab-spacing-x-m);
   position: relative;
   font-size: @dls-tab-font-size-m;
 
-  &-menu button {
-    background: none;
-    border: none;
-    padding: 0;
-  }
-
   &-menu {
-    overflow: hidden;
+    display: flex;
+    position: relative;
+    align-items: center;
     white-space: nowrap;
-    min-height: @veui-tabs-height;
+    height: @veui-tabs-height;
 
-    &-moving {
-      transition: margin-right 0.5s ease-in-out;
+    button {
+      background: none;
+      border: none;
+      padding: 0;
     }
 
     &::after {
       content: "";
-      position: absolute;
-      left: 0;
-      top: dls-sum(@veui-tabs-height, -1px);
-      width: 100%;
+      .absolute(_, 0, 0);
       border-bottom: @dls-tab-container-border-width solid
         @dls-tab-container-separator-color;
     }
   }
 
   &-list {
-    overflow: hidden;
+    display: flex;
     position: relative;
-    display: inline-block;
-    min-height: @veui-tabs-height;
     max-width: 100%;
-    vertical-align: top;
+    flex-shrink: 1;
+    align-self: stretch;
     z-index: 1;
-  }
-
-  &-list-wrapper {
-    display: inline-block;
-    padding: 0;
-    margin: 0;
-    transform: translate(0);
-
-    &-moving {
-      transition: transform 0.5s ease-in-out;
-    }
+    overflow: hidden;
   }
 
   .make-margin-left(@margin) {
-    margin-left: @margin;
+    &-item {
+      margin-left: @margin;
 
-    &:first-child {
-      margin-left: 0;
+      &:first-child {
+        margin-left: 0;
+      }
     }
+
+    &-tip,
+    &:not(&-empty) &-add {
+      margin-left: @margin;
+    }
+  }
+
+  &-prev,
+  &-next {
+    .@{veui-prefix}-icon {
+      .dls-icon-size(@dls-tab-icon-size-aux);
+    }
+  }
+
+  &-prev {
+    margin-right: @dls-tab-nav-spacing-m;
+  }
+
+  &-next {
+    margin-left: @dls-tab-nav-spacing-m;
   }
 
   &-item {
     position: relative;
-    display: inline-block;
-    .make-margin-left(@dls-tab-spacing-x-m);
-    vertical-align: top;
+    display: flex;
+    align-items: stretch;
+    flex-shrink: 0;
 
-    // &.@{veui-prefix}-tabs-item-removable {
-    //   .make-margin-left(@veui-tabs-height);
-
-    //   .@{veui-prefix}-tabs-item-status {
-    //     margin-right: 8px;
-    //   }
-    // }
-
-    & > &-remove {
-      visibility: hidden;
-      color: @veui-text-color-weak;
-      cursor: pointer;
-      outline: none;
-      .veui-button-transition();
-
-      .@{veui-prefix}-icon {
-        display: block;
-      }
-
-      &::after {
-        content: none;
-      }
-
-      &:hover,
-      &.focus-visible {
-        color: @veui-text-color-normal;
-      }
-
-      &.focus-visible {
-        .veui-focus-shadow();
-      }
-
-      &:active {
-        color: @veui-gray-color-1;
-      }
-    }
-
-    &-remove:focus,
-    &:hover > &-remove,
-    &-label.focus-visible > &-remove {
-      visibility: visible;
+    &-label {
+      .veui-transition(color);
     }
 
     & > &-label {
+      display: flex;
+      align-items: center;
       padding: 0 @dls-tab-padding-x-m;
-      line-height: @veui-tabs-height;
-      display: inline-block;
       text-decoration: none;
       outline: none;
       position: relative;
@@ -130,6 +93,7 @@
         .absolute(0, 0, 1px, 0);
         background-color: transparent;
         z-index: -1;
+        .veui-transition(background-color);
       }
     }
 
@@ -138,13 +102,14 @@
 
       &::after {
         content: "";
-        .absolute(_, 0, 0, 0);
+        .absolute(_, 0, 0);
         height: @dls-tab-indicator-width;
         .veui-transition(background-color, height);
       }
 
       &.focus-visible {
         color: @dls-tab-font-color-focus;
+
         &::before {
           background-color: @dls-tab-background-color-focus;
         }
@@ -169,6 +134,7 @@
 
       &.focus-visible {
         color: @dls-tab-font-color-current-focus;
+
         &::after {
           background-color: @dls-tab-font-color-current-focus;
         }
@@ -176,6 +142,7 @@
 
       &:hover {
         color: @dls-tab-font-color-current-hover;
+
         &::after {
           background-color: @dls-tab-font-color-current-hover;
         }
@@ -183,6 +150,7 @@
 
       &:active {
         color: @dls-tab-font-color-current-active;
+
         &::after {
           background-color: @dls-tab-font-color-current-active;
         }
@@ -193,13 +161,51 @@
       cursor: not-allowed;
       color: @dls-tab-font-color-disabled;
     }
+
+    &-label-content {
+      display: flex;
+      align-items: center;
+      line-height: 1.2;
+      .veui-transition(transform);
+    }
+
+    &-removable&-remove-focus &-label-content,
+    &-removable &-label.focus-visible &-label-content,
+    &-removable:hover &-label-content {
+      @offset: dls-sum(
+        calc(@dls-tab-content-spacing * -0.5),
+        calc(@dls-tab-icon-size-aux * -0.5)
+      );
+
+      transform: ~"translateX(@{offset})";
+    }
+
+    &-remove {
+      @offset: dls-sum(
+        @dls-tab-padding-x-m,
+        calc(@dls-tab-content-spacing * -0.5),
+        calc(@dls-tab-icon-size-aux * -0.5)
+      );
+      .absolute(50%, @offset, _, _);
+      transform: translateY(-50%) scale(0.5);
+      opacity: 0;
+      .veui-transition(transform, opacity);
+
+      .@{veui-prefix}-icon {
+        .dls-icon-size(@dls-tab-icon-size-aux);
+      }
+    }
+
+    &-remove.focus-visible,
+    &-removable &-label.focus-visible + &-remove,
+    &-removable:hover &-remove {
+      opacity: 1;
+      transform: translateY(-50%);
+    }
   }
 
   &-item-status {
-    display: inline-block;
-    width: 1em;
-    margin-right: 12px;
-    vertical-align: top;
+    margin-left: @dls-tab-content-spacing;
     cursor: pointer;
 
     .veui-tabs-status(@type) {
@@ -226,322 +232,51 @@
     }
   }
 
-  &-extra {
-    display: inline-block;
-    position: absolute;
-    top: 0;
-
-    .@{veui-prefix}-tabs-list-empty & :first-child {
-      margin-left: 0;
-    }
+  &-add.@{veui-prefix}-button {
+    flex: 0 0 auto;
+    align-self: center;
+    color: @dls-tab-font-color;
   }
 
-  &-extra-tip {
-    display: inline-block;
-    line-height: 2.5;
-    vertical-align: top;
-    color: @veui-text-color-aux;
-  }
-
-  &-operator {
-    display: inline-block;
-    margin-left: 60px;
-    line-height: 2.5;
-    outline: none;
-    cursor: pointer;
-
-    .@{veui-prefix}-icon {
-      margin-right: 6px;
-    }
-
-    &[disabled] {
-      &,
-      &:hover {
-        cursor: not-allowed;
-        color: @veui-text-color-aux;
-      }
-    }
-  }
-
-  &-item-status .@{veui-prefix}-icon,
-  &-item-remove,
-  &-operator .@{veui-prefix}-icon {
-    vertical-align: top;
-    // 减掉的 1px 是底部的线
-    margin-top: calc(@veui-tabs-height / 2 - 0.5em - 1px);
-    user-select: none;
-  }
-
-  &-scroller {
-    display: inline-block;
-    line-height: 2.5;
-    margin-left: 30px;
-
-    &-left,
-    &-right {
-      display: inline-block;
-      .size(2 * @veui-font-size-normal);
-      background-color: @veui-gray-color-8;
-      text-align: center;
-      cursor: pointer;
-      user-select: none;
-      outline: none;
-
-      &:hover,
-      &.focus-visible {
-        background-color: @veui-gray-color-5;
-      }
-
-      &:active {
-        background-color: @veui-gray-color-3;
-      }
-
-      &[disabled] {
-        background-color: #fff;
-        color: @veui-text-color-weak;
-        cursor: not-allowed;
-      }
-    }
-
-    &-right {
-      margin-left: 8px;
-    }
-  }
-
-  &[ui~="block"] & {
-    &-menu {
-      &::after {
-        display: none;
-      }
-    }
-
-    &-list {
-      height: ~"@{veui-height-normal}\9\0";
-      border: 1px solid @veui-gray-color-6;
-
-      .@{veui-prefix}-tabs-list-empty& {
-        border-width: 1px 0 1px 1px;
-      }
-    }
-
-    &-item {
-      overflow: hidden;
-      .make-margin-left(0);
-      border: 1px solid @veui-gray-color-6;
-      border-width: 0 0 0 1px;
-      background-color: #fff;
-      cursor: pointer;
-
-      &.@{veui-prefix}-tabs-item-removable {
-        padding-right: 12px;
-        padding-right: 0\9\0;
-      }
-
-      &-moving.@{veui-prefix}-tabs-item-removable,
-      &.@{veui-prefix}-tab-leave-active {
-        transition: width 0.5s ease-in-out, transform 0.5s ease-in-out,
-          padding-right 0.5s;
-      }
-
-      &.@{veui-prefix}-tab-leave-active {
-        z-index: -1;
-      }
-
-      &::after {
-        display: none;
-      }
-
-      &:first-child {
-        border-left-width: 0;
-        margin-left: 0;
-      }
-
-      &:hover {
-        background-color: @veui-gray-color-8;
-      }
-
-      &-label {
-        min-width: 62px;
-        max-width: 160px;
-        line-height: dls-sum(@veui-tabs-height, -1px);
-        padding: 0 8px 0 12px;
-        .ellipsis();
-        text-align: left;
-        .veui-transition(background-color, box-shadow);
-
-        &::after {
-          display: none;
-        }
-
-        &.focus-visible {
-          box-shadow: inset 0 0 0 2px fadeout(@veui-gray-color-3, 50%);
-        }
-
-        &:active {
-          background-color: @veui-gray-color-6;
-        }
-      }
-
-      &.@{veui-prefix}-tabs-item-removable > .@{veui-prefix}-tabs-item-label {
-        padding-right: 8px;
-      }
-
-      &.@{veui-prefix}-tabs-item-disabled {
-        background-color: #fff;
-        color: @veui-gray-color-4;
-      }
-
-      &.@{veui-prefix}-tabs-item-active {
-        background-color: @veui-gray-color-6;
-      }
-    }
-
-    &-item-status .@{veui-prefix}-icon,
-    &-item-remove,
-    &-operator .@{veui-prefix}-icon,
-    &-scroller .@{veui-prefix}-icon {
-      margin-top: calc(@veui-tabs-height / 2 - 0.5em);
-      vertical-align: top;
-    }
-
-    &-extra {
-      border-bottom: none;
-      vertical-align: top;
-
-      .@{veui-prefix}-tabs-addable&::before {
-        content: "";
-        position: absolute;
-        left: -1px;
-        height: 100%;
-        border-left: 1px solid @veui-gray-color-6;
-        z-index: 1;
-      }
-
-      &-label {
-        display: none;
-      }
-    }
-
-    &-operator {
-      margin-left: 0;
-      margin-right: 20px;
-      width: @veui-tabs-height;
-      line-height: @veui-tabs-height;
-      border: 1px solid @veui-gray-color-6;
-      border-width: 1px 1px 1px 0;
-      text-align: center;
-      vertical-align: top;
-
-      .@{veui-prefix}-icon {
-        margin-right: 0;
-      }
-    }
-
-    &-scroller {
-      line-height: @veui-tabs-height;
-
-      &-left,
-      &-right {
-        .size(@veui-tabs-height);
-        border: 1px solid @veui-gray-color-6;
-        background-color: #fff;
-
-        &:hover,
-        &.focus-visible {
-          background-color: @veui-gray-color-8;
-        }
-
-        &:active {
-          background-color: @veui-gray-color-6;
-        }
-
-        &[disabled] {
-          color: @veui-text-color-aux;
-          background-color: #fff;
-        }
-      }
-    }
-  }
-
-  &[ui~="l"][ui~="block"] & {
-    &-item {
-      &-label {
-        line-height: @veui-tabs-block-height-large;
-      }
-    }
-
-    &-item-status .@{veui-prefix}-icon,
-    &-item-remove,
-    &-operator .@{veui-prefix}-icon,
-    &-scroller .@{veui-prefix}-icon {
-      margin-top: calc(@veui-tabs-block-height-large / 2 - 0.5em);
-      vertical-align: top;
-    }
-
-    &-operator {
-      width: @veui-tabs-height-large;
-      line-height: @veui-tabs-block-height-large;
-    }
-
-    &-scroller {
-      line-height: @veui-tabs-block-height-large;
-
-      &-left,
-      &-right {
-        .size(@veui-tabs-height-large);
-      }
-    }
+  &-tip {
+    color: @dls-font-color-weak;
   }
 
   &[ui~="l"] {
+    .make-margin-left(@dls-tab-spacing-x-l);
     font-size: @dls-tab-font-size-l;
   }
 
   &[ui~="l"] & {
     &-menu {
-      min-height: @veui-tabs-height-l;
-      &::after {
-        top: dls-sum(@veui-tabs-height-l, -1px);
-      }
+      height: @veui-tabs-height-l;
     }
 
-    &-list {
-      min-height: @veui-tabs-height-l;
-    }
-
-    &-item {
-      .make-margin-left(@dls-tab-spacing-x-l);
-
-      &-label {
-        padding: 0 @dls-tab-padding-x-l;
-        line-height: @veui-tabs-height-l;
-      }
+    &-item-label {
+      padding: 0 @dls-tab-padding-x-l;
     }
   }
 
   &[ui~="s"] {
+    .make-margin-left(@dls-tab-spacing-x-s);
     font-size: @dls-tab-font-size-s;
   }
 
   &[ui~="s"] & {
     &-menu {
-      min-height: @veui-tabs-height-s;
-      &::after {
-        top: dls-sum(@veui-tabs-height-s, -1px);
-      }
+      height: @veui-tabs-height-s;
     }
 
-    &-list {
-      min-height: @veui-tabs-height-s;
+    &-item-label {
+      padding: 0 @dls-tab-padding-x-s;
     }
 
-    &-item {
-      .make-margin-left(@dls-tab-spacing-x-s);
+    &-prev {
+      margin-right: @dls-tab-nav-spacing-s;
+    }
 
-      &-label {
-        padding: 0 @dls-tab-padding-x-s;
-        line-height: @veui-tabs-height-s;
-      }
+    &-next {
+      margin-left: @dls-tab-nav-spacing-s;
     }
   }
 }

--- a/packages/veui/demo/cases/Tabs.vue
+++ b/packages/veui/demo/cases/Tabs.vue
@@ -2,7 +2,7 @@
 <article>
   <h1><code>&lt;veui-tabs&gt;</code></h1>
   <section>
-    <h2>默认样式：</h2>
+    <h2>默认样式：(.sync)</h2>
     <p>
       当前标签 <code>{{ active0 }}</code>
     </p>
@@ -23,7 +23,7 @@
         name="shares"
       />
       <veui-button
-        slot="tabs-extra"
+        slot="extra"
         ui="primary"
       >覆盖 extra</veui-button>
     </veui-tabs>
@@ -63,39 +63,22 @@
     </veui-tabs>
   </section>
   <section>
-    <h2>边框样式：</h2>
-    <veui-tabs :active.sync="active0">
-      <veui-tab
-        label="回答问题"
-        name="answers"
-      />
+    <h2>边框样式：(不受控)</h2>
+    <veui-tabs>
+      <veui-tab label="回答问题">Answers</veui-tab>
       <veui-tab
         label="文章评论"
-        name="articles"
         status="error"
-      />
-      <veui-tab
-        label="分享朋友圈"
-        name="shares"
-      />
+      >Articles</veui-tab>
+      <veui-tab label="分享朋友圈">Shares</veui-tab>
     </veui-tabs>
-    <veui-tabs
-      ui="l"
-      :active.sync="active0"
-    >
+    <veui-tabs ui="l">
       <veui-tab
         label="回答问题"
-        name="answers"
         status="warning"
-      />
-      <veui-tab
-        label="文章评论"
-        name="articles"
-      />
-      <veui-tab
-        label="分享朋友圈"
-        name="shares"
-      />
+      >Answers</veui-tab>
+      <veui-tab label="文章评论">Articles</veui-tab>
+      <veui-tab label="分享朋友圈">Shares</veui-tab>
     </veui-tabs>
   </section>
   <section>

--- a/packages/veui/demo/cases/Tabs.vue
+++ b/packages/veui/demo/cases/Tabs.vue
@@ -6,13 +6,9 @@
     <p>
       当前标签 <code>{{ active0 }}</code>
     </p>
-    <p>
-      当前序号 <code>{{ index0 + 1 }}</code>
-    </p>
     <veui-tabs
       ui="l"
       :active.sync="active0"
-      :index.sync="index0"
     >
       <veui-tab
         label="回答问题"
@@ -32,10 +28,7 @@
       >覆盖 extra</veui-button>
     </veui-tabs>
 
-    <veui-tabs
-      :active.sync="active0"
-      :index.sync="index0"
-    >
+    <veui-tabs :active.sync="active0">
       <veui-tab
         label="回答问题"
         name="answers"
@@ -53,7 +46,6 @@
     <veui-tabs
       ui="s"
       :active.sync="active0"
-      :index.sync="index0"
     >
       <veui-tab
         label="回答问题"
@@ -72,11 +64,7 @@
   </section>
   <section>
     <h2>边框样式：</h2>
-    <veui-tabs
-      ui="block"
-      :active.sync="active0"
-      :index.sync="index0"
-    >
+    <veui-tabs :active.sync="active0">
       <veui-tab
         label="回答问题"
         name="answers"
@@ -92,9 +80,8 @@
       />
     </veui-tabs>
     <veui-tabs
-      ui="block large"
+      ui="l"
       :active.sync="active0"
-      :index.sync="index0"
     >
       <veui-tab
         label="回答问题"
@@ -113,7 +100,7 @@
   </section>
   <section>
     <h2>溢出样式：</h2>
-    <veui-tabs :index="0">
+    <veui-tabs>
       <veui-tab
         v-for="n in 30"
         :key="n"
@@ -122,10 +109,7 @@
         "
       />
     </veui-tabs>
-    <veui-tabs
-      ui="block"
-      :index="0"
-    >
+    <veui-tabs>
       <veui-tab
         v-for="n in 30"
         :key="n"
@@ -137,10 +121,7 @@
   </section>
   <section>
     <h2>禁用样式：</h2>
-    <p>
-      当前序号 <code>{{ index1 + 1 }}</code>
-    </p>
-    <veui-tabs :index.sync="index1">
+    <veui-tabs>
       <veui-tab label="Tab1">
         <p>This is Tab1</p>
       </veui-tab>
@@ -157,10 +138,7 @@
         <p>This is Tab4</p>
       </veui-tab>
     </veui-tabs>
-    <veui-tabs
-      ui="block"
-      :index.sync="index1"
-    >
+    <veui-tabs>
       <veui-tab label="Tab1">
         <p>This is Tab1</p>
       </veui-tab>
@@ -193,29 +171,21 @@
         label="Progress"
         to="/tabs/progress"
       />
+      <veui-tab label="内联内容">
+        <b>Hello world.</b>
+      </veui-tab>
       <veui-tab
         label="跳转到 Progress"
         to="/progress"
       />
-      <veui-tab
-        label="包点东西"
-        to="/tabs/switch"
-      >
-        <h3>-------- Tabs 里头的 switch 开始 --------</h3>
-        <router-view v-if="$route.fullPath === '/tabs/switch'"/>
-        <h3>-------- Tabs 里头的 switch 结束 --------</h3>
-      </veui-tab>
+      <router-view slot="panel"/>
     </veui-tabs>
   </section>
   <section class="inner-ui">
     <h2>增删模式1（内部 UI）：</h2>
-    <p>
-      当前序号 <code>{{ index2 != null ? index2 + 1 : '已删光' }}</code>
-    </p>
     <veui-tabs
-      ui="large"
+      ui="l"
       :active.sync="active1"
-      :index.sync="index2"
       addable
       :max="totalTabs0"
       @add="addTab0"
@@ -232,14 +202,10 @@
         <p>Tab {{ tab.name }}</p>
       </veui-tab>
     </veui-tabs>
-    <p>
-      当前序号 <code>{{ index3 != null ? index3 + 1 : '已删光' }}</code>
-    </p>
     <veui-tabs
-      ui="large block"
+      ui="l"
       class="large-block-demo"
       :active.sync="active2"
-      :index.sync="index3"
       addable
       :max="totalTabs1"
       :tip="`还可新建 ${totalTabs1 - tabs1.length} 条`"
@@ -260,19 +226,13 @@
   </section>
   <section>
     <h2>增删模式2（完全外部控制）：</h2>
-    <p>
-      当前序号 <code>{{ index4 != null ? index4 + 1 : '已删光' }}</code>
-    </p>
     <veui-button
       class="add-btn"
       @click="addTab2"
     >
       添加 TAB
     </veui-button>
-    <veui-tabs
-      :active.sync="active3"
-      :index.sync="index4"
-    >
+    <veui-tabs :active.sync="active3">
       <template
         v-if="props.removable && tabs2.length > 1"
         slot="tab-item-extra"
@@ -297,20 +257,13 @@
         <p>Tab {{ tab.name }}</p>
       </veui-tab>
     </veui-tabs>
-    <p>
-      当前序号 <code>{{ index5 != null ? index5 + 1 : '已删光' }}</code>
-    </p>
     <veui-button
       class="add-btn"
       @click="addTab3"
     >
       添加 TAB
     </veui-button>
-    <veui-tabs
-      :active.sync="active4"
-      :index.sync="index5"
-      ui="block"
-    >
+    <veui-tabs :active.sync="active4">
       <template
         slot="tab-item-extra"
         slot-scope="props"
@@ -348,9 +301,6 @@
     <p>
       当前标签 <code>{{ active5 }}</code>
     </p>
-    <p>
-      当前序号 <code>{{ index6 + 1 }}</code>
-    </p>
     <veui-button
       :disabled="tabIfRemoving"
       @click="insertVisiable = !insertVisiable"
@@ -358,9 +308,8 @@
       {{ insertVisiable ? '隐藏' : '显示' }}中间一个可切换 TAB
     </veui-button>
     <veui-tabs
-      ui="large"
+      ui="l"
       :active.sync="active5"
-      :index.sync="index6"
     >
       <veui-tab
         label="DuerOS"
@@ -389,9 +338,8 @@
       </veui-tab>
     </veui-tabs>
     <veui-tabs
-      ui="large block"
+      ui="l"
       :active.sync="active5"
-      :index.sync="index6"
     >
       <veui-tab
         label="DuerOS"
@@ -438,7 +386,7 @@ export default {
   },
   data () {
     return {
-      totalTabs0: 10,
+      totalTabs0: 15,
       totalTabs1: 20,
       tabs0: [
         { label: '弄一个很长的在第一个试试', name: '默认1' },
@@ -466,13 +414,6 @@ export default {
       active3: '',
       active4: '',
       active5: '',
-      index0: 0,
-      index1: 0,
-      index2: 0,
-      index3: 0,
-      index4: 0,
-      index5: 0,
-      index6: 0,
       insertVisiable: false,
       tabIfRemoving: false
     }
@@ -484,11 +425,11 @@ export default {
       }
 
       let label = uniqueId('默认')
-      let index = this.tabs0.push({
+      this.tabs0.push({
         label,
         name: label
       })
-      this.index2 = index - 1
+      this.active1 = label
     },
     addTab1 () {
       if (this.tabs1.length >= this.totalTabs1) {
@@ -496,27 +437,24 @@ export default {
       }
 
       let label = uniqueId('每次都增加一些很长的来试试看')
-      let index = this.tabs1.push({
+      this.tabs1.push({
         label,
         name: label
       })
-      this.index3 = index - 1
     },
     addTab2 () {
       let label = uniqueId('默认')
-      let index = this.tabs2.push({
+      this.tabs2.push({
         label,
         name: label
       })
-      this.index4 = index - 1
     },
     addTab3 () {
       let label = uniqueId('默认')
-      let index = this.tabs3.push({
+      this.tabs3.push({
         label,
         name: label
       })
-      this.index5 = index - 1
     },
     removeTab0 ({ name }) {
       let index = findIndex(this.tabs0, tab => tab.name === name)

--- a/packages/veui/demo/cases/index.js
+++ b/packages/veui/demo/cases/index.js
@@ -311,7 +311,6 @@ export default [
     path: '/tabs',
     name: 'Tabs',
     component: Tabs,
-    disabled: true,
     redirect: '/tabs/button',
     children: [
       {

--- a/packages/veui/src/components/Tabs/Tabs.vue
+++ b/packages/veui/src/components/Tabs/Tabs.vue
@@ -34,10 +34,6 @@ export default {
     active: {
       type: String
     },
-    index: {
-      type: Number,
-      default: 0
-    },
     matches: {
       default () {
         return config.get('tabs.matches')

--- a/packages/veui/src/components/Tabs/Tabs.vue
+++ b/packages/veui/src/components/Tabs/Tabs.vue
@@ -130,8 +130,9 @@ export default {
         return
       }
       this.realActive = tab.name || tab.id
-
       this.scrollTabIntoView(tab)
+
+      this.$emit('change', tab)
     },
     handleRemove (tab, e) {
       this.$emit('remove', tab)

--- a/packages/veui/src/components/Tabs/Tabs.vue
+++ b/packages/veui/src/components/Tabs/Tabs.vue
@@ -121,11 +121,13 @@ export default {
     this.updateLayout()
   },
   methods: {
-    handleActivate ({ disabled, name, id }) {
-      if (disabled) {
+    handleActivate (tab) {
+      if (tab.disabled) {
         return
       }
-      this.realActive = name || id
+      this.realActive = tab.name || tab.id
+
+      this.scrollTabIntoView(tab)
     },
     handleRemove (tab, e) {
       this.$emit('remove', tab)

--- a/packages/veui/src/components/Tabs/Tabs.vue
+++ b/packages/veui/src/components/Tabs/Tabs.vue
@@ -8,6 +8,7 @@ import i18n from '../../mixins/i18n'
 import config from '../../managers/config'
 import { makeCoupledParent } from '../../mixins/coupled'
 import makeControllable from '../../mixins/controllable'
+import resize from '../../directives/resize'
 import { isEmpty } from '../../utils/helper'
 import '../../common/uiTypes'
 import { scrollTo } from '../../utils/dom'
@@ -29,6 +30,9 @@ config.defaults(
 
 export default {
   name: 'veui-tabs',
+  directives: {
+    resize
+  },
   mixins: [prefix, ui, i18n, tabs, makeControllable(['active'])],
   props: {
     active: {
@@ -242,6 +246,14 @@ export default {
         </div>
       ])
 
+    const directives = [
+      {
+        name: 'resize',
+        value: this.updateLayout,
+        modifiers: { debounce: true, leading: true, 200: true }
+      }
+    ]
+
     return (
       <div
         class={{
@@ -253,6 +265,7 @@ export default {
         <div class={this.$c('tabs-menu')}>
           {this.listOverflow ? (
             <Button
+              key="prev"
               class={this.$c('tabs-prev')}
               ui={this.uiParts.nav}
               disabled={this.hit.start}
@@ -266,6 +279,7 @@ export default {
             class={this.$c('tabs-list')}
             role="tablist"
             onScroll={this.updateScrollState}
+            {...{ directives }}
           >
             {this.items.map((tab, index) => (
               <div
@@ -340,6 +354,7 @@ export default {
           </div>
           {this.listOverflow ? (
             <Button
+              key="next"
               class={this.$c('tabs-next')}
               ui={this.uiParts.nav}
               disabled={this.hit.end}
@@ -350,6 +365,7 @@ export default {
           ) : null}
           {this.addable ? (
             <Button
+              key="add"
               class={this.$c('tabs-add')}
               ui={this.uiParts.add}
               disabled={this.max != null && this.items.length >= this.max}

--- a/packages/veui/src/components/Tabs/Tabs.vue
+++ b/packages/veui/src/components/Tabs/Tabs.vue
@@ -1,192 +1,22 @@
-<template>
-<div
-  v-resize.debounce="listResizeHandler"
-  :class="{
-    [$c('tabs')]: true,
-    [$c('tabs-overflow')]: menuOverflow,
-    [$c('tabs-addable')]: addable,
-    [$c('tabs-list-empty')]: items.length === 0,
-    [$c('tabs-left-limited')]: leftLimited,
-    [$c('tabs-right-limited')]: rightLimited
-  }"
-  :ui="realUi"
->
-  <div
-    ref="menu"
-    :class="{
-      [$c('tabs-menu')]: true,
-      [$c('tabs-menu-moving')]: menuMoving
-    }"
-    role="tablist"
-  >
-    <div :class="$c('tabs-list')">
-      <transition-group
-        ref="listContainer"
-        tag="div"
-        :class="{
-          [$c('tabs-list-wrapper')]: true,
-          [$c('tabs-list-wrapper-moving')]: conMoving
-        }"
-        :name="$c('tab')"
-        @before-leave="beforeLeave"
-        @leave="leave"
-        @after-leave="afterLeave"
-      >
-        <div
-          v-for="(tab, i) in items"
-          :key="tab.name"
-          :ref="`tab-${tab.name}`"
-          :data-index="i"
-          :class="{
-            [$c('tabs-item')]: true,
-            [$c('tabs-item-disabled')]: tab.disabled,
-            [$c('tabs-item-removable')]: tab.removable,
-            [$c('tabs-item-active')]: i === localIndex,
-            [$c('tabs-item-moving')]: itemMoving
-          }"
-          @click="
-            $event => {
-              if (
-                $event.target === $refs[`tab-${tab.name}`][0] &&
-                !tab.disabled
-              ) {
-                setActive({ index: i })
-              }
-            }
-          "
-        >
-          <slot
-            name="tab-item"
-            v-bind="tab"
-            :index="i"
-          >
-            <veui-link
-              v-if="tab.to"
-              :class="$c('tabs-item-label')"
-              v-bind="ariaAttrs[i]"
-              :to="tab.to"
-              :native="tab.native"
-              @click="!tab.disabled && setActive({ index: i })"
-            >
-              {{ tab.label }}
-            </veui-link>
-            <button
-              v-else
-              :class="$c('tabs-item-label')"
-              v-bind="ariaAttrs[i]"
-              type="button"
-              @click="!tab.disabled && setActive({ index: i })"
-            >
-              {{ tab.label }}
-            </button>
-            <slot
-              name="tab-item-status"
-              v-bind="tab"
-              :index="i"
-            >
-              <span
-                v-if="tab.status"
-                :class="$c('tabs-item-status')"
-                @click="!tab.disabled && setActive({ index: i })"
-              >
-                <veui-icon
-                  :class="$c(`tabs-item-status-${tab.status}`)"
-                  :name="icons[tab.status]"
-                />
-              </span>
-            </slot>
-            <slot
-              name="tab-item-extra"
-              v-bind="tab"
-              :index="i"
-            >
-              <button
-                v-if="tab.removable"
-                type="button"
-                :class="$c('tabs-item-remove')"
-                :aria-label="t('remove')"
-                :disabled="removing"
-                @click="$emit('remove', tab)"
-              >
-                <veui-icon :name="icons.remove"/>
-              </button>
-            </slot>
-          </slot>
-        </div>
-      </transition-group>
-    </div>
-    <div
-      ref="extra"
-      :class="$c('tabs-extra')"
-    >
-      <slot name="tabs-extra">
-        <button
-          v-if="addable"
-          type="button"
-          :class="$c('tabs-operator')"
-          :aria-label="t('add')"
-          :disabled="(max != null && items.length >= max) || removing"
-          @click="$emit('add')"
-        >
-          <veui-icon :name="icons.add"/>
-          <slot name="tabs-extra-label">
-            <span :class="$c('tabs-extra-label')">
-              {{ t('addTab') }}
-            </span>
-          </slot>
-        </button>
-        <slot name="tabs-extra-tip">
-          <span
-            v-if="tip"
-            :class="$c('tabs-extra-tip')"
-          >
-            {{ tip }}
-          </span>
-        </slot>
-        <div
-          v-if="menuOverflow"
-          ref="scroller"
-          :class="$c('tabs-scroller')"
-          aria-hidden="true"
-        >
-          <button
-            type="button"
-            :class="$c('tabs-scroller-left')"
-            :disabled="leftLimited"
-            @click="scroll({ direction: 'left' })"
-          >
-            <veui-icon :name="icons.prev"/>
-          </button>
-          <button
-            type="button"
-            :class="$c('tabs-scroller-right')"
-            :disabled="rightLimited"
-            @click="scroll({ direction: 'right' })"
-          >
-            <veui-icon :name="icons.next"/>
-          </button>
-        </div>
-      </slot>
-    </div>
-  </div>
-  <div :class="$c('tabs-panel')">
-    <slot/>
-  </div>
-</div>
-</template>
-
 <script>
-import { assign, inRange } from 'lodash'
-import warn from '../../utils/warn'
+import Button from '../Button'
 import Link from '../Link'
 import Icon from '../Icon'
-import resize from '../../directives/resize'
 import prefix from '../../mixins/prefix'
 import ui from '../../mixins/ui'
 import i18n from '../../mixins/i18n'
 import config from '../../managers/config'
+import { makeCoupledParent } from '../../mixins/coupled'
+import makeControllable from '../../mixins/controllable'
+import { isEmpty } from '../../utils/helper'
 import '../../common/uiTypes'
-import { setTransform, getTransform } from '../../utils/dom'
+import { scrollTo } from '../../utils/dom'
+import { find, findIndex, throttle } from 'lodash'
+
+let tabs = makeCoupledParent({
+  type: 'tabs',
+  childrenKey: 'items'
+})
 
 config.defaults(
   {
@@ -199,15 +29,7 @@ config.defaults(
 
 export default {
   name: 'veui-tabs',
-  uiTypes: ['tabs'],
-  components: {
-    'veui-link': Link,
-    'veui-icon': Icon
-  },
-  directives: {
-    resize
-  },
-  mixins: [prefix, ui, i18n],
+  mixins: [prefix, ui, i18n, tabs, makeControllable(['active'])],
   props: {
     active: {
       type: String
@@ -239,694 +61,321 @@ export default {
   data () {
     return {
       items: [],
-      localIndex: null,
-      localActive: null,
-      activeId: null,
-      menuOverflow: false,
-      menuLeft: null,
-      menuRight: null,
-      menuRightStable: null,
-      menuClientWidth: null,
-      tabConClientWidth: null,
-      extraWidth: null,
-      currentTranslate: 0,
-      inited: false,
-      switching: false,
-      menuMoving: false,
-      conMoving: false,
-      itemMoving: false,
-      removing: false,
-      transitionSupported: null,
-      fixedTranslate: null,
-      fixedTabs: null,
-      needResize: false
+      focusedTab: null,
+      listOverflow: false,
+      stops: null,
+      hit: {
+        start: true,
+        end: false
+      }
     }
   },
   computed: {
-    tabUids () {
-      return this.items.map(({ id }) => id)
-    },
-    tabNames () {
-      return this.items.map(({ name }) => name)
-    },
-    leftLimited () {
-      return !this.currentTranslate
-    },
-    rightLimited () {
-      // offsetWidth/clientWidth 的值会取四舍五入，两个数比较误差不超过 2
-      return (
-        this.currentTranslate !== 0 &&
-        (this.currentTranslate < this.maxTranslate ||
-          inRange(
-            this.currentTranslate,
-            this.maxTranslate + 2,
-            this.maxTranslate - 2
-          ))
-      )
-    },
-    maxTranslate () {
-      return this.menuClientWidth - this.tabConClientWidth
-    },
-    needTransition () {
-      return (
-        this.inited &&
-        this.transitionSupported &&
-        this.uiProps.style === 'block'
-      )
-    },
-    ariaAttrs () {
-      return this.items.map(({ id }, index) => {
+    tabAttrs () {
+      return this.items.map(({ id, name, attrs }, index) => {
         return {
           role: 'tab',
-          'aria-selected': index === this.localIndex,
+          'aria-selected': this.activeTab && id === this.activeTab.id,
           'aria-setsize': this.items.length,
           'aria-posinset': index + 1,
-          'aria-controls': id
+          'aria-controls': id,
+          ...attrs
         }
       })
+    },
+    activeTab () {
+      let active = this.realActive
+      return isEmpty(active)
+        ? this.matchedTab || this.items[0]
+        : find(this.items, ({ name, id }) => name === active || id === active)
+    },
+    matchedTab () {
+      if (!this.$route || !this.items.some(({ to }) => to)) {
+        return null
+      }
+
+      return find(this.items, ({ matches, to }) => matches(this.$route, to))
+    },
+    showPanel () {
+      return this.$slots.panel || (this.activeTab && !this.activeTab.empty)
     }
   },
   watch: {
-    active (val) {
-      if (val === this.localActive) {
-        return
-      }
-      this.adaptToSetActive({
-        active: val
-      })
-    },
-    index (val) {
-      if (val === this.localIndex) {
-        return
-      }
-      this.adaptToSetActive({
-        index: val
-      })
-    },
-    localIndex (val) {
-      this.$emit('update:index', val)
-    },
-    localActive (val) {
-      this.$emit('update:active', val)
-    }
-  },
-  mounted () {
-    this.transitionSupported = 'transition' in document.documentElement.style
-
-    // 让子组件渲染完毕
-    this.$nextTick(() => {
-      let { menu, extra } = this.$refs
-      this.listResizeHandler()
-      this.inited = true
-      if (this.menuOverflow) {
-        menu.style.marginRight = extra.getBoundingClientRect().width
-      }
-    })
-  },
-  methods: {
-    add (tab, isMatched) {
-      let tabIndex = this.items.length
-      let domBaseIndex = tab.index
-
-      if (this.tabNames.indexOf(tab.name) !== -1) {
-        warn('[veui-tabs] Duplicate tab name.', this)
-      }
-
-      // 如果还没有找到选中的 tab，优先查看配置的 name
-      // 因为 index 有默认值，而 tab.name 会 fallback 到 id 上边，所以 active 不指定不会误判断
-      if (
-        (!this.activeId && tab.name === this.active) ||
-        (tabIndex === this.index && !this.active) ||
-        isMatched
-      ) {
-        this.localIndex = tabIndex
-        this.localActive = tab.name
-        this.activeId = tab.id
-      }
-
-      if (domBaseIndex >= tabIndex) {
-        this.items.push(tab)
-      } else {
-        this.items.splice(domBaseIndex, 0, tab)
-
-        // 这种情况要更新一下 index
-        this.localIndex = this.tabUids.indexOf(this.activeId)
-      }
-
+    items () {
       this.$nextTick(() => {
-        this.storeBoundingSize()
-        if (!this.transitionSupported) {
-          return
-        }
-
-        let tabItem = this.getTab(tab.name)
-        let end = $event => {
-          $event.stopPropagation()
-        }
-        let label = tabItem.querySelector(`.${this.$c('tabs-item-label')}`)
-        let remove = tabItem.querySelector(`.${this.$c('tabs-item-remove')}`)
-        if (label) {
-          label.addEventListener('transitionend', end)
-        }
-        if (tab.removable && remove) {
-          remove.addEventListener('transitionend', end)
-        }
+        this.updateLayout()
       })
     },
-
-    removeById (id) {
-      let index = this.tabUids.indexOf(id)
-
-      if (index < 0) {
-        return
-      }
-
-      // 外部控制有可能会多次进入，把任务往后推
-      if (this.removing) {
-        setTimeout(() => this.removeById(id), 100)
-        return
-      }
-      this.removing = true
-
-      let items = this.items
-      let item = items[index]
-      let tab = this.getTab(item.name)
-
-      // 视图已经销毁
+    activeTab (tab) {
       if (!tab) {
         return
       }
 
-      let needFixed = false
-      if (items.length > 1) {
-        needFixed =
-          (index === this.localIndex && index === 0) || index < this.localIndex
-        if (index === this.localIndex) {
-          let item = items[this.localIndex - 1] || items[this.localIndex + 1]
-          this.localIndex = items.indexOf(item)
-          this.localActive = item.name
-          this.activeId = item.id
-        }
-      } else {
-        this.localIndex = null
-        this.localActive = null
-        this.activeId = null
-      }
-
-      this.$nextTick(() => {
-        items.splice(index, 1)
-        if (needFixed) {
-          this.localIndex -= 1
-        }
-      })
-    },
-
-    setActive ({ active, index }) {
-      if (this.localActive === active || this.localIndex === index) {
-        return
-      }
-
-      if (this.removing) {
-        return
-      }
-
-      let values = this.tabNames
-
-      this.localIndex = index !== undefined ? index : values.indexOf(active)
-      this.localActive = active !== undefined ? active : values[index]
-      this.activeId =
-        this.localActive != null ? this.items[this.localIndex].id : null
-
-      if (this.menuOverflow && this.localActive) {
-        this.scroll({ itemName: this.localActive })
-      }
-    },
-
-    storeBoundingSize (menuRightStable) {
-      // 记录 resize 后的一些边界
-      let { menu, listContainer, extra } = this.$refs
-      if (!menu || !listContainer || !listContainer.$el || !extra) {
-        return
-      }
-      let tabConClientWidth = listContainer.$el.clientWidth
-      let menuClientWidth = menu.clientWidth
-      let extraWidth = extra.getBoundingClientRect().width
-      if (
-        this.tabConClientWidth !== tabConClientWidth ||
-        this.menuClientWidth !== menuClientWidth ||
-        this.extraWidth !== extraWidth
-      ) {
-        let { left, right } = menu.getBoundingClientRect()
-        assign(this, {
-          extraWidth,
-          tabConClientWidth,
-          menuClientWidth,
-          menuLeft: left,
-          menuRight: right,
-          menuRightStable: menuRightStable || right
-        })
-      }
-    },
-
-    fixResizeOverflow () {
-      if (this.menuOverflow) {
-        let listContainer = this.$refs.listContainer.$el
-        let { right } = listContainer.getBoundingClientRect()
-        if (this.menuRight > right) {
-          this.currentTranslate = this.maxTranslate
-          this.conMoving = true
-          this.bindTransition(listContainer, () => {
-            this.conMoving = false
-          })
-          this.$nextTick(() => {
-            setTransform(listContainer, `translate(${this.maxTranslate}px)`)
-          })
-        }
-      }
-    },
-
-    listResizeHandler () {
-      let { menu, extra, scroller, listContainer } = this.$refs
-      if (!listContainer || this.switching) {
-        // 销毁阶段
-        return
-      }
-
-      let menuWidth = menu.offsetWidth
-      let tabConWidth = listContainer.$el.offsetWidth
-      let stickyWidth = extra.getBoundingClientRect().width
-
-      let factor = this.menuOverflow
-        ? -(
-          scroller.offsetWidth +
-            parseFloat(getComputedStyle(scroller).marginLeft)
-        )
-        : stickyWidth
-      let menuOverflow = menuWidth < tabConWidth + factor
-
-      if (this.menuOverflow !== menuOverflow) {
-        this.switching = true
-      }
-      this.menuOverflow = menuOverflow
-
-      return new Promise(resolve => {
-        if (this.inited) {
-          this.menuMoving = true
-          this.conMoving = true
-        }
-
-        // 需要 menuOverflow 对 dom 进行更新
-        this.$nextTick(() => {
-          let menuRightStable
-          if (this.switching || this.extraWidth !== stickyWidth) {
-            this.bindTransition(menu, e => {
-              this.menuMoving = false
-              this.conMoving = false
-              this.storeBoundingSize()
-              this.fixResizeOverflow()
-              resolve()
-              this.switching = false
-            })
-
-            let extraWidth = extra.getBoundingClientRect().width
-            if (!this.menuOverflow) {
-              this.currentTranslate = 0
-              setTransform(listContainer.$el, 'translate(0)')
-              // 本来用 padding 就完事了，ie9 不让 -  -
-              menu.style.marginRight = 0
-            } else if (this.menuOverflow) {
-              // 这个值是为了溢出时横向滚动的同步动画计算记录的，不记录一个稳定位置无法准确滚到位
-              menuRightStable = this.menuRight
-                ? this.menuRight +
-                  parseFloat(getComputedStyle(menu).marginRight) -
-                  extraWidth
-                : null
-              menu.style.marginRight = extraWidth + 'px'
-            }
-          } else {
-            this.menuMoving = false
-            this.conMoving = false
-            this.storeBoundingSize(menuRightStable)
-            this.fixResizeOverflow()
-            resolve()
-            this.switching = false
-          }
-        })
-      })
-    },
-
-    /**
-     * 处理滚动至 tab 或者整体横向滚动
-     *
-     * 逻辑是如果视窗内最后一个 tab 有 1/3 以上的内容残缺，那就以它为基准，否则以它下一个为基准
-     * 例如往右滚动，视窗最后一个 tab 只有一点点内容看得到，那滚动完后，这个 tab 应该在第一个
-     * 如果能看到 2/3 以上的内容，那就是它的下一个 tab 在第一个，除非它是最后一个
-     *
-     * @param  {string} direction left 或者 right，整体横向滚动方向
-     * @param  {string} itemName  滚动至 tab 的 name，优先级比 direction 高
-     */
-    scroll ({ direction, itemName }) {
-      let listContainer = this.$refs.listContainer.$el
-      this.conMoving = true
-      this.bindTransition(listContainer, () => {
-        this.conMoving = false
-      })
-
-      // 极限值
-      let limited = {
-        left: 0,
-        right: this.maxTranslate
-      }
-      // 标志 tab 的边界值
-      let flag = { left: null, right: null }
-      // 本次滚动偏移值，带方向
-      let localTranslate
-      // 本次最大滚动偏移值，带方向，防止边框连续排列的美观性，统一向上取整，让边框隐藏在视区外
-      let localMaxTranslate
-      // 制定的滚动逻辑是否已经越界
-      let overflow = false
-
-      // TODO: 这里还可以再优化一下，通过计算中心位置的偏移量来判断是正向还是反向查询
-      if (!direction && !itemName) {
-        return
-      } else if (itemName) {
-        let { left, right } = this.getTab(itemName).getBoundingClientRect()
-
-        if (left < this.menuLeft) {
-          localTranslate = this.menuLeft - left
-          direction = 'left'
-        } else if (right > this.menuRightStable) {
-          localTranslate = this.menuRightStable - right
-          direction = 'right'
-        } else {
-          return
-        }
-      } else if (direction === 'left') {
-        let former = null
-        this.items.slice().some((item, index) => {
-          let tab = this.getTab(item.name)
-          let { marginLeft, marginRight } = getComputedStyle(tab)
-          let { left, right } = tab.getBoundingClientRect()
-
-          // 记录向左滚动极限距离
-          if (index === 0) {
-            localMaxTranslate = Math.ceil(this.menuLeft - left)
-          }
-
-          // 检查是否是一整个 tab 占满视窗的特殊情况，如果是，滚到上一个就是了
-          if (
-            Math.floor(left) <= this.menuLeft &&
-            Math.ceil(right) >= this.menuRight
-          ) {
-            former = index - 1
-            return true
-          }
-
-          // 减少 tab 留白和滚动误差带来的影响，三分之二宽度在视窗内才不会被保留在下个视窗中
-          if (
-            left >
-            this.menuLeft -
-              (tab.offsetWidth +
-                parseFloat(marginLeft) +
-                parseFloat(marginRight)) /
-                3
-          ) {
-            if (index === 0) {
-              // 第一个就满足条件，说明边界离第一个很近，往左只能在第一个的内部滚了
-              former = -1
-            }
-            return true
-          }
-
-          assign(flag, { left, right })
-          return false
-        })
-
-        if (former != null) {
-          // 视窗太窄或者只需要滚动一点点
-          if (former === -1) {
-            // 视窗在第一个或者只需要滚动一点点
-            localTranslate = localMaxTranslate
-          } else {
-            // 视窗在中间
-            let tab = this.getTab(this.items[former].name)
-            localTranslate =
-              this.menuRightStable - tab.getBoundingClientRect().right
-          }
-        } else {
-          localTranslate = this.menuRightStable - flag.right
-        }
-
-        // 逻辑滚动距离超出极限状态，向左滚动是正值，溢出使用小于号
-        overflow = localMaxTranslate <= localTranslate
-      } else if (direction === 'right') {
-        let former = null
-        this.items
-          .slice()
-          .reverse()
-          .some((item, index) => {
-            let tab = this.getTab(item.name)
-            let { marginLeft, marginRight } = getComputedStyle(tab)
-            let { left, right } = tab.getBoundingClientRect()
-
-            // 记录向右滚动极限距离
-            if (index === 0) {
-              localMaxTranslate = Math.ceil(this.menuRightStable - right)
-            }
-
-            // 检查是否是一整个 tab 占满视窗的特殊情况，如果是，滚到上一个就是了
-            if (
-              Math.floor(left) <= this.menuLeft &&
-              Math.ceil(right) >= this.menuRight
-            ) {
-              former = this.items.length - index
-              return true
-            }
-
-            // 同向左滚动
-            if (
-              right <
-              this.menuRightStable +
-                (tab.offsetWidth +
-                  parseFloat(marginLeft) +
-                  parseFloat(marginRight)) /
-                  3
-            ) {
-              if (index === 0) {
-                // 最后一个就满足条件，说明边界离最后一个很近，往右只能在最后一个的内部滚了
-                former = this.items.length
-              }
-              return true
-            }
-
-            assign(flag, { left, right })
-            return false
-          })
-
-        if (former != null) {
-          // 视窗太窄或者只需要滚动一点点
-          if (former === this.items.length) {
-            // 视窗在最后一个或者只需要滚动一点点
-            localTranslate = localMaxTranslate
-          } else {
-            // 视窗在中间
-            let tab = this.getTab(this.items[former].name)
-            localTranslate = this.menuLeft - tab.getBoundingClientRect().left
-          }
-        } else {
-          localTranslate = this.menuLeft - flag.left
-        }
-
-        // 逻辑滚动距离超出极限状态，向右滚动是负值，溢出使用大于号
-        overflow = localMaxTranslate >= localTranslate
-      }
-
-      if (overflow) {
-        this.currentTranslate = limited[direction]
-        this.$nextTick(() => {
-          setTransform(listContainer, `translate(${limited[direction]}px)`)
-        })
-        return
-      }
-
-      let matrix = getTransform(listContainer)
-        .slice(7)
-        .split(',')
-        .map(v => +v.trim())
-      let currentTranslate = matrix[4] + localTranslate
-      currentTranslate = inRange(
-        currentTranslate,
-        limited[direction] - 2,
-        limited[direction] + 2
-      )
-        ? limited[direction]
-        : currentTranslate
-      this.currentTranslate = currentTranslate
-      this.$nextTick(() => {
-        setTransform(listContainer, `translate(${currentTranslate}px)`)
-      })
-    },
-
-    adaptToSetActive (activation) {
-      // 由于 watcher 是同步的
-      // 为了支持外部 add/remove 修改完 tab 源数据（slot 中用于循环的数组）就可以同步操作 active/index
-      // 这里要让数据层的异步操作完成
-      this.$nextTick(() => {
-        // add 的逻辑是异步的，因此 add 之后的 resize 会在这个逻辑之后，这里直接同步调用一次让 resize 完成
-        let resizeUpdated = this.listResizeHandler()
-        // 需要判断是不是有返回，因为锁存在的情况下是直接 return 的
-        resizeUpdated && resizeUpdated.then(() => this.setActive(activation))
-      })
-    },
-
-    getTab (name) {
-      return this.$refs[`tab-${name}`][0]
-    },
-
-    bindTransition (el, cb) {
-      if (!this.transitionSupported) {
-        setTimeout(() => {
-          cb()
-        }, 0)
-        return
-      }
-
-      let end = $event => {
-        $event.stopPropagation()
-        cb($event)
-        el.removeEventListener('transitionend', end)
-      }
-      el.addEventListener('transitionend', end)
-    },
-
-    translateTabs (tabs, distance) {
-      tabs.forEach(tab => setTransform(tab, `translate(${distance}px)`))
-    },
-
-    beforeLeave (el) {
-      if (!this.needTransition) {
-        return
-      }
-
-      this.menuMoving = true
-      this.conMoving = true
-      this.itemMoving = true
-    },
-
-    leave (el) {
-      if (!this.needTransition) {
-        return
-      }
-
-      // 若产生子元素局部动画，要把局部的状态收敛到父元素上
-      this.fixedTranslate = null
-      this.fixedTabs = null
-      this.needResize = false
-
-      this.$nextTick(() => {
-        el.style.paddingRight = 0
-      })
-
-      let transitionWidth = 0
-      el.style.width = el.offsetWidth + 'px'
-
-      if (this.menuOverflow) {
-        let { menu, listContainer } = this.$refs
-        let conRight = listContainer.$el.getBoundingClientRect().right
-        let elWidth = el.getBoundingClientRect().width
-        let overflowWidth = conRight - this.menuRight
-        let currentTranslate = Math.abs(this.currentTranslate)
-        let distance
-        switch (true) {
-          // 右侧溢出部分足够填充移除元素
-          case overflowWidth > elWidth:
-            transitionWidth = 0
-            break
-          // 左侧溢出部分足够填充移除元素
-          case overflowWidth < elWidth && currentTranslate > elWidth:
-            transitionWidth = null
-            distance = elWidth
-            this.fixedTabs = this.items
-              .filter((item, index) => index < el.dataset.index)
-              .map(({ name }) => this.getTab(name))
-            this.fixedTranslate = elWidth - currentTranslate
-            break
-          // 左右都不足以单独填充移除元素
-          case overflowWidth < elWidth && currentTranslate < elWidth:
-            transitionWidth = 0
-            distance = currentTranslate
-            this.fixedTabs = this.items.map(({ name }) => this.getTab(name))
-            this.fixedTranslate = 0
-            // 左右合并之后如果足以填充移除元素，可以暂时不关注溢出状态
-            // 但是不足就要先移动右侧来填补中间的空白，然后再主动 resize
-            if (overflowWidth + currentTranslate < elWidth) {
-              this.needResize = true
-              this.$nextTick(() => {
-                // 右侧动画
-                menu.style.marginRight =
-                  parseFloat(menu.style.marginRight) +
-                  elWidth -
-                  currentTranslate -
-                  overflowWidth +
-                  'px'
-              })
-            }
-            break
-          default:
-            break
-        }
-
-        // 左侧的动画
-        if (distance != null) {
-          this.$nextTick(() => {
-            this.translateTabs([...this.fixedTabs, el], distance)
-          })
-        }
-      }
-
-      // 删除元素本身的动画
-      if (transitionWidth != null) {
-        this.$nextTick(() => {
-          el.style.width = transitionWidth
-        })
-      }
-    },
-
-    afterLeave () {
-      if (!this.needTransition) {
-        this.$nextTick(() => {
-          this.removing = false
-          this.listResizeHandler()
-        })
-        return
-      }
-
-      // 动画结束后收敛 transform
-      this.removing = false
-      this.menuMoving = false
-      this.itemMoving = false
-      this.conMoving = false
-      this.$nextTick(() => {
-        if (this.fixedTranslate != null) {
-          this.translateTabs(this.fixedTabs, 0)
-          this.currentTranslate = this.fixedTranslate
-          setTransform(
-            this.$refs.listContainer.$el,
-            `translate(${this.fixedTranslate}px)`
-          )
-        }
-        let extraWidth = this.$refs.extra.getBoundingClientRect().width
-        if (extraWidth !== this.extraWidth && this.menuOverflow) {
-          // extra 里头可能有 tip 会影响宽度，需要检查
-          this.listResizeHandler()
-        } else {
-          this.storeBoundingSize()
-          if (this.needResize) {
-            this.listResizeHandler()
-          }
-        }
+      // Might trigger overflow change and scrollers need to be rendered before this
+      setTimeout(() => {
+        this.scrollTabIntoView(tab)
       })
     }
+  },
+  mounted () {
+    if (!this.active && this.activeTab) {
+      this.realActive = this.activeTab.name || this.activeTab.id
+    }
+
+    this.updateLayout()
+  },
+  methods: {
+    handleActivate ({ disabled, name, id }) {
+      if (disabled) {
+        return
+      }
+      this.realActive = name || id
+    },
+    handleRemove (tab, e) {
+      this.$emit('remove', tab)
+      e.stopPropagation()
+    },
+    handleAdd () {
+      this.$emit('add')
+    },
+    updateLayout () {
+      let { list, items = [] } = this.$refs
+
+      // need to check tab counts because of a WebKit bug
+      // see https://codepen.io/Justineo/pen/Poqdawm
+      this.listOverflow =
+        items.length === 0 ? false : list.scrollWidth > list.clientWidth
+
+      this.stops = items.map(el => [
+        el.offsetLeft,
+        el.offsetLeft + el.offsetWidth
+      ])
+    },
+    scrollTabIntoView (tab) {
+      let { list } = this.$refs
+      let index = findIndex(this.items, ({ id }) => id === tab.id)
+      if (index === -1) {
+        return
+      }
+      let [tabStart, tabEnd] = this.stops[index]
+      let viewStart = list.scrollLeft
+      let viewEnd = list.scrollLeft + list.clientWidth
+
+      if (
+        (tabStart >= viewStart && tabEnd <= viewEnd) ||
+        tabEnd - tabStart >= viewEnd - viewStart
+      ) {
+        return
+      }
+
+      if (tabStart < viewStart) {
+        this.scrollTo(tabStart)
+      } else if (tabEnd > viewEnd) {
+        this.scrollTo(tabEnd - list.clientWidth)
+      }
+    },
+    scrollTo (x) {
+      let { list } = this.$refs
+
+      scrollTo(list, x, 0)
+    },
+    handleScroll (forward) {
+      let { list } = this.$refs
+
+      let current = forward
+        ? list.scrollLeft + list.clientWidth
+        : list.scrollLeft
+      let target = find(this.stops, ([start, end], i) => {
+        if (forward) {
+          let prev = this.stops[i - 1]
+
+          if (!prev) {
+            return false
+          }
+
+          return prev[1] <= current && current < end
+        } else {
+          let next = this.stops[i + 1]
+
+          if (!next) {
+            return false
+          }
+
+          return start <= current && current < next[0]
+        }
+      })
+      if (!target) {
+        return
+      }
+      this.scrollTo(forward ? target[0] : target[1] - list.clientWidth)
+    },
+    updateScrollState () {
+      let { list } = this.$refs
+
+      this.hit = {
+        start: list.scrollLeft === 0,
+        end: list.scrollLeft + list.clientWidth >= list.scrollWidth
+      }
+    },
+    handleRemoveChild (index) {
+      let activeIndex = index === 0 ? 0 : index - 1
+      let tab = this.items[activeIndex]
+      if (tab) {
+        this.realActive = tab.name || tab.id
+      }
+    }
+  },
+  render () {
+    const renderTabItem = this.$scopedSlots['tab-item']
+    const renderLabel =
+      this.$scopedSlots['tab-item-label'] ||
+      (({ label, status }) => [
+        <div class={this.$c('tabs-item-label-content')}>
+          {label}
+          {status ? (
+            <Icon
+              class={[
+                this.$c('tabs-item-status'),
+                this.$c(`tabs-item-status-${status}`)
+              ]}
+              name={this.icons[status]}
+            />
+          ) : null}
+        </div>
+      ])
+
+    return (
+      <div
+        class={{
+          [this.$c('tabs')]: true,
+          [this.$c('tabs-empty')]: this.items.length === 0
+        }}
+        ui={this.realUi}
+      >
+        <div class={this.$c('tabs-menu')}>
+          {this.listOverflow ? (
+            <Button
+              class={this.$c('tabs-prev')}
+              ui={this.uiParts.nav}
+              disabled={this.hit.start}
+              onClick={throttle(() => this.handleScroll(false), 200)}
+            >
+              <Icon name={this.icons.prev} />
+            </Button>
+          ) : null}
+          <div
+            ref="list"
+            class={this.$c('tabs-list')}
+            role="tablist"
+            onScroll={this.updateScrollState}
+          >
+            {this.items.map((tab, index) => (
+              <div
+                key={tab.id}
+                ref="items"
+                refInFor
+                class={{
+                  [this.$c('tabs-item')]: true,
+                  [this.$c('tabs-item-disabled')]: tab.disabled,
+                  [this.$c('tabs-item-removable')]: tab.removable,
+                  [this.$c('tabs-item-active')]: this.activeTab === tab,
+                  [this.$c('tabs-item-remove-focus')]: this.focusedTab === tab
+                }}
+              >
+                {renderTabItem ? (
+                  renderTabItem({
+                    ...tab,
+                    index,
+                    attrs: this.tabAttrs[index],
+                    activate: () => this.handleActivate(tab)
+                  })
+                ) : tab.to ? (
+                  <Link
+                    class={this.$c('tabs-item-label')}
+                    to={tab.to}
+                    native={tab.native}
+                    disabled={tab.disabled}
+                    onClick={() => this.handleActivate(tab)}
+                    {...{ attrs: this.tabAttrs[index] }}
+                  >
+                    {renderLabel({
+                      ...tab,
+                      index,
+                      attrs: this.tabAttrs[index]
+                    })}
+                  </Link>
+                ) : (
+                  <button
+                    type="button"
+                    class={this.$c('tabs-item-label')}
+                    disabled={tab.disabled}
+                    onClick={() => this.handleActivate(tab)}
+                    {...{ attrs: this.tabAttrs[index] }}
+                  >
+                    {renderLabel({
+                      ...tab,
+                      index,
+                      attrs: this.tabAttrs[index]
+                    })}
+                  </button>
+                )}
+                {tab.removable ? (
+                  <Button
+                    class={this.$c('tabs-item-remove')}
+                    ui={this.uiParts.remove}
+                    onClick={e => this.handleRemove(tab, e)}
+                    onFocus={() => {
+                      this.focusedTab = tab
+                    }}
+                    onBlur={() => {
+                      this.focusedTab = null
+                    }}
+                  >
+                    <Icon
+                      name={this.icons.remove}
+                      label={this.t('remove', { label: tab.label })}
+                    />
+                  </Button>
+                ) : null}
+              </div>
+            ))}
+          </div>
+          {this.listOverflow ? (
+            <Button
+              class={this.$c('tabs-next')}
+              ui={this.uiParts.nav}
+              disabled={this.hit.end}
+              onClick={() => this.handleScroll(true)}
+            >
+              <Icon name={this.icons.next} />
+            </Button>
+          ) : null}
+          {this.addable ? (
+            <Button
+              class={this.$c('tabs-add')}
+              ui={this.uiParts.add}
+              disabled={this.max != null && this.items.length >= this.max}
+              onClick={this.handleAdd}
+            >
+              <Icon name={this.icons.add} />
+              {this.t('add')}
+            </Button>
+          ) : null}
+          {this.tip || this.$slots.extra ? (
+            <div class={this.$c('tabs-extra')}>
+              {this.$slots.extra ||
+                (this.tip ? (
+                  <div class={this.$c('tabs-tip')}>{this.tip}</div>
+                ) : null)}
+            </div>
+          ) : null}
+        </div>
+        <div v-show="showPanel" class={this.$c('tabs-panel')}>
+          {this.$slots.default}
+          {!this.activeTab || this.activeTab.empty ? this.$slots.panel : null}
+        </div>
+      </div>
+    )
   }
 }
 </script>

--- a/packages/veui/src/locale/en-US/Tabs.js
+++ b/packages/veui/src/locale/en-US/Tabs.js
@@ -3,7 +3,7 @@ import i18n from '../../managers/i18n'
 i18n.register(
   'en-US',
   {
-    remove: 'Remove',
+    remove: 'Remove {label}',
     add: 'Add'
   },
   {

--- a/packages/veui/src/locale/zh-Hans/Tabs.js
+++ b/packages/veui/src/locale/zh-Hans/Tabs.js
@@ -3,7 +3,7 @@ import i18n from '../../managers/i18n'
 i18n.register(
   'zh-Hans',
   {
-    remove: '删除',
+    remove: '删除{label}',
     add: '添加'
   },
   {

--- a/packages/veui/src/mixins/controllable.js
+++ b/packages/veui/src/mixins/controllable.js
@@ -2,11 +2,8 @@ import { capitalize, isString, isPlainObject, reduce } from 'lodash'
 
 let options = {
   methods: {
-    hasProp (name) {
-      return name in this.$options.propsData && this[name] !== undefined
-    },
     getReal ({ prop, local } = {}) {
-      return this.hasProp(prop)
+      return hasProp(this, prop)
         ? this[prop]
         : local
           ? this[local]
@@ -25,6 +22,10 @@ let options = {
       }
     }
   }
+}
+
+function hasProp (vm, name) {
+  return name in vm.$options.propsData && vm[name] !== undefined
 }
 
 export default function makeControllable (props) {

--- a/packages/veui/test/unit/specs/components/Tabs.spec.js
+++ b/packages/veui/test/unit/specs/components/Tabs.spec.js
@@ -54,7 +54,7 @@ describe('components/Tabs', () => {
     wrapper.destroy()
   })
 
-  it('should render active tab correctly with controlled `active` prop', async () => {
+  it('should render active tab correctly with controlled `active` prop and `change` event', async () => {
     let wrapper = mount(
       {
         components: {
@@ -62,7 +62,7 @@ describe('components/Tabs', () => {
           'veui-tab': Tab
         },
         template: `
-          <veui-tabs :active="active">
+          <veui-tabs :active="active" @change="handleChange">
             <veui-tab name="a" label="#1">ONE</veui-tab>
             <veui-tab name="b" label="#2">TWO</veui-tab>
             <veui-tab name="c" label="#3">THREE</veui-tab>
@@ -70,6 +70,13 @@ describe('components/Tabs', () => {
         data () {
           return {
             active: 'c'
+          }
+        },
+        methods: {
+          handleChange ({ name }) {
+            if (name === 'c') {
+              this.active = name
+            }
           }
         }
       },
@@ -109,6 +116,19 @@ describe('components/Tabs', () => {
 
     panel = wrapper.find('.veui-tabs-panel')
     expect(panel.text()).to.equal('TWO')
+
+    tabs
+      .at(2)
+      .find('button')
+      .trigger('click')
+
+    await vm.$nextTick()
+
+    expect(tabs.at(1).classes()).to.not.include('veui-tabs-item-active')
+    expect(tabs.at(2).classes()).to.include('veui-tabs-item-active')
+
+    panel = wrapper.find('.veui-tabs-panel')
+    expect(panel.text()).to.equal('THREE')
 
     wrapper.destroy()
   })
@@ -560,7 +580,6 @@ describe('components/Tabs', () => {
     btns.at(2).trigger('click')
 
     await wait(400)
-    console.log(list.scrollLeft, list.clientWidth, list.scrollWidth)
     expect(list.scrollLeft + list.clientWidth).to.equal(list.scrollWidth)
     expect(prev.element.disabled).to.equal(false)
     expect(next.element.disabled).to.equal(true)

--- a/packages/veui/test/unit/specs/components/Tabs.spec.js
+++ b/packages/veui/test/unit/specs/components/Tabs.spec.js
@@ -1,0 +1,499 @@
+import { mount } from '@vue/test-utils'
+import Tabs from '@/components/Tabs'
+import Tab from '@/components/Tab'
+import { findIndex } from 'lodash'
+
+describe('components/Tabs', () => {
+  it('should render default active tab correctly with uncontrolled `active` prop', async () => {
+    let wrapper = mount(
+      {
+        components: {
+          'veui-tabs': Tabs,
+          'veui-tab': Tab
+        },
+        template: `
+          <veui-tabs>
+            <veui-tab label="#1">ONE</veui-tab>
+            <veui-tab label="#2">TWO</veui-tab>
+            <veui-tab label="#3">THREE</veui-tab>
+          </veui-tabs>`
+      },
+      {
+        sync: false,
+        attachToDocument: true
+      }
+    )
+
+    let { vm } = wrapper
+
+    await vm.$nextTick()
+
+    let tabs = wrapper.findAll('.veui-tabs-item')
+    expect(tabs.at(0).text()).to.equal('#1')
+    expect(tabs.at(1).text()).to.equal('#2')
+    expect(tabs.at(2).text()).to.equal('#3')
+    expect(tabs.at(0).classes()).to.include('veui-tabs-item-active')
+
+    let panel = wrapper.find('.veui-tabs-panel')
+    expect(panel.text()).to.equal('ONE')
+
+    tabs
+      .at(2)
+      .find('button')
+      .trigger('click')
+
+    await vm.$nextTick()
+
+    expect(tabs.at(0).classes()).to.not.include('veui-tabs-item-active')
+    expect(tabs.at(2).classes()).to.include('veui-tabs-item-active')
+
+    panel = wrapper.find('.veui-tabs-panel')
+    expect(panel.text()).to.equal('THREE')
+
+    wrapper.destroy()
+  })
+
+  it('should render active tab correctly with controlled `active` prop', async () => {
+    let wrapper = mount(
+      {
+        components: {
+          'veui-tabs': Tabs,
+          'veui-tab': Tab
+        },
+        template: `
+          <veui-tabs :active="active">
+            <veui-tab name="a" label="#1">ONE</veui-tab>
+            <veui-tab name="b" label="#2">TWO</veui-tab>
+            <veui-tab name="c" label="#3">THREE</veui-tab>
+          </veui-tabs>`,
+        data () {
+          return {
+            active: 'c'
+          }
+        }
+      },
+      {
+        sync: false,
+        attachToDocument: true
+      }
+    )
+
+    let { vm } = wrapper
+
+    await vm.$nextTick()
+    let tabs = wrapper.findAll('.veui-tabs-item')
+    expect(tabs.at(2).classes()).to.include('veui-tabs-item-active')
+
+    let panel = wrapper.find('.veui-tabs-panel')
+    expect(panel.text()).to.equal('THREE')
+
+    vm.active = 'b'
+
+    await vm.$nextTick()
+
+    expect(tabs.at(1).classes()).to.include('veui-tabs-item-active')
+
+    panel = wrapper.find('.veui-tabs-panel')
+    expect(panel.text()).to.equal('TWO')
+
+    tabs
+      .at(0)
+      .find('button')
+      .trigger('click')
+
+    await vm.$nextTick()
+
+    expect(tabs.at(1).classes()).to.include('veui-tabs-item-active')
+    expect(tabs.at(0).classes()).to.not.include('veui-tabs-item-active')
+
+    panel = wrapper.find('.veui-tabs-panel')
+    expect(panel.text()).to.equal('TWO')
+
+    wrapper.destroy()
+  })
+
+  it('should render active tab correctly with controlled `active` prop with `.sync`', async () => {
+    let wrapper = mount(
+      {
+        components: {
+          'veui-tabs': Tabs,
+          'veui-tab': Tab
+        },
+        template: `
+          <veui-tabs :active.sync="active">
+            <veui-tab name="a" label="#1">ONE</veui-tab>
+            <veui-tab name="b" label="#2">TWO</veui-tab>
+            <veui-tab name="c" label="#3">THREE</veui-tab>
+          </veui-tabs>`,
+        data () {
+          return {
+            active: 'c'
+          }
+        }
+      },
+      {
+        sync: false,
+        attachToDocument: true
+      }
+    )
+
+    let { vm } = wrapper
+
+    await vm.$nextTick()
+    let tabs = wrapper.findAll('.veui-tabs-item')
+    expect(tabs.at(2).classes()).to.include('veui-tabs-item-active')
+
+    let panel = wrapper.find('.veui-tabs-panel')
+    expect(panel.text()).to.equal('THREE')
+
+    vm.active = 'b'
+
+    await vm.$nextTick()
+
+    expect(tabs.at(1).classes()).to.include('veui-tabs-item-active')
+
+    panel = wrapper.find('.veui-tabs-panel')
+    expect(panel.text()).to.equal('TWO')
+
+    tabs
+      .at(0)
+      .find('button')
+      .trigger('click')
+
+    await vm.$nextTick()
+
+    expect(tabs.at(1).classes()).to.not.include('veui-tabs-item-active')
+    expect(tabs.at(0).classes()).to.include('veui-tabs-item-active')
+
+    panel = wrapper.find('.veui-tabs-panel')
+    expect(panel.text()).to.equal('ONE')
+
+    expect(vm.active).to.equal('a')
+
+    wrapper.destroy()
+  })
+
+  it('should handle add & remove correctly', async () => {
+    let count = 4
+    let wrapper = mount(
+      {
+        components: {
+          'veui-tabs': Tabs,
+          'veui-tab': Tab
+        },
+        template: `
+          <veui-tabs
+            :active.sync="active"
+            addable
+            @add="handleAdd"
+            @remove="handleRemove"
+          >
+            <veui-tab
+              v-for="tab in tabs"
+              :key="tab.name"
+              :name="tab.name"
+              :label="tab.label"
+              removable
+            >{{ tab.content }}</veui-tab>
+          </veui-tabs>`,
+        data () {
+          return {
+            tabs: [
+              { label: '#1', content: '=1=', name: '1' },
+              { label: '#2', content: '=2=', name: '2' },
+              { label: '#3', content: '=3=', name: '3' },
+              { label: '#4', content: '=4=', name: '4' }
+            ],
+            active: '2'
+          }
+        },
+        methods: {
+          handleAdd () {
+            count++
+            this.tabs.push({
+              label: `#${count}`,
+              content: `=${count}=`,
+              name: String(count)
+            })
+          },
+          handleRemove ({ name }) {
+            this.tabs.splice(
+              findIndex(this.tabs, tab => tab.name === name),
+              1
+            )
+          }
+        }
+      },
+      {
+        sync: false,
+        attachToDocument: true
+      }
+    )
+
+    let { vm } = wrapper
+
+    await vm.$nextTick()
+    let tabs = wrapper.findAll('.veui-tabs-item')
+    let btns = wrapper.findAll('.veui-tabs-item-remove')
+    expect(tabs.at(1).classes()).to.include('veui-tabs-item-active')
+    btns.at(1).trigger('click')
+
+    await vm.$nextTick()
+    tabs = wrapper.findAll('.veui-tabs-item')
+    btns = wrapper.findAll('.veui-tabs-item-remove')
+    expect(tabs.at(0).classes()).to.include('veui-tabs-item-active')
+    expect(tabs.at(1).text()).to.equal('#3')
+    btns.at(0).trigger('click')
+
+    await vm.$nextTick()
+    tabs = wrapper.findAll('.veui-tabs-item')
+    btns = wrapper.findAll('.veui-tabs-item-remove')
+    expect(tabs.at(0).classes()).to.include('veui-tabs-item-active')
+    expect(tabs.at(0).text()).to.equal('#3')
+
+    let add = wrapper.find('.veui-tabs-add')
+    add.trigger('click')
+
+    await vm.$nextTick()
+    tabs = wrapper.findAll('.veui-tabs-item')
+    expect(tabs.at(2).text()).to.equal('#5')
+
+    add.trigger('click')
+
+    await vm.$nextTick()
+    tabs = wrapper.findAll('.veui-tabs-item')
+    expect(tabs.at(3).text()).to.equal('#6')
+
+    wrapper.destroy()
+  })
+
+  it('should handle `max` prop correctly', async () => {
+    let count = 4
+    let wrapper = mount(
+      {
+        components: {
+          'veui-tabs': Tabs,
+          'veui-tab': Tab
+        },
+        template: `
+          <veui-tabs
+            :max="5"
+            addable
+            @add="handleAdd"
+          >
+            <veui-tab
+              v-for="tab in tabs"
+              :key="tab.name"
+              :name="tab.name"
+              :label="tab.label"
+              removable
+            >{{ tab.content }}</veui-tab>
+          </veui-tabs>`,
+        data () {
+          return {
+            tabs: [
+              { label: '#1', content: '=1=', name: '1' },
+              { label: '#2', content: '=2=', name: '2' },
+              { label: '#3', content: '=3=', name: '3' },
+              { label: '#4', content: '=4=', name: '4' }
+            ]
+          }
+        },
+        methods: {
+          handleAdd () {
+            count++
+            this.tabs.push({
+              label: `#${count}`,
+              content: `=${count}=`,
+              name: String(count)
+            })
+          }
+        }
+      },
+      {
+        sync: false,
+        attachToDocument: true
+      }
+    )
+
+    let { vm } = wrapper
+
+    await vm.$nextTick()
+    let add = wrapper.find('.veui-tabs-add')
+
+    expect(add.element.disabled).to.equal(false)
+    add.trigger('click')
+
+    await vm.$nextTick()
+    expect(add.element.disabled).to.equal(true)
+
+    wrapper.destroy()
+  })
+
+  it('should render `tip` prop correctly', async () => {
+    let wrapper = mount(
+      {
+        components: {
+          'veui-tabs': Tabs,
+          'veui-tab': Tab
+        },
+        template: `
+          <veui-tabs tip="Watch out!">
+            <veui-tab label="#1">ONE</veui-tab>
+            <veui-tab label="#2">TWO</veui-tab>
+            <veui-tab label="#3">THREE</veui-tab>
+          </veui-tabs>`
+      },
+      {
+        sync: false,
+        attachToDocument: true
+      }
+    )
+
+    let { vm } = wrapper
+
+    await vm.$nextTick()
+
+    expect(wrapper.find('.veui-tabs-extra').text()).to.equal('Watch out!')
+
+    wrapper.destroy()
+  })
+
+  it('should render `tab-item` scoped slot correctly', async () => {
+    let wrapper = mount(
+      {
+        components: {
+          'veui-tabs': Tabs,
+          'veui-tab': Tab
+        },
+        template: `
+          <veui-tabs>
+            <veui-tab label="#1">ONE</veui-tab>
+            <veui-tab label="#2" disabled>TWO</veui-tab>
+            <veui-tab label="#3">THREE</veui-tab>
+            <template #tab-item="tab">
+              <button
+                type="button"
+                class="my-btn"
+                :disabled="tab.disabled"
+                v-bind="tab.attrs"
+                @click="tab.activate"
+              >
+                {{ tab.label }}
+              </button>
+            </template>
+          </veui-tabs>`
+      },
+      {
+        sync: false,
+        attachToDocument: true
+      }
+    )
+
+    let { vm } = wrapper
+
+    await vm.$nextTick()
+
+    let tabs = wrapper.findAll('.veui-tabs-item')
+    expect(tabs.at(0).classes()).to.include('veui-tabs-item-active')
+
+    let btns = wrapper.findAll('.my-btn')
+    expect(btns.length).to.equal(3)
+
+    btns.at(1).trigger('click')
+
+    await vm.$nextTick()
+    expect(tabs.at(0).classes()).to.include('veui-tabs-item-active')
+    expect(tabs.at(1).classes()).to.not.include('veui-tabs-item-active')
+
+    btns.at(2).trigger('click')
+
+    await vm.$nextTick()
+    expect(tabs.at(0).classes()).to.not.include('veui-tabs-item-active')
+    expect(tabs.at(2).classes()).to.include('veui-tabs-item-active')
+
+    wrapper.destroy()
+  })
+
+  it('should render `extra` and `panel` slots correctly', async () => {
+    let wrapper = mount(
+      {
+        components: {
+          'veui-tabs': Tabs,
+          'veui-tab': Tab
+        },
+        template: `
+          <veui-tabs>
+            <veui-tab label="#1"/>
+            <veui-tab label="#2"/>
+            <veui-tab label="#3"/>
+            <template #extra>WATCH OUT!</template>
+            <template #panel>PANEL CONTENT</template>
+          </veui-tabs>`
+      },
+      {
+        sync: false,
+        attachToDocument: true
+      }
+    )
+
+    let { vm } = wrapper
+
+    await vm.$nextTick()
+
+    expect(wrapper.find('.veui-tabs-extra').text()).to.equal('WATCH OUT!')
+    expect(wrapper.find('.veui-tabs-panel').text()).to.equal('PANEL CONTENT')
+
+    let tabs = wrapper.findAll('.veui-tabs-item')
+    tabs
+      .at(1)
+      .find('button')
+      .trigger('click')
+
+    await vm.$nextTick()
+    expect(wrapper.find('.veui-tabs-panel').text()).to.equal('PANEL CONTENT')
+
+    wrapper.destroy()
+  })
+
+  it("should render Tab's `status` correctly", async () => {
+    let wrapper = mount(
+      {
+        components: {
+          'veui-tabs': Tabs,
+          'veui-tab': Tab
+        },
+        template: `
+          <veui-tabs>
+            <veui-tab label="#1" status="error">ONE</veui-tab>
+            <veui-tab label="#2">TWO</veui-tab>
+            <veui-tab label="#3" status="success">THREE</veui-tab>
+          </veui-tabs>`
+      },
+      {
+        sync: false,
+        attachToDocument: true
+      }
+    )
+
+    let { vm } = wrapper
+
+    await vm.$nextTick()
+
+    let tabs = wrapper.findAll('.veui-tabs-item')
+    expect(
+      tabs
+        .at(0)
+        .find('.veui-tabs-item-status-error')
+        .exists()
+    ).to.equal(true)
+    expect(
+      tabs
+        .at(2)
+        .find('.veui-tabs-item-status-success')
+        .exists()
+    ).to.equal(true)
+
+    wrapper.destroy()
+  })
+})

--- a/packages/veui/test/unit/specs/components/Tabs.spec.js
+++ b/packages/veui/test/unit/specs/components/Tabs.spec.js
@@ -498,7 +498,9 @@ describe('components/Tabs', () => {
     wrapper.destroy()
   })
 
-  it('should handle scroll correctly', async () => {
+  it('should handle scroll and resize correctly', async function () {
+    this.timeout(3000)
+
     let wrapper = mount(
       {
         components: {
@@ -558,6 +560,7 @@ describe('components/Tabs', () => {
     btns.at(2).trigger('click')
 
     await wait(400)
+    console.log(list.scrollLeft, list.clientWidth, list.scrollWidth)
     expect(list.scrollLeft + list.clientWidth).to.equal(list.scrollWidth)
     expect(prev.element.disabled).to.equal(false)
     expect(next.element.disabled).to.equal(true)
@@ -568,6 +571,12 @@ describe('components/Tabs', () => {
     expect(list.scrollLeft).to.equal(0)
     expect(prev.element.disabled).to.equal(true)
     expect(next.element.disabled).to.equal(false)
+
+    wrapper.find('.veui-tabs').element.style.width = '300px'
+
+    await wait(400)
+    expect(wrapper.find('.veui-tabs-prev').exists()).to.equal(false)
+    expect(wrapper.find('.veui-tabs-next').exists()).to.equal(false)
 
     wrapper.destroy()
   })


### PR DESCRIPTION
### 具体变更

- 移除了添加/移除 Tab 的动效以及 `ui="block"` **<sup>BREAKING</sup>**
- 移除了 `index` prop **<sup>BREAKING</sup>**
- `tabs-extra` slot 更名为 `extra`，且仅包括提示区域的内容，不包括添加按钮 **<sup>BREAKING</sup>**
- 移除了 `tabs-extra-label` 与 `tabs-extra-tip` slot **<sup>BREAKING</sup>**
- `tab-item` scoped slot 现在包含整个按钮/链接，方便替换为自定义实现 **<sup>BREAKING</sup>**
- 新增了 `tab-item-label` scoped slot 用来仅自定义标签内容
- 移除了 `tab-item-extra` scoped slot，`removable` 的 `Tab` 组件始终显示移除按钮 **<sup>BREAKING</sup>**
- 新增了 `panel` slot，在 `Tab` 组件无内联内容时在 `Tabs` panel 内输出自定义内容。
- 在路由模式下，不再自动输出 `<router-view>` 组件，需要通过 `Tab` 的 `default` slot 或 `Tabs` 的 `panel` slot 中进行输出。**<sup>BREAKING</sup>**

---

### 总结

新的 `Tabs` 仅用 `active` prop 控制激活态，支持受控（包括 `.sync`）/非受控方式。

`Tabs` 的 slot 支持：`panel`、`extra`、`tab-item` <sup>scoped</sup>、`tab-item-label` <sup>scoped</sup>。

