### PR TITLE
fix(style): make vertical align less opinionated

### DIFF
--- a/packages/veui-theme-dls/components/autocomplete.less
+++ b/packages/veui-theme-dls/components/autocomplete.less
@@ -3,7 +3,6 @@
 
 .@{veui-prefix}-autocomplete {
   display: inline-flex;
-  vertical-align: middle;
   border-radius: @dls-input-border-radius-m;
 
   &[ui~="s"] {

--- a/packages/veui-theme-dls/components/badge.less
+++ b/packages/veui-theme-dls/components/badge.less
@@ -4,7 +4,6 @@
   position: relative;
   display: inline-flex;
   align-items: center;
-  vertical-align: middle;
 
   &-main {
     .absolute(0, 0, _, _);

--- a/packages/veui-theme-dls/components/button-group.less
+++ b/packages/veui-theme-dls/components/button-group.less
@@ -2,7 +2,6 @@
 
 .@{veui-prefix}-button-group {
   display: inline-flex;
-  vertical-align: middle;
 
   .@{veui-prefix}-button {
     position: relative;

--- a/packages/veui-theme-dls/components/button.less
+++ b/packages/veui-theme-dls/components/button.less
@@ -11,9 +11,12 @@
   color: @dls-button-font-color-normal;
   line-height: 2;
   white-space: nowrap;
-  vertical-align: middle;
   cursor: pointer;
   .veui-button-transition();
+
+  &::before {
+    content: "\200b";
+  }
 
   .make-metrics(@size) {
     @height: ~"dls-button-height-@{size}";
@@ -225,7 +228,6 @@
     line-height: inherit;
     background-color: @dls-button-background-color-text;
     color: @dls-button-font-color-text;
-    vertical-align: inherit;
 
     &::after {
       content: "";

--- a/packages/veui-theme-dls/components/dropdown.less
+++ b/packages/veui-theme-dls/components/dropdown.less
@@ -4,7 +4,6 @@
 .@{veui-prefix}-dropdown {
   &:extend(._veui-dropdown-button all);
   display: inline-flex;
-  vertical-align: middle;
 
   &-box {
     pointer-events: none;

--- a/packages/veui-theme-dls/components/input-group.less
+++ b/packages/veui-theme-dls/components/input-group.less
@@ -3,7 +3,6 @@
 .@{veui-prefix}-input-group {
   display: inline-flex;
   align-items: stretch;
-  vertical-align: middle;
 
   .@{veui-prefix}-span,
   .@{veui-prefix}-label {

--- a/packages/veui-theme-dls/components/input.less
+++ b/packages/veui-theme-dls/components/input.less
@@ -13,7 +13,6 @@
   color: @dls-input-font-color;
   border-radius: @dls-input-border-radius-m;
   font-size: @dls-input-font-size-m;
-  vertical-align: middle;
   line-height: normal;
   cursor: text;
   .veui-transition(border-color, color, box-shadow);

--- a/packages/veui-theme-dls/components/loading.less
+++ b/packages/veui-theme-dls/components/loading.less
@@ -4,7 +4,6 @@
   line-height: 1;
   align-items: center;
   display: inline-flex;
-  vertical-align: middle;
   font-size: @dls-loading-font-size-m;
 
   &[ui~="s"] {

--- a/packages/veui-theme-dls/components/pagination.less
+++ b/packages/veui-theme-dls/components/pagination.less
@@ -2,7 +2,6 @@
 
 .@{veui-prefix}-pagination {
   display: inline-flex;
-  vertical-align: middle;
   font-size: @dls-pagination-font-size-m;
 
   &,

--- a/packages/veui-theme-dls/components/progress.less
+++ b/packages/veui-theme-dls/components/progress.less
@@ -3,7 +3,6 @@
 .@{veui-prefix}-progress {
   display: inline-flex;
   align-items: center;
-  vertical-align: middle;
   position: relative;
   color: @dls-progress-font-color;
   .veui-transition(color);

--- a/packages/veui-theme-dls/components/search-box.less
+++ b/packages/veui-theme-dls/components/search-box.less
@@ -3,7 +3,6 @@
 
 .@{veui-prefix}-search-box {
   display: inline-flex;
-  vertical-align: middle;
   width: @dls-input-width;
   color: @dls-input-font-color;
   background-color: @dls-input-background-color;

--- a/packages/veui-theme-dls/components/select.less
+++ b/packages/veui-theme-dls/components/select.less
@@ -8,7 +8,6 @@
   display: inline-flex;
   align-items: center;
   width: @dls-select-width;
-  vertical-align: middle;
   outline: none;
 
   &:not(&-empty):not(&-expanded)

--- a/packages/veui-theme-dls/components/switch.less
+++ b/packages/veui-theme-dls/components/switch.less
@@ -48,7 +48,6 @@
 
   display: inline-flex;
   align-items: center;
-  vertical-align: middle;
   position: relative;
   cursor: pointer;
   outline: none;

--- a/packages/veui-theme-dls/components/tag.less
+++ b/packages/veui-theme-dls/components/tag.less
@@ -4,7 +4,6 @@
   position: relative;
   display: inline-flex;
   align-items: center;
-  vertical-align: middle;
   .make-metrics(m);
   .padding(0, @dls-tag-padding);
   white-space: nowrap;

--- a/packages/veui/demo/cases/Button.vue
+++ b/packages/veui/demo/cases/Button.vue
@@ -256,6 +256,26 @@
       </veui-button>
     </p>
   </section>
+  <section class="inline">
+    文本 Text
+    <veui-button ui="text">
+      Text
+    </veui-button>
+    <veui-button ui="icon">
+      <veui-icon name="home"/>
+    </veui-button>
+    <veui-button ui="icon strong">
+      <veui-icon name="home"/>
+    </veui-button>
+    <veui-button ui="icon aux">
+      <veui-icon name="home"/>
+    </veui-button>
+    <veui-button ui="primary square">
+      <veui-icon name="home"/>
+    </veui-button>
+    <veui-button ui="text aux">编辑</veui-button>
+    <veui-button>保存</veui-button>
+  </section>
 </article>
 </template>
 
@@ -266,6 +286,7 @@ import 'veui-theme-dls-icons/check'
 import 'veui-theme-dls-icons/edit'
 import 'veui-theme-dls-icons/times'
 import 'veui-theme-dls-icons/search'
+import 'veui-theme-dls-icons/home'
 
 export default {
   name: 'button-demo',
@@ -302,5 +323,9 @@ section {
 
 .veui-button {
   margin-right: 10px;
+}
+
+.inline {
+  display: block;
 }
 </style>

--- a/packages/veui/demo/cases/Input.vue
+++ b/packages/veui/demo/cases/Input.vue
@@ -5,7 +5,7 @@
     <section class="five-sizes">
       <h3>4 种大小：</h3>
       <veui-field
-        ui="micro"
+        ui="xs"
         label="xs"
       >
         <veui-input
@@ -15,7 +15,7 @@
         />
       </veui-field>
       <veui-field
-        ui="tiny"
+        ui="s"
         label="s"
       >
         <veui-input
@@ -24,7 +24,7 @@
         />
       </veui-field>
       <veui-field
-        ui="small"
+        ui="s"
         label="m"
       >
         <veui-input
@@ -33,7 +33,7 @@
         />
       </veui-field>
       <veui-field
-        ui="large"
+        ui="l"
         label="l"
       >
         <veui-input
@@ -49,7 +49,9 @@
       <veui-input
         value="固定内容"
         composition
+        ui="xs"
       />
+      <veui-button ui="xs">Submit</veui-button>
       <h3>受控（不感知输入法，固定值）</h3>
       <p class="attention">现象：英文直接不能输入，中文输入法结束时直接被重置</p>
       <veui-input


### PR DESCRIPTION
* Removed built-in `vertical-align: middle` for input components.
* Applied a hack for better default alignment for buttons with icons.