### PR TITLE
feat: add overflow tooltip for tooltip directive and table column

### DIFF
--- a/packages/veui-theme-dls/components/table.less
+++ b/packages/veui-theme-dls/components/table.less
@@ -6,6 +6,9 @@
   border-bottom: 1px solid @dls-table-cell-border-color;
   font-variant-numeric: tabular-nums;
 
+  --dls-table-head-cell-lines: 1;
+  --dls-table-cell-lines: 1;
+
   table {
     width: 100%;
     table-layout: fixed;

--- a/packages/veui/demo/cases/Table.vue
+++ b/packages/veui/demo/cases/Table.vue
@@ -113,6 +113,7 @@
       <veui-table-column
         field="desc"
         title="数据描述"
+        :tooltip="({ desc }) => desc.substring(0, 30) + '...'"
       />
       <veui-table-column
         field="price"
@@ -552,7 +553,8 @@ const tableData = [
   },
   {
     id: '3156',
-    desc: '数据描述3',
+    desc:
+      '数据描述3-Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sed dolores culpa ipsa alias pariatur cumque libero in earum vel vitae officia ullam, eum consequuntur perferendis! Optio maxime error qui veritatis!',
     price: 820,
     updateDate: '20170610',
     group: '1578',
@@ -578,7 +580,8 @@ const tableData = [
   },
   {
     id: '3157',
-    desc: '数据描述4',
+    desc:
+      '数据描述4-Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sed dolores culpa ipsa alias pariatur cumque libero in earum vel vitae officia ullam, eum consequuntur perferendis! Optio maxime error qui veritatis!',
     price: 736,
     updateDate: '20180109',
     group: '1578',

--- a/packages/veui/demo/cases/Tooltip.vue
+++ b/packages/veui/demo/cases/Tooltip.vue
@@ -420,6 +420,44 @@
       >{{ showDesc ? 'Disable' : 'Enable' }}</veui-button>
     </section>
   </section>
+  <section>
+    <h3><code>v-tooltip.overflow</code></h3>
+    <section class="group overflow">
+      <p
+        v-tooltip.overflow="{
+          content: descA,
+          disabled: !showDesc
+        }"
+        class="ellipsis"
+      >
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Inventore
+        nisi suscipit saepe ipsum enim mollitia voluptates, blanditiis aperiam
+        vel facere assumenda hic libero iusto, at soluta magni cum in
+        voluptatibus?
+      </p>
+      <p
+        v-tooltip.overflow="{
+          content: descA,
+          disabled: !showDesc
+        }"
+        class="ellipsis"
+      >
+        Lorem ipsum.
+      </p>
+      <p
+        v-tooltip.overflow="{
+          content: descB,
+          disabled: !showDesc
+        }"
+        class="line-clamp"
+      >
+        Lorem ipsum dolor sit, amet consectetur adipisicing elit. Repudiandae
+        quia modi, architecto sunt dolorem provident? Hic similique, at
+        corrupti dolorem, tempore libero magni accusantium aut repellat cum
+        fuga quidem et.
+      </p>
+    </section>
+  </section>
 </article>
 </template>
 
@@ -531,5 +569,25 @@ section {
   display: flex;
   align-items: center;
   gap: 8px;
+}
+
+.group.overflow {
+  flex-direction: column;
+}
+
+.ellipsis {
+  width: 200px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.line-clamp {
+  display: -webkit-box;
+  width: 200px;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  -webkit-line-clamp: 2;
 }
 </style>

--- a/packages/veui/src/components/Table/Column.vue
+++ b/packages/veui/src/components/Table/Column.vue
@@ -16,6 +16,7 @@ let col = useChild('table-column', 'colgroup', [
   'span',
   'allowedOrders',
   'desc',
+  'tooltip',
   ['filterValue', 'realFilterValue'],
   'filterTitle',
   ['filterOptions', 'realFilterOptions'],
@@ -77,7 +78,8 @@ export default {
     filterValue: {},
     filterTitle: String,
     filterOptions: Array,
-    filterMultiple: Boolean
+    filterMultiple: Boolean,
+    tooltip: [Boolean, Function]
   },
   computed: {
     realFixed () {

--- a/packages/veui/src/components/Table/_HeadCell.js
+++ b/packages/veui/src/components/Table/_HeadCell.js
@@ -251,7 +251,7 @@ export default {
             target="self"
             open={this.descOpen}
             onToggle={this.handleToggleDesc}
-            position="bottom"
+            position="top"
           >
             {desc}
           </Popover>

--- a/packages/veui/src/components/Table/_Row.js
+++ b/packages/veui/src/components/Table/_Row.js
@@ -6,11 +6,27 @@ import Icon from '../Icon'
 import prefix from '../../mixins/prefix'
 import table from '../../mixins/table'
 import i18n from '../../mixins/i18n'
+import tooltip from '../../directives/tooltip'
 import '../../common/uiTypes'
+
+function renderTooltip (tooltip, item, field) {
+  if (tooltip === true) {
+    return item[field]
+  }
+
+  if (typeof tooltip === 'function') {
+    return tooltip(item, field)
+  }
+
+  return null
+}
 
 export default {
   name: 'veui-table-row',
   mixins: [prefix, table, i18n],
+  directives: {
+    tooltip
+  },
   uiTypes: ['transparent'],
   props: {
     index: Number,
@@ -257,7 +273,20 @@ export default {
             {...data}
           >
             <div class={this.$c('table-cell')}>
-              <div class={this.$c('table-cell-content')}>
+              <div
+                class={this.$c('table-cell-content')}
+                {...(col.tooltip
+                  ? {
+                    directives: [
+                      {
+                        name: 'tooltip',
+                        value: renderTooltip(col.tooltip, item, col.field),
+                        modifiers: { overflow: true }
+                      }
+                    ]
+                  }
+                  : {})}
+              >
                 {(isSubRow ? col.renderSubRow : col.renderBody)({
                   ...item,
                   item,

--- a/packages/veui/src/components/Tooltip.vue
+++ b/packages/veui/src/components/Tooltip.vue
@@ -89,7 +89,7 @@ export default {
       return this.position || 'top'
     },
     targetNode () {
-      return this.getTargetNode(this.target)
+      return this.getTargetNode()
     },
     outsideOptions () {
       return {
@@ -141,7 +141,7 @@ export default {
     this.removeHandler()
   },
   methods: {
-    getTargetNode (target) {
+    getTargetNode () {
       return getNodes(this.target, this.$vnode.context)[0]
     },
     openHandler () {

--- a/packages/veui/src/directives/tooltip.js
+++ b/packages/veui/src/directives/tooltip.js
@@ -1,13 +1,15 @@
 import { normalize } from 'vue-directive-normalizer'
 import tooltip from '../managers/tooltip'
 import { flatMap } from 'lodash'
+import { isOverflow } from '../utils/dom'
 
 const OPTIONS_SCHEMA = {
   value: 'content',
   modifiers: {
     position: flatMap(['top', 'right', 'bottom', 'left', 'auto'], side => {
       return [side, `${side}-start`, `${side}-end`]
-    })
+    }),
+    overflow: false
   },
   defaults: () => ({
     disabled: false
@@ -28,7 +30,10 @@ function refresh (el, binding) {
     if (options.disabled) {
       return
     }
-    tooltip.enter(this, options)
+
+    if (!options.overflow || isOverflow(el)) {
+      tooltip.enter(this, options)
+    }
   }
 
   function handleMouseLeave () {
@@ -36,7 +41,9 @@ function refresh (el, binding) {
     if (options.disabled) {
       return
     }
-    tooltip.leave()
+    if (!options.overflow || isOverflow(el)) {
+      tooltip.leave()
+    }
   }
 
   context = el.__tooltip_context__ = {
@@ -52,7 +59,7 @@ function refresh (el, binding) {
 function clear (el) {
   const { handleMouseEnter, handleMouseLeave } = el.__tooltip_context__
 
-  tooltip.leave(el)
+  tooltip.destroy()
   el.removeEventListener('mouseenter', handleMouseEnter)
   el.removeEventListener('mouseleave', handleMouseLeave)
 

--- a/packages/veui/src/managers/tooltip.js
+++ b/packages/veui/src/managers/tooltip.js
@@ -51,11 +51,7 @@ export function createTooltipManager ({ warmup, cooldown = warmup } = {}) {
     )
   }
 
-  function leave (target) {
-    if (target && component && target !== component.target) {
-      return
-    }
-
+  function leave () {
     close()
     if (timer !== null) {
       // warmup timer
@@ -75,12 +71,12 @@ export function createTooltipManager ({ warmup, cooldown = warmup } = {}) {
   }
 
   function open (target, { position, content }) {
-    if (!component) {
-      component = createComponent()
-    }
-
     if (!target || !content) {
       return
+    }
+
+    if (!component) {
+      component = createComponent()
     }
 
     assign(component, {

--- a/packages/veui/src/managers/tooltip.js
+++ b/packages/veui/src/managers/tooltip.js
@@ -18,6 +18,7 @@ export function createTooltipManager ({ warmup, cooldown = warmup } = {}) {
 
   function destroy () {
     clearTimeout(timer)
+    timer = null
 
     if (component) {
       component.$destroy()
@@ -67,7 +68,6 @@ export function createTooltipManager ({ warmup, cooldown = warmup } = {}) {
     // warmup complete and being active
     timer = setTimeout(
       () => {
-        timer = null
         destroy()
       },
       cooldown == null ? config.get('tooltip.cooldown') : cooldown

--- a/packages/veui/test/unit/specs/components/Table.spec.js
+++ b/packages/veui/test/unit/specs/components/Table.spec.js
@@ -2070,7 +2070,9 @@ describe('components/Table', () => {
     wrapper.destroy()
   })
 
-  it('should support tooltip prop on Columns', async () => {
+  it('should support tooltip prop on Columns', async function () {
+    this.timeout(5000)
+
     const loremIpsum =
       'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sed dolores culpa ipsa alias pariatur cumque libero in earum vel vitae officia ullam, eum consequuntur perferendis! Optio maxime error qui veritatis!'
 
@@ -2084,8 +2086,8 @@ describe('components/Table', () => {
           return {
             selectable: true,
             data: [
-              { id: 1, name: loremIpsum },
-              { id: 2, name: '2name' }
+              { id: 1, foo: loremIpsum, bar: loremIpsum, baz: loremIpsum },
+              { id: 2, foo: 'foo', bar: 'bar', baz: 'baz' }
             ]
           }
         },
@@ -2095,15 +2097,22 @@ describe('components/Table', () => {
             :data="data"
           >
             <veui-table-column
-              field="id"
-              title="id"
-              :width="120"
-            />
-            <veui-table-column
-              field="name"
-              title="name"
+              field="foo"
+              title="Foo"
               :width="200"
               tooltip
+            />
+            <veui-table-column
+              field="bar"
+              title="Bar"
+              :width="200"
+              :tooltip="({ bar }) => bar"
+            />
+            <veui-table-column
+              field="baz"
+              title="Baz"
+              :width="200"
+              :tooltip="null"
             />
           </veui-table>`
       },
@@ -2113,18 +2122,23 @@ describe('components/Table', () => {
       }
     )
 
-    let [, long, , short] = wrapper.findAll(
+    let [longFoo, longBar, longBaz, shortFoo] = wrapper.findAll(
       'tbody .veui-table-cell-content'
     ).wrappers
 
-    long.trigger('mouseenter')
+    longFoo.trigger('mouseenter')
     let warmup = config.get('tooltip.warmup')
 
     await wait(warmup + 100)
     expectTooltip(loremIpsum)
 
-    long.trigger('mouseleave')
-    short.trigger('mouseenter')
+    longBar.trigger('mouseleave')
+    shortFoo.trigger('mouseenter')
+    await wait(warmup + 100)
+    expectTooltip(null)
+
+    shortFoo.trigger('mouseleave')
+    longBaz.trigger('mouseenter')
     await wait(warmup + 100)
     expectTooltip(null)
 

--- a/packages/veui/test/unit/specs/components/Table.spec.js
+++ b/packages/veui/test/unit/specs/components/Table.spec.js
@@ -3,7 +3,9 @@ import Popover from '@/components/Popover'
 import Table from '@/components/Table'
 import Column from '@/components/Table/Column'
 import Select from '@/components/Select'
-import { mount, wait } from '../../../utils'
+import { expectTooltip, mount, wait } from '../../../utils'
+import tooltipManager from '@/managers/tooltip'
+import config from '@/managers/config'
 
 describe('components/Table', () => {
   it('should select the specified fields.', async () => {
@@ -2065,6 +2067,68 @@ describe('components/Table', () => {
       wrapper.find('.veui-table-cell-sticky-edge').element.style.left
     ).to.equal('0px')
 
+    wrapper.destroy()
+  })
+
+  it('should support tooltip prop on Columns', async () => {
+    const loremIpsum =
+      'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sed dolores culpa ipsa alias pariatur cumque libero in earum vel vitae officia ullam, eum consequuntur perferendis! Optio maxime error qui veritatis!'
+
+    const wrapper = mount(
+      {
+        components: {
+          'veui-table': Table,
+          'veui-table-column': Column
+        },
+        data () {
+          return {
+            selectable: true,
+            data: [
+              { id: 1, name: loremIpsum },
+              { id: 2, name: '2name' }
+            ]
+          }
+        },
+        template: `
+          <veui-table
+            key-field="id"
+            :data="data"
+          >
+            <veui-table-column
+              field="id"
+              title="id"
+              :width="120"
+            />
+            <veui-table-column
+              field="name"
+              title="name"
+              :width="200"
+              tooltip
+            />
+          </veui-table>`
+      },
+      {
+        sync: false,
+        attachToDocument: true
+      }
+    )
+
+    let [, long, , short] = wrapper.findAll(
+      'tbody .veui-table-cell-content'
+    ).wrappers
+
+    long.trigger('mouseenter')
+    let warmup = config.get('tooltip.warmup')
+
+    await wait(warmup + 100)
+    expectTooltip(loremIpsum)
+
+    long.trigger('mouseleave')
+    short.trigger('mouseenter')
+    await wait(warmup + 100)
+    expectTooltip(null)
+
+    tooltipManager.destroy()
     wrapper.destroy()
   })
 })

--- a/packages/veui/test/unit/specs/managers/tooltip.spec.js
+++ b/packages/veui/test/unit/specs/managers/tooltip.spec.js
@@ -1,4 +1,6 @@
 import { createTooltipManager } from '@/managers/tooltip'
+import config from '@/managers/config'
+import { getPortalEntry } from '@/utils/dom'
 import { expectTooltip, wait } from '../../../utils'
 
 describe('managers/tooltip', () => {
@@ -36,5 +38,39 @@ describe('managers/tooltip', () => {
     expectTooltip(null)
 
     manager.destroy()
+  })
+
+  it('should handle ignore invalid usage', async () => {
+    const warmup = config.get('tooltip.warmup')
+
+    const manager = createTooltipManager()
+    const el = document.createElement('div')
+
+    manager.enter(null, { content: 'Hi' })
+    await wait(warmup + 50)
+    expectTooltip(null)
+
+    manager.enter(el, {})
+    await wait(warmup + 50)
+    expectTooltip(null)
+
+    manager.leave()
+
+    manager.destroy()
+  })
+
+  it('should be safely destroyed', async () => {
+    const manager = createTooltipManager({ warmup: 100 })
+    const el = document.createElement('div')
+
+    manager.enter(el, { content: 'Hi' })
+    await wait(150)
+    expectTooltip('Hi')
+
+    const entry = getPortalEntry(document.querySelector('.veui-tooltip'))
+    entry.remove()
+
+    manager.destroy()
+    expectTooltip(null)
   })
 })

--- a/packages/veui/test/utils.js
+++ b/packages/veui/test/utils.js
@@ -52,6 +52,7 @@ export function expectTooltip (content, position) {
   if (content === null) {
     expect(tooltip).to.equal(null)
   } else if (content === false) {
+    expect(tooltip).to.not.equal(null)
     expect(tooltip.style.display).to.equal('none')
   } else {
     expect(tooltip).to.not.equal(null)


### PR DESCRIPTION
* `v-tooltip` 增加 `overflow` modifier
* 修正 `v-tooltip` 全局销毁逻辑
* `Column` 增加 `tooltip: boolean | ((item: Object) => string)` prop
* `Column` 的 Popover 浮层默认定位修正为 `top`
* Table 默认样式增加固定 1 行样式

Closes #918.