### PR TITLE
Revert #502, redesign slots of Input

### DIFF
--- a/packages/veui-theme-dls/components/button.less
+++ b/packages/veui-theme-dls/components/button.less
@@ -102,6 +102,7 @@
     }
 
     &[data-focus-visible-added] {
+      border-color: @dls-border-color-focus;
       background-color: @dls-button-background-color-basic-focus;
     }
 

--- a/packages/veui-theme-dls/components/date-picker.less
+++ b/packages/veui-theme-dls/components/date-picker.less
@@ -36,22 +36,16 @@
     background-color: transparent;
 
     .@{veui-prefix}-input {
-      &,
-      &.@{veui-prefix}-focus {
-        .margin(-1px, _);
-
-        .@{veui-prefix}-input-main {
-          border: 0;
-          padding-right: 0;
-          background-color: transparent;
-        }
-      }
+      border: 0;
+      padding-right: 0;
+      background-color: transparent;
+      .margin(-1px, _);
     }
 
     .@{veui-prefix}-invalid & {
       border-color: @dls-input-border-color-error;
 
-      .@{veui-prefix}-input-main {
+      .@{veui-prefix}-input {
         color: @dls-input-font-color-error;
       }
 
@@ -152,18 +146,15 @@
     .@{veui-prefix}-input {
       flex: 1 1 auto;
       width: auto; // 覆盖 width
+      margin-bottom: -1px;
+      // 不加会导致年份选择的 input 下面的 highlight 部分被滚动条盖住
+      z-index: 1;
 
       &:first-child {
         border-top-left-radius: inherit;
       }
       &:last-child {
         border-top-right-radius: inherit;
-      }
-
-      &-main {
-        margin-bottom: -1px;
-        // 不加会导致年份选择的 input 下面的 highlight 部分被滚动条盖住
-        z-index: 1;
       }
     }
   }

--- a/packages/veui-theme-dls/components/dropdown.less
+++ b/packages/veui-theme-dls/components/dropdown.less
@@ -120,9 +120,6 @@
 
   &-search-box.@{veui-prefix}-search-box {
     width: 100%;
-    .@{veui-prefix}-input .@{veui-prefix}-input-main {
-      width: 100%;
-    }
   }
 
   &[ui~="text"] {

--- a/packages/veui-theme-dls/components/filter-panel.less
+++ b/packages/veui-theme-dls/components/filter-panel.less
@@ -27,7 +27,7 @@
     width: 100%;
     flex: none;
 
-    .@{veui-prefix}-input-main {
+    .@{veui-prefix}-input {
       .padding(_, @dls-transfer-padding-x);
     }
   }

--- a/packages/veui-theme-dls/components/input-group.less
+++ b/packages/veui-theme-dls/components/input-group.less
@@ -41,11 +41,11 @@
     margin-right: -1px;
     z-index: 1;
 
-    &:first-child {
+    &:first-child:not(:last-child) {
       .border-right-radius(0);
     }
 
-    &:last-child {
+    &:last-child:not(:first-child) {
       .border-left-radius(0);
     }
 

--- a/packages/veui-theme-dls/components/input.less
+++ b/packages/veui-theme-dls/components/input.less
@@ -3,14 +3,20 @@
 .@{veui-prefix}-input {
   @left-padding: @dls-input-padding;
 
+  position: relative;
   display: inline-flex;
   align-items: stretch;
-  vertical-align: middle;
-  height: @dls-input-height-m;
-  font-size: @dls-input-font-size-m;
-  width: @dls-input-width;
+  .size(@dls-input-width, @dls-input-height-m);
+  padding: 0 @dls-input-padding;
+  border: 1px solid @dls-input-border-color;
+  background-color: @dls-input-background-color;
+  color: @dls-input-font-color;
   border-radius: @dls-input-border-radius-m;
-  line-height: 2;
+  font-size: @dls-input-font-size-m;
+  vertical-align: middle;
+  line-height: normal;
+  cursor: text;
+  .veui-transition(border-color, color, box-shadow);
 
   &-autofill {
     background-color: @veui-autofill-color;
@@ -22,65 +28,21 @@
 
   &-main {
     display: flex;
-    flex: 1 1 auto;
     align-items: stretch;
-    position: relative;
-    padding: 0 @dls-input-padding;
-    border: 1px solid @dls-input-border-color;
-    border-radius: inherit;
-    background-color: @dls-input-background-color;
-    color: @dls-input-font-color;
-    cursor: text;
-    .veui-transition(border-color, color, box-shadow);
-  }
-
-  &-has-before &-main {
-    .border-left-radius(0);
-  }
-
-  &-has-after &-main {
-    .border-right-radius(0);
   }
 
   &-before,
-  &-after,
-  &-prepend,
-  &-append {
+  &-after {
     display: flex;
     flex: 0 0 auto;
     align-items: center;
   }
 
-  &-before,
-  &-after {
-    border-radius: inherit;
-  }
-
-  &-before-label,
-  &-after-label {
-    display: flex;
-    align-items: center;
-    .size(100%);
-    border: 1px solid @dls-input-border-color;
-    border-radius: inherit;
-    padding: 0 @dls-input-padding;
-  }
-
-  &-before-label {
-    .border-right-radius(0);
-    border-right: none;
-  }
-
-  &-after-label {
-    .border-left-radius(0);
-    border-left: none;
-  }
-
-  &-prepend {
+  &-before {
     padding-right: @dls-input-content-spacing;
   }
 
-  &-append {
+  &-after {
     padding-left: @dls-input-content-spacing;
   }
 
@@ -110,7 +72,7 @@
       color: @dls-input-icon-color;
     }
 
-    &-has-append {
+    &-has-after {
       margin-right: dls-sum(
         @dls-button-padding-text * -1,
         -2px,
@@ -123,16 +85,16 @@
     margin-left: @dls-input-content-spacing;
   }
 
-  &-main:hover {
+  &:hover {
     border-color: @dls-input-border-color-hover;
   }
 
-  &.@{veui-prefix}-readonly &-main {
+  &.@{veui-prefix}-readonly {
     border-color: @dls-input-border-color-read-only;
     background-color: @dls-input-background-color-read-only;
   }
 
-  &.@{veui-prefix}-readonly &-main:hover {
+  &.@{veui-prefix}-readonly:hover {
     border-color: @dls-input-border-color-read-only-hover;
   }
 
@@ -144,47 +106,39 @@
     position: relative;
   }
 
-  &.@{veui-prefix}-focus &-main {
+  &.@{veui-prefix}-focus {
     .dls-focus-ring(@dls-input-border-color-focus, @dls-input-shadow-focus);
   }
 
-  &.@{veui-prefix}-invalid &-main {
+  &.@{veui-prefix}-invalid {
     border-color: @dls-input-border-color-error;
     color: @dls-input-font-color-error;
   }
 
-  &.@{veui-prefix}-invalid &-main:hover {
+  &.@{veui-prefix}-invalid:hover {
     border-color: @dls-input-border-color-error-hover;
   }
 
-  &.@{veui-prefix}-invalid.@{veui-prefix}-focus &-main {
+  &.@{veui-prefix}-invalid.@{veui-prefix}-focus {
     .dls-focus-ring(
       @dls-input-border-color-error-focus,
       @dls-input-shadow-error-focus
     );
   }
 
-  &.@{veui-prefix}-focus.@{veui-prefix}-readonly &-main {
+  &.@{veui-prefix}-focus.@{veui-prefix}-readonly {
     border-color: @dls-input-border-color-read-only-focus;
   }
 
-  &.@{veui-prefix}-disabled &-main,
-  &.@{veui-prefix}-readonly &-before-label,
-  &.@{veui-prefix}-readonly &-after-label,
-  &.@{veui-prefix}-disabled &-before-label,
-  &.@{veui-prefix}-disabled &-after-label {
+  &.@{veui-prefix}-disabled {
     background-color: @dls-input-background-color-disabled;
     border-color: @dls-input-border-color-disabled;
     cursor: not-allowed;
   }
 
   &.@{veui-prefix}-disabled &-input,
-  &.@{veui-prefix}-readonly &-before-label,
-  &.@{veui-prefix}-readonly &-after-label,
-  &.@{veui-prefix}-disabled &-before-label,
-  &.@{veui-prefix}-disabled &-after-label,
-  &.@{veui-prefix}-disabled &-prepend,
-  &.@{veui-prefix}-disabled &-append {
+  &.@{veui-prefix}-disabled &-before,
+  &.@{veui-prefix}-disabled &-after {
     color: @dls-input-font-color-disabled;
     pointer-events: none;
   }
@@ -234,31 +188,21 @@
   &[ui~="inline"] {
     border-radius: 0;
     position: relative;
+    border-style: none none solid !important;
     background-color: transparent;
+    box-shadow: none;
 
     &.@{veui-prefix}-readonly,
     &.@{veui-prefix}-disabled {
-      .@{veui-prefix}-input-main {
-        background-color: transparent;
+      background-color: transparent;
+    }
+
+    &.@{veui-prefix}-focus {
+      box-shadow: @dls-input-shadow-inline-focus;
+
+      &.@{veui-prefix}-invalid {
+        box-shadow: @dls-input-shadow-inline-error-focus;
       }
     }
-  }
-
-  &[ui~="inline"] &-main {
-    position: relative;
-    box-shadow: none;
-    border-style: none none solid !important;
-  }
-
-  &[ui~="inline"].@{veui-prefix}-input-has-after .@{veui-prefix}-input-main {
-    border-radius: 0;
-  }
-
-  &.@{veui-prefix}-focus[ui~="inline"] &-main {
-    box-shadow: @dls-input-shadow-inline-focus;
-  }
-
-  &.@{veui-prefix}-invalid.@{veui-prefix}-focus[ui~="inline"] &-main {
-    box-shadow: @dls-input-shadow-inline-error-focus;
   }
 }

--- a/packages/veui-theme-dls/components/number-input.less
+++ b/packages/veui-theme-dls/components/number-input.less
@@ -15,14 +15,13 @@
   input {
     ime-mode: disabled;
     text-overflow: ellipsis;
-  }
-
-  &[ui~="normal"] .@{veui-prefix}-input-main {
-    overflow: hidden;
+    font-variant-numeric: tabular-nums;
   }
 
   &[ui~="normal"] {
-    .@{veui-prefix}-input-append {
+    overflow: hidden;
+
+    .@{veui-prefix}-input-after {
       right: 0;
       position: absolute;
       min-width: dls-sum(@dls-number-input-spin-button-min-width-normal, -1px);
@@ -30,30 +29,26 @@
       margin-left: @dls-input-padding;
     }
 
-    .@{veui-prefix}-input-append,
+    .@{veui-prefix}-input-after,
     .@{veui-prefix}-number-input-controls {
       .border-right-radius(inherit);
     }
 
-    &[ui~="xs"] .@{veui-prefix}-input-append {
+    &[ui~="xs"] .@{veui-prefix}-input-after {
       .size(dls-sum(@dls-number-input-spin-button-width-normal-xs, -1px), 100%);
     }
 
-    &[ui~="s"] .@{veui-prefix}-input-append {
+    &[ui~="s"] .@{veui-prefix}-input-after {
       .size(dls-sum(@dls-number-input-spin-button-width-normal-s, -1px), 100%);
     }
 
-    &[ui~="m"] .@{veui-prefix}-input-append {
+    &[ui~="m"] .@{veui-prefix}-input-after {
       .size(dls-sum(@dls-number-input-spin-button-width-normal-m, -1px), 100%);
     }
   }
 
   &-controls-focus[ui~="normal"] {
     overflow: visible;
-
-    .@{veui-prefix}-input-main {
-      overflow: visible;
-    }
   }
 
   &[ui~="normal"] &-controls {
@@ -126,28 +121,30 @@
   }
 
   &[ui~="strong"] {
-    .@{veui-prefix}-input {
-      &-main {
-        padding: 0;
-      }
+    padding: 0;
 
+    .@{veui-prefix}-input {
       &-input {
         text-align: center;
       }
 
       &-before,
       &-after {
-        position: absolute;
+        position: relative;
         z-index: 1;
-        top: 0;
+        margin-top: -1px;
+        padding: 0;
+        border-radius: inherit;
       }
 
       &-before {
-        left: 0;
+        margin-right: @dls-input-padding;
+        margin-left: -1px;
       }
 
       &-after {
-        right: 0;
+        margin-right: -1px;
+        margin-left: @dls-input-padding;
       }
     }
 
@@ -155,10 +152,6 @@
       width: @dls-number-input-width-strong-xs;
 
       .@{veui-prefix}-input {
-        &-main {
-          border-radius: @dls-input-border-radius-xs;
-        }
-
         &-before,
         &-after {
           .size(@dls-number-input-height-xs);
@@ -170,10 +163,6 @@
       width: @dls-number-input-width-strong-s;
 
       .@{veui-prefix}-input {
-        &-main {
-          border-radius: @dls-input-border-radius-s;
-        }
-
         &-before,
         &-after {
           .size(@dls-number-input-height-s);
@@ -185,10 +174,6 @@
       width: @dls-number-input-width-strong-m;
 
       .@{veui-prefix}-input {
-        &-main {
-          border-radius: @dls-input-border-radius-m;
-        }
-
         &-before,
         &-after {
           .size(@dls-number-input-height-m);

--- a/packages/veui-theme-dls/components/pagination.less
+++ b/packages/veui-theme-dls/components/pagination.less
@@ -40,10 +40,7 @@
 
     .@{veui-prefix}-input {
       width: @dls-pagination-goto-input-width;
-
-      &-main {
-        .padding(_, @dls-pagination-goto-input-padding-x);
-      }
+      .padding(_, @dls-pagination-goto-input-padding-x);
     }
 
     &-label-before,

--- a/packages/veui-theme-dls/components/search-box.less
+++ b/packages/veui-theme-dls/components/search-box.less
@@ -4,7 +4,6 @@
 .@{veui-prefix}-search-box {
   display: inline-flex;
   vertical-align: middle;
-  position: relative;
   width: @dls-input-width;
   color: @dls-input-font-color;
   background-color: @dls-input-background-color;
@@ -22,39 +21,36 @@
     border-radius: @dls-input-border-radius-l;
   }
 
-  .@{veui-prefix}-input-main {
-    .border-right-radius(inherit);
-  }
-
   .@{veui-prefix}-input {
     width: 100%;
     overflow: visible;
     border-radius: inherit;
 
-    &-append {
+    &:hover {
+      z-index: 1;
+    }
+
+    @{veui-prefix}-input:focus {
+      z-index: 2;
+    }
+
+    &-group {
+      display: flex;
+      flex-grow: 1;
+    }
+
+    &-after {
       .@{veui-prefix}-input-clear {
         margin-right: 0;
       }
-      .@{veui-prefix}-search-box-action-icon {
+      .@{veui-prefix}-search-box-action {
         margin-left: @dls-input-content-spacing;
       }
     }
   }
-  .@{veui-prefix}-focus {
-    .@{veui-prefix}-input-main {
-      z-index: 1;
-    }
-  }
 
   &-action {
-    display: flex;
-    white-space: nowrap;
-    color: @dls-input-font-color;
-
-    &-button.@{veui-prefix}-button {
-      display: none;
-      outline: none;
-    }
+    flex: none;
   }
 
   &.@{veui-prefix}-readonly {
@@ -62,12 +58,7 @@
     border-color: @dls-input-border-color-read-only;
     color: @dls-input-font-color-read-only;
 
-    .@{veui-prefix}-input-after {
-      overflow: hidden;
-    }
-
-    .@{veui-prefix}-search-box-action,
-    .@{veui-prefix}-search-box-action-icon {
+    .@{veui-prefix}-search-box-action {
       cursor: not-allowed;
       color: @dls-input-font-color-read-only;
     }
@@ -78,20 +69,9 @@
     border-color: @dls-input-border-color-disabled;
     color: @dls-input-font-color-disabled;
 
-    .@{veui-prefix}-input-after {
-      overflow: hidden;
-    }
-
-    .@{veui-prefix}-search-box-action,
-    .@{veui-prefix}-search-box-action-icon {
+    .@{veui-prefix}-search-box-action {
       cursor: not-allowed;
       color: @dls-input-font-color-disabled;
-    }
-  }
-
-  &:not(.@{veui-prefix}-disabled):not(.@{veui-prefix}-readonly) {
-    .@{veui-prefix}-search-box-action:hover {
-      color: @dls-input-font-color;
     }
   }
 
@@ -106,7 +86,7 @@
   }
 
   &[ui~="inline"] {
-    .@{veui-prefix}-input-has-after .@{veui-prefix}-input-main {
+    .@{veui-prefix}-input-group {
       border-radius: 0;
     }
 
@@ -118,25 +98,14 @@
   }
 
   &[ui~="strong"] {
-    .@{veui-prefix}-input-has-after {
-      .@{veui-prefix}-input-main {
-        .border-right-radius(0);
-
-        .@{veui-prefix}-search-box-action {
-          display: none;
-        }
+    .@{veui-prefix}-input {
+      .@{veui-prefix}-search-box-action {
+        display: none;
       }
-      .@{veui-prefix}-input-after {
-        .border-left-radius(0);
-        margin-left: -1px;
+    }
 
-        .@{veui-prefix}-search-box-action {
-          .@{veui-prefix}-search-box-action-button {
-            display: flex;
-            .border-left-radius(0);
-          }
-        }
-      }
+    .@{veui-prefix}-search-box-action {
+      display: flex;
     }
   }
 }

--- a/packages/veui-theme-dls/components/select.less
+++ b/packages/veui-theme-dls/components/select.less
@@ -21,8 +21,8 @@
     color: @dls-input-font-color-read-only;
   }
 
-  &.focus-visible .@{veui-prefix}-input-main,
-  &[data-focus-visible-added] .@{veui-prefix}-input-main {
+  &.focus-visible .@{veui-prefix}-input,
+  &[data-focus-visible-added] .@{veui-prefix}-input {
     .dls-focus-ring(@dls-input-border-color-focus, @dls-input-shadow-focus);
   }
 
@@ -42,22 +42,20 @@
   }
 
   &-trigger {
-    .@{veui-prefix}-input-prepend {
+    max-width: 100%;
+    cursor: pointer;
+    .padding(_, @dls-select-padding-x);
+
+    .@{veui-prefix}-input-before {
       flex-grow: 0;
       flex-shrink: 0;
       padding-right: 0;
       .ellipsis();
     }
 
-    .@{veui-prefix}-input-append {
+    .@{veui-prefix}-input-after {
       padding-left: @dls-select-content-spacing;
       color: @dls-foreground-color-neutral-weak;
-    }
-
-    .@{veui-prefix}-input-main {
-      max-width: 100%;
-      cursor: pointer;
-      .padding(_, @dls-select-padding-x);
     }
 
     .@{veui-prefix}-input-input {
@@ -79,16 +77,13 @@
   }
 
   &-multiple:not(.@{veui-prefix}-select-empty) {
-    .@{veui-prefix}-input-main {
-      min-width: 100%;
-      display: block;
-      overflow: hidden;
-    }
-
     .@{veui-prefix}-input {
+      display: block;
+      min-width: 100%;
       height: auto;
+      overflow: hidden;
 
-      &-prepend {
+      &-before {
         display: block;
         overflow: visible;
 
@@ -114,7 +109,7 @@
         margin-top: @adjusted-select-padding-y;
       }
 
-      &-append {
+      &-after {
         float: right;
         margin: @adjusted-select-padding-y 0;
       }
@@ -206,7 +201,7 @@
           line-height: @@height;
         }
 
-        .@{veui-prefix}-input-append {
+        .@{veui-prefix}-input-after {
           height: @@height;
         }
 

--- a/packages/veui/demo/cases/Input.vue
+++ b/packages/veui/demo/cases/Input.vue
@@ -131,18 +131,10 @@
     </section>
 
     <section>
-      <h3>Prepend / Append</h3>
+      <h3>Before / After</h3>
       <section>
         <veui-input clearable>
-          <template slot="before-label">前缀内容</template>
-          <template slot="prepend"><veui-icon name="user-circle"/></template>
-          <template slot="after-label">后缀内容</template>
-        </veui-input>
-        <veui-input clearable>
-          <template slot="before-label">前缀内容</template>
-        </veui-input>
-        <veui-input clearable>
-          <template slot="after-label">后缀内容</template>
+          <template slot="before"><veui-icon name="user-circle"/></template>
         </veui-input>
       </section>
     </section>
@@ -158,30 +150,18 @@
           clearable
           class="input-nudge"
           @focus="log('focus')"
-        >
-          <template slot="after-label">
-            元
-          </template>
-        </veui-input>
+        />
         <veui-input
           v-model="price"
           class="input-nudge"
           clearable
           readonly
-        >
-          <template slot="after-label">
-            元
-          </template>
-        </veui-input>
+        />
         <veui-input
           v-model="price"
           class="input-nudge"
           disabled
-        >
-          <template slot="after-label">
-            元
-          </template>
-        </veui-input>
+        />
       </veui-field>
     </section>
 

--- a/packages/veui/src/components/Input.vue
+++ b/packages/veui/src/components/Input.vue
@@ -5,90 +5,66 @@
     [$c('focus')]: focused,
     [$c('input-hidden')]: type === 'hidden',
     [$c('input-autofill')]: autofill,
-    [$c('input-has-before')]: !!($slots.before || $slots['before-label']),
-    [$c('input-has-after')]: !!($slots.after || $slots['after-label']),
     [$c('invalid')]: realInvalid || lengthOverflow,
     [$c('readonly')]: realReadonly,
     [$c('disabled')]: realDisabled
   }"
   :ui="realUi"
   v-on="containerListeners"
+  @mousedown="handleMousedown"
 >
-  <template v-if="$slots.before || $slots['before-label']">
+  <template v-if="$slots.before">
     <div :class="$c('input-before')">
-      <slot name="before">
-        <div :class="$c('input-before-label')">
-          <slot name="before-label"/>
-        </div>
-      </slot>
+      <slot name="before"/>
     </div>
   </template>
-  <div
-    :class="$c('input-main')"
-    @mousedown="handleMousedown"
-  >
-    <template v-if="$slots.prepend">
-      <div :class="$c('input-prepend')">
-        <slot name="prepend"/>
-      </div>
-    </template>
-    <div :class="$c('input-content')">
-      <div
-        v-show="empty"
-        :class="$c('input-placeholder')"
-        @selectstart.prevent="() => false"
-      >
-        {{ placeholder }}
-      </div>
-      <input
-        ref="input"
-        v-model="localValue"
-        :class="$c('input-input')"
-        v-bind="attrs"
-        v-on="inputListeners"
-        @focus="handleFocus"
-        @blur="handleBlur"
-        @input="handleInput"
-        @compositionupdate="handleComposition"
-        @compositionend="handleCompositionEnd"
-        @change="$emit('change', $event.target.value, $event)"
-      >
+  <div :class="$c('input-content')">
+    <div
+      v-show="empty"
+      :class="$c('input-placeholder')"
+      @selectstart.prevent="() => false"
+    >
+      {{ placeholder }}
     </div>
-    <template v-if="$slots.append || clearable || realMaxlength !== null">
-      <div :class="$c('input-append')">
-        <veui-button
-          v-if="clearable"
-          v-show="editable && !empty"
-          :class="{
-            [$c('input-clear')]: true,
-            [$c('input-clear-has-append')]: !!$slots.append
-          }"
-          :ui="uiParts.clear"
-          :aria-label="t('clear')"
-          @click.stop="clear"
-        >
-          <veui-icon :name="icons.clear"/>
-        </veui-button>
-        <span
-          v-if="realMaxlength !== null"
-          :class="{
-            [$c('input-count')]: true,
-            [$c('input-count-overflow')]: lengthOverflow
-          }"
-        >
-          {{ length }}/{{ realMaxlength }}
-        </span>
-        <slot name="append"/>
-      </div>
-    </template>
+    <input
+      ref="input"
+      v-model="localValue"
+      :class="$c('input-input')"
+      v-bind="attrs"
+      v-on="inputListeners"
+      @focus="handleFocus"
+      @blur="handleBlur"
+      @input="handleInput"
+      @compositionupdate="handleComposition"
+      @compositionend="handleCompositionEnd"
+      @change="$emit('change', $event.target.value, $event)"
+    >
   </div>
-  <template v-if="$slots.after || $slots['after-label']">
+  <template v-if="$slots.after || clearable || realMaxlength !== null">
     <div :class="$c('input-after')">
-      <slot name="after">
-        <div :class="$c('input-after-label')">
-          <slot name="after-label"/>
-        </div>
-      </slot>
+      <veui-button
+        v-if="clearable"
+        v-show="editable && !empty"
+        :class="{
+          [$c('input-clear')]: true,
+          [$c('input-clear-has-after')]: !!$slots.after
+        }"
+        :ui="uiParts.clear"
+        :aria-label="t('clear')"
+        @click.stop="clear"
+      >
+        <veui-icon :name="icons.clear"/>
+      </veui-button>
+      <span
+        v-if="realMaxlength !== null"
+        :class="{
+          [$c('input-count')]: true,
+          [$c('input-count-overflow')]: lengthOverflow
+        }"
+      >
+        {{ length }}/{{ realMaxlength }}
+      </span>
+      <slot name="after"/>
     </div>
   </template>
 </div>

--- a/packages/veui/src/components/NumberInput.vue
+++ b/packages/veui/src/components/NumberInput.vue
@@ -35,7 +35,7 @@
       />
     </veui-button>
   </template>
-  <template slot="append">
+  <template slot="after">
     <div
       v-if="editable && !isStrong"
       :class="$c('number-input-controls')"

--- a/packages/veui/src/components/Progress.vue
+++ b/packages/veui/src/components/Progress.vue
@@ -62,7 +62,7 @@
       />
       <template v-else>{{ valueText }}</template>
       <slot
-        name="append"
+        name="after"
         v-bind="{ percent, value: realValue, status }"
       />
     </slot>

--- a/packages/veui/src/components/SearchBox.vue
+++ b/packages/veui/src/components/SearchBox.vue
@@ -10,56 +10,50 @@
   :ui="realUi"
   @click="handleClickBox"
 >
-  <veui-input
-    ref="input"
-    v-model="localValue"
-    v-outside:input,box="closeSuggestions"
-    :name="realName"
-    :readonly="realReadonly"
-    :disabled="realDisabled"
-    v-bind="attrs"
-    autocomplete="off"
-    role="search"
-    :aria-haspopup="inputPopup"
-    :aria-owns="inputPopup ? dropdownId : null"
-    @input="keyword = $event"
-    @focus="handleInputFocus"
-    @keydown="handleInputKeydown"
-    @clear="handleClear"
-  >
-    <div
-      slot="after"
-      ref="search"
-      :class="$c('search-box-action')"
-      @click.stop="search"
+  <veui-input-group>
+    <veui-input
+      ref="input"
+      v-model="localValue"
+      v-outside:input,box="closeSuggestions"
+      :name="realName"
+      :readonly="realReadonly"
+      :disabled="realDisabled"
+      v-bind="attrs"
+      autocomplete="off"
+      role="search"
+      :aria-haspopup="inputPopup"
+      :aria-owns="inputPopup ? dropdownId : null"
+      @input="keyword = $event"
+      @focus="handleInputFocus"
+      @keydown="handleInputKeydown"
+      @clear="handleClear"
     >
       <veui-button
-        :ui="uiParts.button"
-        :class="$c('search-box-action-button')"
-        :disabled="realDisabled || realReadonly"
-        :aria-haspopup="submitPopup"
-        :aria-label="t('search')"
-      >
-        <veui-icon :name="icons.search"/>
-      </veui-button>
-    </div>
-    <div
-      slot="append"
-      :class="$c('search-box-action')"
-      @click.stop="search"
-    >
-      <veui-button
+        v-if="!isStrong"
+        slot="after"
         type="button"
+        :class="$c('search-box-action')"
         :ui="uiParts.search"
-        :class="$c('search-box-action-icon')"
         :disabled="realDisabled || realReadonly"
         :aria-haspopup="submitPopup"
         :aria-label="t('search')"
+        @click.stop="search"
       >
         <veui-icon :name="icons.search"/>
       </veui-button>
-    </div>
-  </veui-input>
+    </veui-input>
+    <veui-button
+      v-if="isStrong"
+      :ui="uiParts.button"
+      :class="$c('search-box-action')"
+      :disabled="realDisabled || realReadonly"
+      :aria-haspopup="submitPopup"
+      :aria-label="t('search')"
+      @click.stop="search"
+    >
+      <veui-icon :name="icons.search"/>
+    </veui-button>
+  </veui-input-group>
   <veui-overlay
     v-show="realExpanded"
     ref="overlay"
@@ -160,6 +154,7 @@ import Input from './Input'
 import Icon from './Icon'
 import Overlay from './Overlay'
 import Button from './Button'
+import InputGroup from './InputGroup'
 import OptionGroup from './OptionGroup'
 import focusable from '../mixins/focusable'
 import { createKeySelect } from '../mixins/key-select'
@@ -186,7 +181,8 @@ export default {
     'veui-icon': Icon,
     'veui-overlay': Overlay,
     'veui-button': Button,
-    'veui-option-group': OptionGroup
+    'veui-option-group': OptionGroup,
+    'veui-input-group': InputGroup
   },
   mixins: [
     prefix,
@@ -235,6 +231,9 @@ export default {
   computed: {
     attrs () {
       return pick(this, ['ui', ...without(SHARED_PROPS, 'value')])
+    },
+    isStrong () {
+      return this.uiProps.style === 'strong'
     },
     realExpanded () {
       return !!(

--- a/packages/veui/src/components/Select/Select.vue
+++ b/packages/veui/src/components/Select/Select.vue
@@ -382,7 +382,7 @@ export default {
       </Tag>
     ))
 
-    let multiPrependSlot = this.searchable ? (
+    let multibeforeSlot = this.searchable ? (
       selectedTags
     ) : this.labels.length === 0 ? (
       <span class={this.$c('select-placeholder')} id={this.labelId}>
@@ -392,7 +392,7 @@ export default {
       selectedTags
     )
 
-    let prependSlot = !this.searchable ? (
+    let beforeSlot = !this.searchable ? (
       <span
         class={{
           [this.$c('select-label')]: true,
@@ -463,10 +463,10 @@ export default {
           onInput={this.handleTriggerInput}
           composition
         >
-          <template slot="prepend">
-            {this.multiple ? multiPrependSlot : prependSlot}
+          <template slot="before">
+            {this.multiple ? multibeforeSlot : beforeSlot}
           </template>
-          <template slot="append">
+          <template slot="after">
             {this.limitLabel ? (
               <span class={this.$c('select-count')}>{this.limitLabel}</span>
             ) : null}

--- a/packages/veui/src/components/TimePicker/TimePicker.vue
+++ b/packages/veui/src/components/TimePicker/TimePicker.vue
@@ -22,7 +22,7 @@
     @click="openDropdown"
   >
     <div
-      slot="append"
+      slot="after"
       :class="$c('time-picker-icon')"
     >
       <veui-button

--- a/packages/veui/src/components/Transfer/_SelectedPanel.vue
+++ b/packages/veui/src/components/Transfer/_SelectedPanel.vue
@@ -75,7 +75,7 @@
         </template>
       </template>
       <template
-        slot="item-append"
+        slot="item-after"
         slot-scope="props"
       >
         <veui-button

--- a/packages/veui/src/components/Tree/Tree.vue
+++ b/packages/veui/src/components/Tree/Tree.vue
@@ -49,7 +49,7 @@
           <veui-icon :name="icons.collapse"/>
         </button>
         <slot
-          name="item-prepend"
+          name="item-before"
           v-bind="item"
           :item="item"
           :index="index"
@@ -82,7 +82,7 @@
           </slot>
         </div>
         <slot
-          name="item-append"
+          name="item-after"
           v-bind="item"
           :item="item"
           :index="index"

--- a/packages/veui/test/unit/specs/components/Input.spec.js
+++ b/packages/veui/test/unit/specs/components/Input.spec.js
@@ -170,57 +170,17 @@ describe('components/Input', () => {
       },
       data () {
         return {
-          money: null
-        }
-      },
-      template: `
-        <veui-input v-model="money">
-          <template slot="after">元</template>
-        </veui-input>
-      `
-    })
-
-    expect(wrapper.find('.veui-input-after').text()).to.equal('元')
-  })
-
-  it('should render prepend slot correctly', () => {
-    let wrapper = mount({
-      components: {
-        'veui-input': Input
-      },
-      data () {
-        return {
           userName: null
         }
       },
       template: `
         <veui-input v-model="userName">
-          <template slot="prepend">user</template>
+          <template slot="after">user</template>
         </veui-input>
       `
     })
 
-    expect(wrapper.find('.veui-input-prepend').text()).to.equal('user')
-  })
-
-  it('should render append slot correctly', () => {
-    let wrapper = mount({
-      components: {
-        'veui-input': Input
-      },
-      data () {
-        return {
-          userName: null
-        }
-      },
-      template: `
-        <veui-input v-model="userName">
-          <template slot="append">user</template>
-        </veui-input>
-      `
-    })
-
-    expect(wrapper.find('.veui-input-append').text()).to.equal('user')
+    expect(wrapper.find('.veui-input-after').text()).to.equal('user')
   })
 
   it('should render maxlength limit correctly', () => {
@@ -234,7 +194,7 @@ describe('components/Input', () => {
     })
 
     expect(wrapper.find('input').attributes('maxlength')).to.equal(undefined)
-    expect(wrapper.find('.veui-input-append').text()).to.equal('3/5')
+    expect(wrapper.find('.veui-input-after').text()).to.equal('3/5')
   })
 
   it('should render maxlength limit with strict prop correctly', () => {
@@ -248,6 +208,6 @@ describe('components/Input', () => {
     })
 
     expect(wrapper.find('input').attributes('maxlength')).to.equal('5')
-    expect(wrapper.find('.veui-input-append').text()).to.equal('3/5')
+    expect(wrapper.find('.veui-input-after').text()).to.equal('3/5')
   })
 })

--- a/packages/veui/test/unit/specs/components/Select/OptionGroup.spec.js
+++ b/packages/veui/test/unit/specs/components/Select/OptionGroup.spec.js
@@ -132,7 +132,7 @@ describe('components/Select/OptionGroup', () => {
 
     await wrapper.vm.$nextTick()
 
-    let controlButton = wrapper.find('.veui-select-trigger .veui-input-main')
+    let controlButton = wrapper.find('.veui-select-trigger')
     controlButton.trigger('click')
     await wrapper.vm.$nextTick()
     let options = wrapper.findAll('.veui-option')


### PR DESCRIPTION
As we now have an `InputGroup`, slots outside the `Input` itself is no longer useful but makes it harder for styling the input from parent contexts. So in this PR the current `before`/`after` slots are removed and all `prepend`/`append` related slots (for all components) are renamed back to `before`/`after` so that now we keep the semantics consistent with CSS's `::before`/`::after` (before/after *the content* of the element).