### PR TITLE
feat: add lazy load for Carousel (#655)

### DIFF
--- a/packages/veui/demo/cases/Carousel.vue
+++ b/packages/veui/demo/cases/Carousel.vue
@@ -62,6 +62,7 @@
       :wrap="wrap"
       :indicator="indicator"
       :autoplay="autoplay"
+      lazy
     />
   </section>
 </article>
@@ -116,6 +117,17 @@ export default {
             'http://ecmb.bdimg.com/public01/one-design/e1b6473c898d9e456452ee79d7533a86.jpeg',
           alt: 'A white and gray dolphin in blue water.',
           label: '海豚'
+        },
+        {
+          src: 'https://www.baidu.com/img/bd_logo1.png',
+          alt: 'Baidu logo.',
+          label: '百度'
+        },
+        {
+          src:
+            'https://ss3.bdstatic.com/yrwDcj7w0QhBkMak8IuT_XF5ehU5bvGh7c50/logopic/1b61ee88fdb4a4b918816ae1cfd84af1_fullsize.jpg',
+          alt: 'Tesla logo.',
+          label: '特斯拉'
         }
       ]
     }

--- a/packages/veui/src/components/Carousel.vue
+++ b/packages/veui/src/components/Carousel.vue
@@ -217,6 +217,7 @@ export default {
   },
   beforeDestroy () {
     this.stop()
+    clearTimeout(this.focusTimer)
   },
   methods: {
     step (delta, focus) {
@@ -255,9 +256,9 @@ export default {
     focusCurrent () {
       clearTimeout(this.focusTimer)
       this.focusTimer = setTimeout(() => {
-        this.$refs.item[this.realIndex].focus()
         this.focused = true
         this.focusedIndex = this.realIndex
+        this.$refs.item[this.realIndex].focus()
       })
     },
     initPlay () {
@@ -266,15 +267,11 @@ export default {
         return
       }
       this.playTimer = setInterval(() => {
-        if (this.focusedIndex != null) {
-          this.focusCurrent()
-        }
         this.step(1)
       }, this.interval)
     },
     stop () {
       clearTimeout(this.playTimer)
-      clearTimeout(this.focusTimer)
     },
     handleEnter () {
       if (this.pauseOnHover) {

--- a/packages/veui/test/unit/specs/components/Carousel.spec.js
+++ b/packages/veui/test/unit/specs/components/Carousel.spec.js
@@ -1,0 +1,577 @@
+import { mount } from '@vue/test-utils'
+import { wait } from '../../../utils'
+import Carousel from '@/components/Carousel'
+
+let items = [
+  {
+    src:
+      'http://ecmb.bdimg.com/public01/one-design/2b77cc4a4c5c906993c0e512f3ddaf03.jpg',
+    alt: 'A cute kitty looking at you with its greenish eyes.',
+    label: '猫'
+  },
+  {
+    src:
+      'http://ecmb.bdimg.com/public01/one-design/6fedc62b9221846ce5114c7447622e47.jpeg',
+    alt: 'A common kingfisher flying above river.',
+    label: '翠鸟'
+  },
+  {
+    src:
+      'http://ecmb.bdimg.com/public01/one-design/e1b6473c898d9e456452ee79d7533a86.jpeg',
+    alt: 'A white and gray dolphin in blue water.',
+    label: '海豚'
+  },
+  {
+    src: 'https://www.baidu.com/img/bd_logo1.png',
+    alt: 'Baidu logo.',
+    label: '百度'
+  },
+  {
+    src:
+      'https://ss3.bdstatic.com/yrwDcj7w0QhBkMak8IuT_XF5ehU5bvGh7c50/logopic/1b61ee88fdb4a4b918816ae1cfd84af1_fullsize.jpg',
+    alt: 'Tesla logo.',
+    label: '特斯拉'
+  }
+]
+
+describe('components/Carousel', () => {
+  it('should switch correctly with local state', async () => {
+    let wrapper = mount(
+      {
+        components: {
+          'veui-carousel': Carousel
+        },
+        template: `
+          <veui-carousel
+            :datasource="items"
+          />`,
+        data () {
+          return {
+            items
+          }
+        }
+      },
+      {
+        sync: false
+      }
+    )
+
+    let { vm } = wrapper
+    let next = wrapper.find('.veui-carousel-control-next')
+
+    expect(
+      wrapper
+        .findAll('.veui-carousel-item')
+        .at(0)
+        .classes()
+    ).to.include('veui-carousel-item-current')
+    next.trigger('click')
+
+    await vm.$nextTick()
+    expect(
+      wrapper
+        .findAll('.veui-carousel-item')
+        .at(1)
+        .classes()
+    ).to.include('veui-carousel-item-current')
+
+    wrapper.destroy()
+  })
+
+  it('should switch correctly with .sync', async () => {
+    let wrapper = mount(
+      {
+        components: {
+          'veui-carousel': Carousel
+        },
+        template: `
+          <veui-carousel
+            :datasource="items"
+            :index.sync="index"
+          />`,
+        data () {
+          return {
+            items,
+            index: 3
+          }
+        }
+      },
+      {
+        sync: false
+      }
+    )
+
+    let { vm } = wrapper
+    let next = wrapper.find('.veui-carousel-control-next')
+
+    expect(
+      wrapper
+        .findAll('.veui-carousel-item')
+        .at(3)
+        .classes()
+    ).to.include('veui-carousel-item-current')
+    next.trigger('click')
+
+    await vm.$nextTick()
+    expect(
+      wrapper
+        .findAll('.veui-carousel-item')
+        .at(4)
+        .classes()
+    ).to.include('veui-carousel-item-current')
+    expect(vm.index).to.equal(4)
+    vm.index = 1
+
+    await vm.$nextTick()
+    expect(
+      wrapper
+        .findAll('.veui-carousel-item')
+        .at(1)
+        .classes()
+    ).to.include('veui-carousel-item-current')
+
+    wrapper.destroy()
+  })
+
+  it('should switch correctly with controlled mode', async () => {
+    let wrapper = mount(
+      {
+        components: {
+          'veui-carousel': Carousel
+        },
+        template: `
+          <veui-carousel
+            :datasource="items"
+            :index="index"
+            @change="change"
+          />`,
+        data () {
+          return {
+            items,
+            index: 1
+          }
+        },
+        methods: {
+          change (index) {
+            if (index >= 3) {
+              this.index = index
+            }
+          }
+        }
+      },
+      {
+        sync: false
+      }
+    )
+
+    let { vm } = wrapper
+    let next = wrapper.find('.veui-carousel-control-next')
+
+    expect(
+      wrapper
+        .findAll('.veui-carousel-item')
+        .at(1)
+        .classes()
+    ).to.include('veui-carousel-item-current')
+    next.trigger('click')
+
+    await vm.$nextTick()
+    expect(
+      wrapper
+        .findAll('.veui-carousel-item')
+        .at(1)
+        .classes()
+    ).to.include('veui-carousel-item-current')
+    vm.index = 2
+
+    await vm.$nextTick()
+    expect(
+      wrapper
+        .findAll('.veui-carousel-item')
+        .at(2)
+        .classes()
+    ).to.include('veui-carousel-item-current')
+    next.trigger('click')
+
+    await vm.$nextTick()
+    expect(
+      wrapper
+        .findAll('.veui-carousel-item')
+        .at(3)
+        .classes()
+    ).to.include('veui-carousel-item-current')
+    expect(vm.index).to.equal(3)
+
+    wrapper.destroy()
+  })
+
+  it('should handle `autoplay` and `interval` correctly', async () => {
+    let wrapper = mount(
+      {
+        components: {
+          'veui-carousel': Carousel
+        },
+        template: `
+          <veui-carousel
+            :datasource="items"
+            :autoplay="autoplay"
+            :interval="interval"
+          />`,
+        data () {
+          return {
+            items,
+            autoplay: true,
+            interval: 200
+          }
+        }
+      },
+      {
+        sync: false
+      }
+    )
+
+    let { vm } = wrapper
+    expect(
+      wrapper
+        .findAll('.veui-carousel-item')
+        .at(0)
+        .classes()
+    ).to.include('veui-carousel-item-current')
+
+    await wait(300)
+    expect(
+      wrapper
+        .findAll('.veui-carousel-item')
+        .at(1)
+        .classes()
+    ).to.include('veui-carousel-item-current')
+
+    await wait(200)
+    expect(
+      wrapper
+        .findAll('.veui-carousel-item')
+        .at(2)
+        .classes()
+    ).to.include('veui-carousel-item-current')
+    vm.interval = 100
+
+    await wait(150)
+    expect(
+      wrapper
+        .findAll('.veui-carousel-item')
+        .at(3)
+        .classes()
+    ).to.include('veui-carousel-item-current')
+    vm.autoplay = false
+
+    await wait(100)
+    expect(
+      wrapper
+        .findAll('.veui-carousel-item')
+        .at(3)
+        .classes()
+    ).to.include('veui-carousel-item-current')
+
+    wrapper.destroy()
+  })
+
+  it('should render `indicator` correctly', async () => {
+    let wrapper = mount(
+      {
+        components: {
+          'veui-carousel': Carousel
+        },
+        template: `
+          <veui-carousel
+            :datasource="items"
+            :indicator="indicator"
+          />`,
+        data () {
+          return {
+            items,
+            indicator: 'radio'
+          }
+        }
+      },
+      {
+        sync: false
+      }
+    )
+
+    let { vm } = wrapper
+    expect(wrapper.find('.veui-carousel-indicator-radios').exists()).to.equal(
+      true
+    )
+    expect(
+      wrapper
+        .findAll('.veui-carousel-indicator-item')
+        .at(0)
+        .classes()
+    ).to.include('veui-carousel-indicator-item-current')
+    vm.indicator = 'number'
+
+    await vm.$nextTick()
+    expect(wrapper.find('.veui-carousel-indicator-numbers').exists()).to.equal(
+      true
+    )
+    expect(
+      wrapper
+        .find('.veui-carousel-indicator-numbers')
+        .text()
+        .split(/\s+/)
+    ).to.eql(['1', '5'])
+    vm.indicator = 'tab'
+
+    await vm.$nextTick()
+    expect(wrapper.find('.veui-carousel-indicator-tabs').exists()).to.equal(
+      true
+    )
+    expect(
+      wrapper
+        .findAll('.veui-carousel-indicator-item')
+        .at(0)
+        .classes()
+    ).to.include('veui-carousel-indicator-item-current')
+    vm.indicator = 'none'
+
+    await vm.$nextTick()
+    expect(wrapper.find('.veui-carousel-indicator-radios').exists()).to.equal(
+      false
+    )
+    expect(wrapper.find('.veui-carousel-indicator-numbers').exists()).to.equal(
+      false
+    )
+    expect(wrapper.find('.veui-carousel-indicator-tabs').exists()).to.equal(
+      false
+    )
+    vm.indicator = 'number'
+
+    wrapper.destroy()
+  })
+
+  it('should handle `switch-trigger` correctly', async () => {
+    let wrapper = mount(
+      {
+        components: {
+          'veui-carousel': Carousel
+        },
+        template: `
+          <veui-carousel
+            :datasource="items"
+            :switch-trigger="trigger"
+          />`,
+        data () {
+          return {
+            items,
+            trigger: 'click'
+          }
+        }
+      },
+      {
+        sync: false
+      }
+    )
+
+    let { vm } = wrapper
+
+    wrapper
+      .findAll('.veui-carousel-indicator-item')
+      .at(3)
+      .trigger('mouseenter')
+
+    await vm.$nextTick()
+    expect(
+      wrapper
+        .findAll('.veui-carousel-indicator-item')
+        .at(0)
+        .classes()
+    ).to.include('veui-carousel-indicator-item-current')
+    wrapper
+      .findAll('.veui-carousel-indicator-item')
+      .at(3)
+      .trigger('click')
+
+    await vm.$nextTick()
+    expect(
+      wrapper
+        .findAll('.veui-carousel-indicator-item')
+        .at(3)
+        .classes()
+    ).to.include('veui-carousel-indicator-item-current')
+    vm.trigger = 'hover'
+
+    await vm.$nextTick()
+    wrapper
+      .findAll('.veui-carousel-indicator-item')
+      .at(1)
+      .trigger('mouseenter')
+
+    await vm.$nextTick()
+    expect(
+      wrapper
+        .findAll('.veui-carousel-indicator-item')
+        .at(1)
+        .classes()
+    ).to.include('veui-carousel-indicator-item-current')
+
+    wrapper.destroy()
+  })
+
+  it('should handle `pause-on-hover` correctly', async () => {
+    let wrapper = mount(
+      {
+        components: {
+          'veui-carousel': Carousel
+        },
+        template: `
+          <veui-carousel
+            :datasource="items"
+            pause-on-hover
+            autoplay
+            :interval="200"
+          />`,
+        data () {
+          return {
+            items
+          }
+        }
+      },
+      {
+        sync: false
+      }
+    )
+
+    await wait(300)
+    expect(
+      wrapper
+        .findAll('.veui-carousel-indicator-item')
+        .at(1)
+        .classes()
+    ).to.include('veui-carousel-indicator-item-current')
+    wrapper.find('.veui-carousel-viewport').trigger('mouseenter')
+
+    await wait(300)
+    expect(
+      wrapper
+        .findAll('.veui-carousel-indicator-item')
+        .at(1)
+        .classes()
+    ).to.include('veui-carousel-indicator-item-current')
+    wrapper.find('.veui-carousel-viewport').trigger('mouseleave')
+
+    await wait(300)
+    expect(
+      wrapper
+        .findAll('.veui-carousel-indicator-item')
+        .at(2)
+        .classes()
+    ).to.include('veui-carousel-indicator-item-current')
+
+    wrapper.destroy()
+  })
+
+  it('should handle `wrap` correctly', async () => {
+    let wrapper = mount(
+      {
+        components: {
+          'veui-carousel': Carousel
+        },
+        template: `
+          <veui-carousel
+            :datasource="items"
+            :wrap="wrap"
+          />`,
+        data () {
+          return {
+            items,
+            wrap: false
+          }
+        }
+      },
+      {
+        sync: false
+      }
+    )
+
+    let { vm } = wrapper
+    let prev = wrapper.find('.veui-carousel-control-prev')
+
+    prev.trigger('click')
+
+    await vm.$nextTick()
+    expect(
+      wrapper
+        .findAll('.veui-carousel-item')
+        .at(0)
+        .classes()
+    ).to.include('veui-carousel-item-current')
+    vm.wrap = true
+
+    await vm.$nextTick()
+    prev.trigger('click')
+
+    await vm.$nextTick()
+    expect(
+      wrapper
+        .findAll('.veui-carousel-item')
+        .at(4)
+        .classes()
+    ).to.include('veui-carousel-item-current')
+
+    wrapper.destroy()
+  })
+
+  it('should handle `lazy` correctly', async () => {
+    let wrapper = mount(
+      {
+        components: {
+          'veui-carousel': Carousel
+        },
+        template: `
+          <veui-carousel
+            :datasource="items"
+            :lazy="lazy"
+          />`,
+        data () {
+          return {
+            items,
+            lazy: false
+          }
+        }
+      },
+      {
+        sync: false,
+        attachToDocument: true
+      }
+    )
+
+    let { vm } = wrapper
+    let next = wrapper.find('.veui-carousel-control-next')
+
+    expect(wrapper.findAll('.veui-carousel-item img').length).to.equal(5)
+    vm.lazy = true
+
+    await vm.$nextTick()
+    expect(
+      wrapper
+        .findAll('.veui-carousel-item img')
+        .wrappers.map(wrapper => wrapper.element.alt)
+    ).to.eql([items[0].alt, items[1].alt, items[4].alt])
+    next.trigger('click')
+
+    await vm.$nextTick()
+    expect(
+      wrapper
+        .findAll('.veui-carousel-item img')
+        .wrappers.map(wrapper => wrapper.element.alt)
+    ).to.eql([items[0].alt, items[1].alt, items[2].alt])
+    vm.lazy = {
+      preload: 2
+    }
+
+    await vm.$nextTick()
+    expect(wrapper.findAll('.veui-carousel-item img').length).to.equal(5)
+
+    wrapper.destroy()
+  })
+})


### PR DESCRIPTION
增加了 `lazy` prop，接受 `Boolean|{ preload: Number }`。

当传 `true` 时，默认等同于 `{ preload: 1 }`，即提前加载当前项的前后各 1 项。当传入 `Object` 时可以自行指定提前加载的个数。

同时给 `Carousel` 补充了所有 props 的单测。