### PR TITLE
fix(#676): fix option-group rendering issues

### DIFF
--- a/packages/veui/demo/cases/Select.vue
+++ b/packages/veui/demo/cases/Select.vue
@@ -765,9 +765,7 @@ export default {
       })
     })
 
-    setTimeout(() => {
-      this.loaded = true
-    }, 3000)
+    this.loaded = true
   },
   methods: {
     change (value) {

--- a/packages/veui/demo/cases/Select.vue
+++ b/packages/veui/demo/cases/Select.vue
@@ -340,6 +340,24 @@
     </veui-select>
   </section>
   <section>
+    <h2>动态内联样式：</h2>
+    <section>
+      <veui-select
+        searchable
+        @input="keyword = $event"
+      >
+        <template v-if="keyword">
+          <veui-option
+            v-for="option in result"
+            :key="option.value"
+            :value="option.value"
+            :label="option.label"
+          />
+        </template>
+      </veui-select>
+    </section>
+  </section>
+  <section>
     <h2>复杂自定义样式：</h2>
     <section>
       <veui-select
@@ -456,9 +474,9 @@
         slot="option"
         slot-scope="props"
       >
-        <span class="veui-option-label-text veui-option-custom-label">{{
-          props.label
-        }}</span>
+        <span class="veui-option-label-text veui-option-custom-label">
+          {{ props.label }}
+        </span>
         <veui-icon name="gift"/>
       </template>
     </veui-select>
@@ -734,6 +752,13 @@ export default {
     }
   },
   computed: {
+    result () {
+      return [
+        { label: 'Foo', value: 'foo' },
+        { label: 'Bar', value: 'bar' },
+        { label: this.keyword, value: this.keyword }
+      ]
+    },
     groupedOpts () {
       return type
         .clone(this.optGroupAttrs.options)

--- a/packages/veui/src/components/Select/OptionGroup.vue
+++ b/packages/veui/src/components/Select/OptionGroup.vue
@@ -153,7 +153,7 @@ const OptionGroup = {
       if (index >= length || index === -1) {
         this.items.push(item)
       } else {
-        this.items.splice(index, 1, item)
+        this.items.splice(index, 0, item)
       }
     },
     removeById (id) {

--- a/packages/veui/src/mixins/menu.js
+++ b/packages/veui/src/mixins/menu.js
@@ -23,8 +23,12 @@ export default {
       index,
       renderLabel:
         this.$scopedSlots.label || (() => this.$slots.label || label),
-      renderBefore: () => this.$slots.before,
-      renderAfter: () => this.$slots.after
+      renderBefore: () =>
+        this.$scopedSlots.before
+          ? this.$scopedSlots.before()
+          : this.$slots.before,
+      renderAfter: () =>
+        this.$scopedSlots.after ? this.$scopedSlots.after() : this.$slots.after
     })
   },
   destroyed () {

--- a/packages/veui/test/unit/specs/components/Select/OptionGroup.spec.js
+++ b/packages/veui/test/unit/specs/components/Select/OptionGroup.spec.js
@@ -202,16 +202,15 @@ describe('components/Select/OptionGroup', () => {
           'veui-option': Option
         },
         template: `
-        <veui-select>
-          <veui-option-group label="A" position="popup" overlay-class="my-group">
-            <veui-option value="a0" label="A.0"/>
-            <veui-option value="a1" label="A.1"/>
-            <veui-option value="a2" label="A.2"/>
-            <template #before>BEFORE</template>
-            <template #after>AFTER</template>
-          </veui-option-group>
-        </veui-select>
-      `
+          <veui-select>
+            <veui-option-group label="A" position="popup" overlay-class="my-group">
+              <veui-option value="a0" label="A.0"/>
+              <veui-option value="a1" label="A.1"/>
+              <veui-option value="a2" label="A.2"/>
+              <template #before><span class="before"></span></template>
+              <template #after><span class="after"></span></template>
+            </veui-option-group>
+          </veui-select>`
       },
       {
         sync: false,
@@ -228,11 +227,88 @@ describe('components/Select/OptionGroup', () => {
       .trigger('click')
     await wrapper.vm.$nextTick()
 
-    let options = wrapper.find(
-      '.veui-option-group-options[aria-expanded="true"]'
+    expect(
+      wrapper
+        .find('.veui-option-group-options[aria-expanded="true"] .before')
+        .exists()
+    ).to.equal(true)
+    expect(
+      wrapper
+        .find('.veui-option-group-options[aria-expanded="true"] .after')
+        .exists()
+    ).to.equal(true)
+
+    wrapper.destroy()
+  })
+
+  it('should render `before` and `after` slot after embedded option selected', async () => {
+    let wrapper = mount(
+      {
+        components: {
+          'veui-select': Select,
+          'veui-option-group': OptionGroup,
+          'veui-option': Option
+        },
+        template: `
+          <veui-select
+            v-model="complex"
+            multiple
+          >
+            <template v-if="loaded">
+              <veui-option-group
+                label="Foo"
+                position="popup"
+              >
+                <template #before><span class="before"></span></template>
+                <template #after><span class="after"></span></template>
+                <veui-option
+                  label="Foo1"
+                  value="foo1"
+                />
+              </veui-option-group>
+            </template>
+          </veui-select>`,
+        data () {
+          return {
+            complex: ['1', '2'],
+            loaded: false
+          }
+        },
+        mounted () {
+          this.loaded = true
+        }
+      },
+      {
+        sync: false,
+        attachToDocument: true
+      }
     )
-    expect(options.element.firstChild.nodeValue).to.equal('BEFORE')
-    expect(options.element.lastChild.nodeValue).to.equal('AFTER')
+
+    let { vm } = wrapper
+    wrapper.find(Select).vm.expanded = true
+
+    await wrapper.vm.$nextTick()
+
+    wrapper
+      .find(
+        '.veui-option-group:not([aria-hidden="true"]) > .veui-option-group > .veui-option-group-button'
+      )
+      .trigger('click')
+    await wrapper.vm.$nextTick()
+
+    vm.complex.push('foo1')
+    await wrapper.vm.$nextTick()
+
+    expect(
+      wrapper
+        .find('.veui-option-group-options[aria-expanded="true"] .before')
+        .exists()
+    ).to.equal(true)
+    expect(
+      wrapper
+        .find('.veui-option-group-options[aria-expanded="true"] .after')
+        .exists()
+    ).to.equal(true)
 
     wrapper.destroy()
   })

--- a/packages/veui/test/unit/specs/components/Select/Select.spec.js
+++ b/packages/veui/test/unit/specs/components/Select/Select.spec.js
@@ -524,8 +524,8 @@ describe('components/Select/Select', () => {
         },
         template: `
           <veui-select :options="options">
-            <template v-slot:option-label="{ label }">{{ label }} - 🤘</template>
-            <template v-slot:group-label="{ label }">{{ label }} - 🤞</template>
+            <template #option-label="{ label }">{{ label }} - 🤘</template>
+            <template #group-label="{ label }">{{ label }} - 🤞</template>
           </veui-select>`
       },
       {

--- a/packages/veui/test/unit/specs/components/Select/Select.spec.js
+++ b/packages/veui/test/unit/specs/components/Select/Select.spec.js
@@ -544,4 +544,51 @@ describe('components/Select/Select', () => {
     expect(groups.at(0).text()).to.equal('选项1 - 🤞')
     wrapper.destroy()
   })
+
+  it('should update correctly with dynamic options and inline option components', async () => {
+    let wrapper = mount(
+      {
+        components: {
+          'veui-select': Select,
+          'veui-option': Option
+        },
+        data () {
+          return {
+            options: [
+              { label: 'Foo', value: 'foo' },
+              { label: 'Bar', value: 'bar' }
+            ]
+          }
+        },
+        template: `
+          <veui-select>
+            <veui-option
+              v-for="o in options"
+              :label="o.label"
+              :value="o.value"
+              :key="o.value"
+            />
+          </veui-select>`
+      },
+      {
+        sync: false,
+        attachToDocument: true
+      }
+    )
+
+    let { vm } = wrapper
+    await vm.$nextTick()
+
+    vm.options = [
+      { label: 'Foo', value: 'foo' },
+      { label: 'Baz', value: 'baz' }
+    ]
+
+    await vm.$nextTick()
+    let options = wrapper.findAll(OPTION_ITEM)
+    expect(options.at(1).exists()).to.equal(true)
+    expect(options.at(1).text()).to.equal('Baz')
+
+    wrapper.destroy()
+  })
 })


### PR DESCRIPTION
1. Per #676, rendering inline `Option`/`OptionGroup` with dynamic options may lead to unexpected situation.
2. `before`/`after` slots sometimes do not render correctly after data updates.