### PR TITLE
Add `aim-center` support for Tooltip & Popover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -857,108 +857,111 @@
 
 - [-] 移除了 `babel-preset-veui`。<!-- #babel-preset-veui -->
 - [-] 移除了 `veui-theme-one`。<!-- #veui-theme-one -->
-- [^] 对 `Tabs` 组件进行了重写，其中引入的非兼容性变更如下：<!-- #Tabs -->
+- [-] 移除了 `Tabs` 组件的 `index` prop，现在控制激活标签页只能使用 `active` prop，并支持可受控模式。<!-- #Tabs -->
 
-  - [-] 移除了 `index` prop，现在控制激活标签页只能使用 `active` prop，并支持可受控模式。
-  - [^] `tabs-extra` slot 更名为 `extra`，且仅包括提示区域的内容，不包括添加按钮。
-  - [-] 移除了 `tabs-extra-label` 与 `tabs-extra-tip` slot。
-  - [^] `tab-item` scoped slot 现在包含整个按钮/链接，方便替换为自定义实现。
-  - [-] 移除了 `tab-item-extra` scoped slot，`removable` 的 `Tab` 组件始终显示移除按钮。
-  - [^] 在路由模式下，不再自动输出 `<router-view>` 组件，需要通过 `Tab` 的 `default` slot 或 `Tabs` 新增的 `panel` slot 中进行输出。
+  > #### 使用指南
+  >
+  > ##### 使用 `active` prop 与 `change` 事件完全外部控制激活状态
+  >
+  > ```html
+  > <veui-tabs :active="active" @change="tab => active = tab.name">
+  >   <veui-tab label="A" name="a">Content A</veui-tab>
+  >   <veui-tab label="B" name="b">Content B</veui-tab>
+  >   <veui-tab label="C" name="c">Content C</veui-tab>
+  > </veui-tabs>
+  > ```
+  > ##### 使用 `active.sync` 双向同步激活状态
+  >
+  > ```html
+  > <veui-tabs :active.sync="active">
+  >   <veui-tab label="A" name="a">Content A</veui-tab>
+  >   <veui-tab label="B" name="b">Content B</veui-tab>
+  >   <veui-tab label="C" name="c">Content C</veui-tab>
+  > </veui-tabs>
+  > ```
+  > ##### 激活状态完全由组件内部控制
+  >
+  > ```html
+  > <veui-tabs>
+  >   <veui-tab label="A">Content A</veui-tab>
+  >   <veui-tab label="B">Content B</veui-tab>
+  >   <veui-tab label="C">Content C</veui-tab>
+  > </veui-tabs>
+  > ```
 
-  其余变更：
+- [^] `Tabs` 组件的 `tabs-extra` slot 更名为 `extra`，且仅包括提示区域的内容，不包括添加按钮。<!-- #Tabs -->
+- [-] 移除了 `Tabs` 组件的 `tabs-extra-label` 与 `tabs-extra-tip` slot。<!-- #Tabs -->
+- [^] `Tabs` 组件的 `tab-item` scoped slot 现在包含整个按钮/链接，方便替换为自定义实现。<!-- #Tabs -->
+- [-] 移除了`Tabs` 组件的 `tab-item-extra` scoped slot，`removable` 的 `Tab` 组件始终显示移除按钮。<!-- #Tabs -->
+- [^] `Tabs` 组件在路由模式下，不再自动输出 `<router-view>` 组件，需要通过 `Tab` 的 `default` slot 或 `Tabs` 新增的 `panel` slot 中进行输出。<!-- #Tabs -->
 
-  - [+] 新增了 <del>`tab-item-label`</del><ins datetime="2020-10-21" title="修正于 2020-10-21">`tab-label`</ins> scoped slot，用于仅自定义标签项内容。
-  - [+] 新增 `panel` slot，用于指定标签下方面板内的自定义内容。
-  - [+] 新增 `change` 事件，回调参数为 `tab` 对像，包含 `name`、`label`、`to`、`status` 等字段。
-  - [+] `Tab` 组件新增了 `item` slot，用于自定义标签内容，与 `Tabs` 组件的 `tab-item` 对应，优先级更高。
-  - [+] `Tab` 组件新增了 `label` slot，用于自定义标签内容，与 `Tabs` 组件的 `tab-label` 对应，优先级更高。
+  > #### 使用指南
+  >
+  > ##### （嵌套）路由模式
+  >
+  > 在之前的版本，如果 `Tab` 组件的 `default` slot 未传入任何内容，路由模式下 VEUI 会自动在标签内容容器内渲染 `<router-view>`。这导致在不使用嵌套路由时或是希望灵活控制 `<router-view>` 位置时产生额外的问题。所以在这个版本中移除了这个逻辑，用户可以使用 `Tabs` 的 `panel` slot 来统一在标签内容容器中输出 `<router-view>`，也可以在某些 `Tab` 的 `default` slot 中输出 `<router-view>` 及额外内容来覆盖全局的 `panel` slot，甚至可以将 `<router-view>` 输出到其它任意合适的位置。
+  >
+  > ```html
+  > <veui-tabs>
+  >   <veui-tab label="A" to="content/a"/>
+  >   <veui-tab label="B" to="content/b"/>
+  >   <veui-tab label="C" to="content/c">
+  >     <h3>Content C</h3>
+  >     <router-view/>
+  >   </veui-tab>
+  >   <template #panel>
+  >     <router-view/>
+  >   </template>
+  > </veui-tabs>
+  > ```
 
-    > #### 使用指南
-    >
-    > ##### 使用 `active` prop 与 `change` 事件完全外部控制激活状态
-    >
-    > ```html
-    > <veui-tabs :active="active" @change="tab => active = tab.name">
-    >   <veui-tab label="A" name="a">Content A</veui-tab>
-    >   <veui-tab label="B" name="b">Content B</veui-tab>
-    >   <veui-tab label="C" name="c">Content C</veui-tab>
-    > </veui-tabs>
-    > ```
-    > ##### 使用 `active.sync` 双向同步激活状态
-    >
-    > ```html
-    > <veui-tabs :active.sync="active">
-    >   <veui-tab label="A" name="a">Content A</veui-tab>
-    >   <veui-tab label="B" name="b">Content B</veui-tab>
-    >   <veui-tab label="C" name="c">Content C</veui-tab>
-    > </veui-tabs>
-    > ```
-    > ##### 激活状态完全由组件内部控制
-    >
-    > ```html
-    > <veui-tabs>
-    >   <veui-tab label="A">Content A</veui-tab>
-    >   <veui-tab label="B">Content B</veui-tab>
-    >   <veui-tab label="C">Content C</veui-tab>
-    > </veui-tabs>
-    > ```
-    >
-    > ##### （嵌套）路由模式
-    >
-    > 在之前的版本，如果 `Tab` 组件的 `default` slot 未传入任何内容，路由模式下 VEUI 会自动在标签内容容器内渲染 `<router-view>`。这导致在不使用嵌套路由时或是希望灵活控制 `<router-view>` 位置时产生额外的问题。所以在这个版本中移除了这个逻辑，用户可以使用 `Tabs` 的 `panel` slot 来统一在标签内容容器中输出 `<router-view>`，也可以在某些 `Tab` 的 `default` slot 中输出 `<router-view>` 及额外内容来覆盖全局的 `panel` slot，甚至可以将 `<router-view>` 输出到其它任意合适的位置。
-    >
-    > ```html
-    > <veui-tabs>
-    >   <veui-tab label="A" to="content/a"/>
-    >   <veui-tab label="B" to="content/b"/>
-    >   <veui-tab label="C" to="content/c">
-    >     <h3>Content C</h3>
-    >     <router-view/>
-    >   </veui-tab>
-    >   <template #panel>
-    >     <router-view/>
-    >   </template>
-    > </veui-tabs>
-    > ```
-    >
-    > ##### 自定义标签项内容
-    >
-    > 可以使用 `Tabs` 的 `tab-item` scoped slot 来自定义所有标签项的内容，也可以使用 `Tab` 的 `item` scoped slot 来自定义单个标签项内容（单个内容将覆盖整体的内容）。
-    >
-    > ```html
-    > <veui-tabs>
-    >   <veui-tab label="A">
-    >     Content A
-    >     <template #item="tab">
-    >       <button
-    >         type="button"
-    >         class="foo-btn"
-    >         :disabled="tab.disabled"
-    >         v-bind="tab.attrs"
-    >         @click="tab.activate"
-    >       >
-    >         {{ `${tab.label} ${tab.active ? '✅' : '' }` }}
-    >       </button>
-    >     </template>
-    >   </veui-tab>
-    >   <veui-tab label="B">Content B</veui-tab>
-    >   <veui-tab label="C">Content C</veui-tab>
-    > </veui-tabs>
-    > ```
-    >
-    > 如果只想定义文本区域的内容（不需重写点击激活等逻辑），请使用 `Tabs` 的 `tab-label` 或 `Tab` 的 `label` scoped slot，用法类似。
-    >
-    > ```html
-    > <veui-tabs>
-    >   <veui-tab label="A">
-    >     Content A
-    >     <template #label="tab">Content A {{ `${tab.active ? '✅' : '' }` }}</template>
-    >   </veui-tab>
-    >   <veui-tab label="B">Content B</veui-tab>
-    >   <veui-tab label="C">Content C</veui-tab>
-    > </veui-tabs>
-    > ```
+### 💡 主要变更
+
+- [+] 新增了 `Tabs` 组件的 `tab-label` scoped slot，用于仅自定义标签项内容。
+- [+] 新增 `Tabs` 组件的 `panel` slot，用于指定标签下方面板内的自定义内容。
+- [+] 新增 `Tabs` 组件的 `change` 事件，回调参数为 `tab` 对像，包含 `name`、`label`、`to`、`status` 等字段。
+- [+] 新增 `Tab` 组件的 `item` slot，用于自定义标签内容，与 `Tabs` 组件的 `tab-item` 对应，优先级更高。
+- [+] 新增 `Tab` 组件的 `label` slot，用于自定义标签内容，与 `Tabs` 组件的 `tab-label` 对应，优先级更高。
+
+  > #### 使用指南
+  >
+  > ##### 自定义标签项内容
+  >
+  > 可以使用 `Tabs` 的 `tab-item` scoped slot 来自定义所有标签项的内容，也可以使用 `Tab` 的 `item` scoped slot 来自定义单个标签项内容（单个内容将覆盖整体的内容）。
+  >
+  > ```html
+  > <veui-tabs>
+  >   <veui-tab label="A">
+  >     Content A
+  >     <template #item="tab">
+  >       <button
+  >         type="button"
+  >         class="foo-btn"
+  >         :disabled="tab.disabled"
+  >         v-bind="tab.attrs"
+  >         @click="tab.activate"
+  >       >
+  >         {{ `${tab.label} ${tab.active ? '✅' : '' }` }}
+  >       </button>
+  >     </template>
+  >   </veui-tab>
+  >   <veui-tab label="B">Content B</veui-tab>
+  >   <veui-tab label="C">Content C</veui-tab>
+  > </veui-tabs>
+  > ```
+  >
+  > 如果只想定义文本区域的内容（不需重写点击激活等逻辑），请使用 `Tabs` 的 `tab-label` 或 `Tab` 的 `label` scoped slot，用法类似。
+  >
+  > ```html
+  > <veui-tabs>
+  >   <veui-tab label="A">
+  >     Content A
+  >     <template #label="tab">Content A {{ `${tab.active ? '✅' : '' }` }}</template>
+  >   </veui-tab>
+  >   <veui-tab label="B">Content B</veui-tab>
+  >   <veui-tab label="C">Content C</veui-tab>
+  > </veui-tabs>
+  > ```
 
 ### 🐞 问题修复
 

--- a/packages/veui-theme-dls/components/popover.less
+++ b/packages/veui-theme-dls/components/popover.less
@@ -17,6 +17,11 @@
 
     @arrow-offset: @arrow-indent - @arrow-size / 2;
 
+    .make-align(@side) {
+      &-aim-center {
+        margin-@{side}: dls-sum(-@arrow-indent, -@arrow-size / 2);
+      }
+    }
     .make-align(top) {
       &-arrow {
         top: @arrow-offset;

--- a/packages/veui-theme-dls/components/tooltip.less
+++ b/packages/veui-theme-dls/components/tooltip.less
@@ -92,6 +92,11 @@
 
   @arrow-offset: @arrow-indent - @arrow-size / 2;
 
+  .make-align(@side) {
+    &.@{veui-prefix}-tooltip-aim-center {
+      margin-@{side}: dls-sum(-@arrow-indent, -@arrow-size / 2);
+    }
+  }
   .make-align(top) {
     &-arrow {
       top: @arrow-offset;

--- a/packages/veui/demo/cases/Popover.vue
+++ b/packages/veui/demo/cases/Popover.vue
@@ -2,6 +2,14 @@
 <article>
   <h1><code>&lt;veui-popover&gt;</code></h1>
   <section>
+    <veui-checkbox
+      v-model="aimCenter"
+      style="margin-left: 20px"
+    >
+      对准中心
+    </veui-checkbox>
+  </section>
+  <section>
     <div class="demo-wrap">
       <div style="margin-bottom:10px;">
         hover事件
@@ -169,6 +177,7 @@
       :overlay-style="{
         '--dls-dropdown-max-display-items': 8
       }"
+      :aim-center="aimCenter"
       trigger="hover"
     >
       当前是hover事件
@@ -339,6 +348,7 @@
       :position="clickPosition"
       :target="clickTarget"
       :open.sync="clickOpen"
+      :aim-center="aimCenter"
       trigger="click"
     >
       当前是click事件
@@ -349,12 +359,13 @@
 
 <script>
 import bus from '../bus'
-import { Button, Popover } from 'veui'
+import { Button, Checkbox, Popover } from 'veui'
 
 export default {
   name: 'popover-demo',
   components: {
     'veui-button': Button,
+    'veui-checkbox': Checkbox,
     'veui-popover': Popover
   },
   data () {
@@ -365,7 +376,8 @@ export default {
       clickTarget: 'topLeftClick',
       open: false,
       clickOpen: false,
-      overlayOptions: {}
+      overlayOptions: {},
+      aimCenter: false
     }
   },
   mounted () {

--- a/packages/veui/demo/cases/Tooltip.vue
+++ b/packages/veui/demo/cases/Tooltip.vue
@@ -2,12 +2,19 @@
 <article>
   <h1><code>&lt;veui-tooltip&gt;</code></h1>
   <section>
-    <veui-button
-      ui="primary"
-      @click="ui = ui ? '' : 'reverse'"
+    <veui-checkbox
+      v-model="ui"
+      true-value="reverse"
+      false-value=""
     >
-      切换皮肤
-    </veui-button>
+      反色皮肤
+    </veui-checkbox>
+    <veui-checkbox
+      v-model="aimCenter"
+      style="margin-left: 20px"
+    >
+      对准中心
+    </veui-checkbox>
   </section>
   <section>
     <div class="demo-wrap">
@@ -173,6 +180,7 @@
       :target="target"
       :open.sync="open"
       :overlay-options="overlayOptions"
+      :aim-center="aimCenter"
       trigger="hover"
     >
       当前是hover事件
@@ -341,6 +349,7 @@
       :ui="ui"
       :target="clickTarget"
       :open.sync="clickOpen"
+      :aim-center="aimCenter"
       trigger="click"
     >
       当前是click事件
@@ -366,6 +375,7 @@
         '--dls-dropdown-max-display-items': 8
       }"
       :open.sync="numberOpen"
+      :aim-center="aimCenter"
     >
       你focus到了
     </veui-tooltip>
@@ -380,6 +390,7 @@
       trigger="hover"
       :interactive="false"
       :hide-delay="0"
+      :aim-center="aimCenter"
     >
       你focus到了
     </veui-tooltip>
@@ -414,7 +425,7 @@
 
 <script>
 import bus from '../bus'
-import { Tooltip, Button, Input } from 'veui'
+import { Tooltip, Checkbox, Button, Input } from 'veui'
 import { tooltip } from 'veui/directives'
 
 export default {
@@ -424,6 +435,7 @@ export default {
   },
   components: {
     'veui-button': Button,
+    'veui-checkbox': Checkbox,
     'veui-tooltip': Tooltip,
     'veui-input': Input
   },
@@ -441,7 +453,8 @@ export default {
       overlayOptions: {},
       descA: 1,
       descB: 'B',
-      showDesc: true
+      showDesc: true,
+      aimCenter: false
     }
   },
   mounted () {

--- a/packages/veui/src/components/DatePicker.vue
+++ b/packages/veui/src/components/DatePicker.vue
@@ -292,7 +292,7 @@ export default {
       picking: null,
       localSelected: null,
       localInputValue: [],
-      localOverlayOptions: {
+      defaultOverlayOptions: {
         position: 'top-start',
         inner: {
           enabled: true

--- a/packages/veui/src/components/Menu/Menu.vue
+++ b/packages/veui/src/components/Menu/Menu.vue
@@ -254,7 +254,7 @@ export default {
   },
   data () {
     return {
-      localOverlayOptions: {
+      defaultOverlayOptions: {
         position: 'right-start'
       },
       hoverItem: null,

--- a/packages/veui/src/components/Select/OptionGroup.vue
+++ b/packages/veui/src/components/Select/OptionGroup.vue
@@ -93,7 +93,7 @@ const OptionGroup = {
   data () {
     return {
       items: [],
-      localOverlayOptions: {
+      defaultOverlayOptions: {
         position: 'right-start'
       },
       outsideRefs: ['button'],

--- a/packages/veui/src/components/Tooltip.vue
+++ b/packages/veui/src/components/Tooltip.vue
@@ -56,14 +56,8 @@ export default {
       type: Boolean,
       default: true
     },
-    autofocus: Boolean
-  },
-  data () {
-    return {
-      localOverlayOptions: {
-        position: this.position
-      }
-    }
+    autofocus: Boolean,
+    aimCenter: Boolean
   },
   computed: {
     realTrigger () {
@@ -102,6 +96,23 @@ export default {
     },
     realAutofocus () {
       return this.interactive ? this.autofocus : false
+    },
+    defaultOverlayOptions () {
+      return {
+        position: this.position,
+        ...(this.aimCenter
+          ? {
+            offset: {
+              offset:
+                  this.position.indexOf('start') !== -1
+                    ? '50%'
+                    : this.position.indexOf('end') !== -1
+                      ? '-50%'
+                      : 0
+            }
+          }
+          : {})
+      }
     }
   },
   watch: {
@@ -113,7 +124,7 @@ export default {
       this.rebindHandler()
     },
     position (val) {
-      this.localOverlayOptions.position = val
+      this.defaultOverlayOptions.position = val
     }
   },
   mounted () {
@@ -186,7 +197,10 @@ export default {
         autofocus={this.realAutofocus}
       >
         <div
-          class={this.$c('tooltip')}
+          class={{
+            [this.$c('tooltip')]: true,
+            [this.$c('tooltip-aim-center')]: this.aimCenter
+          }}
           ui={this.realUi}
           role="tooltip"
           {...{ directives }}

--- a/packages/veui/src/mixins/dropdown.js
+++ b/packages/veui/src/mixins/dropdown.js
@@ -24,7 +24,7 @@ const baseMixin = {
   },
   data () {
     return {
-      localOverlayOptions: {
+      defaultOverlayOptions: {
         position: 'bottom-start'
       },
       dropdownId: uniqueId('veui-dropdown-')

--- a/packages/veui/src/mixins/overlay.js
+++ b/packages/veui/src/mixins/overlay.js
@@ -11,14 +11,9 @@ export default {
       }
     }
   },
-  data () {
-    return {
-      localOverlayOptions: {}
-    }
-  },
   computed: {
     realOverlayOptions () {
-      return { ...this.localOverlayOptions, ...this.overlayOptions }
+      return { ...this.defaultOverlayOptions, ...this.overlayOptions }
     }
   },
   methods: {


### PR DESCRIPTION
...and refactored a little for components depend on the `overlay` mixin. (rename `localOverlayOptions` to `defaultOverlayOptions`)

Closes #904.