### PR TITLE
fix: fix Uploader .veui-uploader-list-media-item overflow:hidden bug

### DIFF
--- a/packages/veui-theme-dls/components/uploader.less
+++ b/packages/veui-theme-dls/components/uploader.less
@@ -152,7 +152,6 @@
 
     &-item {
       display: inline-block;
-      overflow: hidden;
       vertical-align: top;
       margin: @dls-uploader-media-spacing-y 0 0 @dls-uploader-media-spacing-x;
       .size(@dls-uploader-media-width-m, @dls-uploader-media-height-m);


### PR DESCRIPTION
修复uploader .veui-uploader-list-media-item 设置overflow:hidden导致file-after slot的内容无法展示出来