### PR TITLE
fix: make scrollIntoView immune to transform

### DIFF
--- a/packages/veui/src/components/Overlay.vue
+++ b/packages/veui/src/components/Overlay.vue
@@ -101,6 +101,7 @@ export default {
     realOpen (val) {
       if (val) {
         this.leaving = false
+        this.handleAfterOpen()
       }
 
       if (this.inline) {
@@ -354,13 +355,15 @@ export default {
       this.popper.destroy()
       this.popper = null
     },
-    handleAfterEnter () {
-      this.$emit('afteropen')
+    handleAfterOpen () {
+      this.$nextTick(() => {
+        this.$emit('afteropen')
+      })
     },
     handleLeave () {
       this.leaving = true
     },
-    handleAfterLeave () {
+    handleAfterClose () {
       this.leaving = false
       this.$emit('afterclose')
     }
@@ -391,9 +394,8 @@ export default {
         <transition
           name={this.$c('overlay')}
           appear
-          onAfterEnter={this.handleAfterEnter}
           onLeave={this.handleLeave}
-          onAfterLeave={this.handleAfterLeave}
+          onAfterLeave={this.handleAfterClose}
         >
           {box}
         </transition>

--- a/packages/veui/src/components/Overlay.vue
+++ b/packages/veui/src/components/Overlay.vue
@@ -201,7 +201,6 @@ export default {
         this.overlayNode.appendTo(this.findParentOverlayId(), this.priority)
       }
     },
-
     initPortal () {
       let { box } = this.$refs
 
@@ -218,7 +217,6 @@ export default {
 
       this.updateLocator()
     },
-
     disposePortal () {
       this.destroyLocator()
 
@@ -234,7 +232,6 @@ export default {
         this.removePortal = null
       }
     },
-
     findParentOverlayId () {
       let cur = this.$parent
       while (cur) {
@@ -244,7 +241,6 @@ export default {
         cur = cur.$parent
       }
     },
-
     updateWidth () {
       if (!this.matchWidth) {
         this.minWidth = null
@@ -259,7 +255,6 @@ export default {
 
       this.minWidth = `${targetEl.offsetWidth}px`
     },
-
     updateLocator () {
       if (!this.realOpen) {
         return
@@ -298,13 +293,11 @@ export default {
         })
       }
     },
-
     relocate () {
       if (this.popper) {
         this.popper.scheduleUpdate()
       }
     },
-
     updateTargetElement () {
       if (this.target) {
         this.targetEl = getNodes(this.target, this.$vnode.context)[0]
@@ -312,7 +305,6 @@ export default {
         this.targetEl = null
       }
     },
-
     focus () {
       if (this.overlayNode) {
         this.overlayNode.toTop()
@@ -321,7 +313,6 @@ export default {
         this.focusContext.toTop()
       }
     },
-
     initFocus () {
       if (!this.autofocus) {
         return
@@ -334,7 +325,6 @@ export default {
         }
       })
     },
-
     createFocusContext () {
       if (!this.focusContext) {
         this.focusContext = focusManager.createContext(this.$refs.box, {
@@ -345,27 +335,34 @@ export default {
         this.lastSource = document.activeElement
       }
     },
-
     destroyFocus () {
       if (this.focusContext) {
         focusManager.remove(this.focusContext)
         this.focusContext = null
       }
     },
-
     toggleLocator (enable) {
       if (this.inline || !this.popper) {
         return
       }
       this.popper[enable ? 'enableEventListeners' : 'disableEventListeners']()
     },
-
     destroyLocator () {
       if (this.inline || !this.popper) {
         return
       }
       this.popper.destroy()
       this.popper = null
+    },
+    handleAfterEnter () {
+      this.$emit('afteropen')
+    },
+    handleLeave () {
+      this.leaving = true
+    },
+    handleAfterLeave () {
+      this.leaving = false
+      this.$emit('afterclose')
     }
   },
   render () {
@@ -394,16 +391,9 @@ export default {
         <transition
           name={this.$c('overlay')}
           appear
-          onAfterEnter={() => {
-            this.$emit('afteropen')
-          }}
-          onLeave={() => {
-            this.leaving = true
-          }}
-          onAfterLeave={() => {
-            this.leaving = false
-            this.$emit('afterclose')
-          }}
+          onAfterEnter={this.handleAfterEnter}
+          onLeave={this.handleLeave}
+          onAfterLeave={this.handleAfterLeave}
         >
           {box}
         </transition>

--- a/packages/veui/src/directives/drag/SortHandler.js
+++ b/packages/veui/src/directives/drag/SortHandler.js
@@ -257,8 +257,10 @@ function getHotRects (elements, container, axis, target, dragElementIndex) {
 
   // `getStableBoundingClientRect` is used here as it will ignore interpolated
   // values during transition
-  const elementRects = [...elements].map(el => getStableBoundingClientRect(el))
-  const currentRect = getStableBoundingClientRect(target)
+  const elementRects = [...elements].map(el =>
+    getStableBoundingClientRect(el, container)
+  )
+  const currentRect = getStableBoundingClientRect(target, container)
 
   // 找出换行的 index，切成行，按行处理热区
   const breakIndices = elementRects

--- a/packages/veui/src/utils/dom.js
+++ b/packages/veui/src/utils/dom.js
@@ -165,7 +165,7 @@ export function isOverflow (elem) {
   )
 }
 
-function getScrollportOffset (elem) {
+function getScrollContainerOffset (elem) {
   let container = getScrollParent(elem)
 
   if (!container) {
@@ -213,7 +213,7 @@ export function scrollIntoView (elem, forceToTop) {
     return
   }
 
-  let { top } = getScrollportOffset(elem)
+  let { top } = getScrollContainerOffset(elem)
 
   if (forceToTop) {
     container.scrollTop = top

--- a/packages/veui/test/unit/specs/components/Calendar.spec.js
+++ b/packages/veui/test/unit/specs/components/Calendar.spec.js
@@ -7,7 +7,8 @@ describe('components/Calendar', () => {
     const wrapper = mount(Calendar, {
       propsData: {
         selected: null
-      }
+      },
+      attachToDocument: true
     })
 
     wrapper.vm.$on('select', val => {
@@ -24,7 +25,8 @@ describe('components/Calendar', () => {
     const wrapper = mount(Calendar, {
       propsData: {
         type: 'year'
-      }
+      },
+      attachToDocument: true
     })
 
     wrapper.vm.$on('select', val => {
@@ -41,7 +43,8 @@ describe('components/Calendar', () => {
     const wrapper = mount(Calendar, {
       propsData: {
         type: 'month'
-      }
+      },
+      attachToDocument: true
     })
 
     wrapper.vm.$on('select', val => {
@@ -55,17 +58,22 @@ describe('components/Calendar', () => {
   })
 
   it('should select date multiple correctly.', async () => {
-    const wrapper = mount({
-      components: {
-        'veui-calendar': Calendar
+    const wrapper = mount(
+      {
+        components: {
+          'veui-calendar': Calendar
+        },
+        data () {
+          return {
+            selected: null
+          }
+        },
+        template: '<veui-calendar v-model="selected" multiple />'
       },
-      data () {
-        return {
-          selected: null
-        }
-      },
-      template: '<veui-calendar v-model="selected" multiple />'
-    })
+      {
+        attachToDocument: true
+      }
+    )
 
     const days = wrapper.findAll('.veui-calendar-day button')
     const { vm } = wrapper
@@ -84,17 +92,22 @@ describe('components/Calendar', () => {
   })
 
   it('should select date range correctly.', async () => {
-    const wrapper = mount({
-      components: {
-        'veui-calendar': Calendar
+    const wrapper = mount(
+      {
+        components: {
+          'veui-calendar': Calendar
+        },
+        data () {
+          return {
+            selected: null
+          }
+        },
+        template: '<veui-calendar v-model="selected" range />'
       },
-      data () {
-        return {
-          selected: null
-        }
-      },
-      template: '<veui-calendar v-model="selected" range />'
-    })
+      {
+        attachToDocument: true
+      }
+    )
 
     const days = wrapper.findAll('.veui-calendar-day button')
     days.at(0).trigger('click')
@@ -115,7 +128,8 @@ describe('components/Calendar', () => {
     const wrapper = mount(Calendar, {
       propsData: {
         panel: 3
-      }
+      },
+      attachToDocument: true
     })
 
     const panels = wrapper.findAll('.veui-calendar-panel')
@@ -128,7 +142,8 @@ describe('components/Calendar', () => {
     const wrapper = mount(Calendar, {
       propsData: {
         today: new Date(2019, 10, 1)
-      }
+      },
+      attachToDocument: true
     })
 
     expect(wrapper.vm.getDefaultDate() - new Date(2019, 10, 1)).to.equal(0)
@@ -143,7 +158,8 @@ describe('components/Calendar', () => {
     const wrapper = mount(Calendar, {
       propsData: {
         weekStart: 6
-      }
+      },
+      attachToDocument: true
     })
 
     expect(wrapper.vm.getDayNames()[0] === wrapper.vm.daysShort[5]).to.equal(
@@ -157,17 +173,21 @@ describe('components/Calendar', () => {
     const wrapper = mount(Calendar, {
       propsData: {
         fillMonth: false
-      }
+      },
+      attachToDocument: true
     })
 
     expect(wrapper.find('.veui-calendar-aux button').exists()).to.equal(false)
+
+    wrapper.destroy()
   })
 
   it('should support customized date-class correctly.', () => {
     const wrapper = mount(Calendar, {
       propsData: {
         dateClass: 'date-class'
-      }
+      },
+      attachToDocument: true
     })
 
     const cells = wrapper.findAll('tbody td')
@@ -184,7 +204,8 @@ describe('components/Calendar', () => {
         disabledDate: date => {
           return date.getDay() === 6
         }
-      }
+      },
+      attachToDocument: true
     })
 
     const index = Math.floor(Math.random() * 2) + 1
@@ -202,7 +223,8 @@ describe('components/Calendar', () => {
     const wrapper = mount(Calendar, {
       propsData: {
         disabled: true
-      }
+      },
+      attachToDocument: true
     })
 
     expectDisabled(wrapper)
@@ -217,7 +239,8 @@ describe('components/Calendar', () => {
     let wrapper = mount(Calendar, {
       propsData: {
         readonly: true
-      }
+      },
+      attachToDocument: true
     })
 
     expect(wrapper.attributes('aria-readonly')).to.equal('true')
@@ -232,7 +255,8 @@ describe('components/Calendar', () => {
     const wrapper = mount(Calendar, {
       propsData: {
         selected: new Date(1987, 6, 11)
-      }
+      },
+      attachToDocument: true
     })
 
     const { vm } = wrapper
@@ -247,20 +271,26 @@ describe('components/Calendar', () => {
     const wrapper = mount(Calendar, {
       slots: {
         before: '<div class="calendar-before">Before</div>'
-      }
+      },
+      attachToDocument: true
     })
 
     expect(wrapper.find('.calendar-before').exists()).to.equal(true)
+
+    wrapper.destroy()
   })
 
   it('should support after solt correctly.', () => {
     const wrapper = mount(Calendar, {
       slots: {
         after: '<div class="calendar-after">After</div>'
-      }
+      },
+      attachToDocument: true
     })
 
     expect(wrapper.find('.calendar-after').exists()).to.equal(true)
+
+    wrapper.destroy()
   })
 
   it('should support date slot correctly.', () => {
@@ -268,7 +298,8 @@ describe('components/Calendar', () => {
       scopedSlots: {
         date:
           '<template slot-scope="{year, month,date}">{{ year }}-{{ month + 1 }}-{{ date }}</template>'
-      }
+      },
+      attachToDocument: true
     })
 
     const date = new Date()
@@ -280,51 +311,65 @@ describe('components/Calendar', () => {
         .text()
         .trim()
     ).to.equal(target)
+
+    wrapper.destroy()
   })
 
   it('should handle select.', async () => {
-    const wrapper = mount({
-      components: {
-        'veui-calendar': Calendar
-      },
-      data () {
-        return {
-          selected: null
+    const wrapper = mount(
+      {
+        components: {
+          'veui-calendar': Calendar
+        },
+        data () {
+          return {
+            selected: null
+          }
+        },
+        template: '<veui-calendar @select="handleSelect" />',
+        methods: {
+          handleSelect (selected) {
+            this.selected = selected
+          }
         }
       },
-      template: '<veui-calendar @select="handleSelect" />',
-      methods: {
-        handleSelect (selected) {
-          this.selected = selected
-        }
+      {
+        attachToDocument: true
       }
-    })
+    )
 
     wrapper.find('.veui-calendar-day button').trigger('click')
     const { vm } = wrapper
     await vm.$nextTick()
     expect(vm.selected).to.be.an.instanceof(Date)
+
+    wrapper.destroy()
   })
 
   it('should handle select correctly when set range.', async () => {
-    const wrapper = mount({
-      components: {
-        'veui-calendar': Calendar
-      },
-      data () {
-        return {
-          selected: null,
-          times: 0
+    const wrapper = mount(
+      {
+        components: {
+          'veui-calendar': Calendar
+        },
+        data () {
+          return {
+            selected: null,
+            times: 0
+          }
+        },
+        template: '<veui-calendar range @select="handleSelect" />',
+        methods: {
+          handleSelect (selected) {
+            this.selected = selected
+            this.times += 1
+          }
         }
       },
-      template: '<veui-calendar range @select="handleSelect" />',
-      methods: {
-        handleSelect (selected) {
-          this.selected = selected
-          this.times += 1
-        }
+      {
+        attachToDocument: true
       }
-    })
+    )
 
     const days = wrapper.findAll('.veui-calendar-day button')
 
@@ -341,25 +386,30 @@ describe('components/Calendar', () => {
   })
 
   it('should handle select correctly when set multiple.', async () => {
-    const wrapper = mount({
-      components: {
-        'veui-calendar': Calendar
-      },
-      data () {
-        return {
-          selected: null,
-          times: 0
+    const wrapper = mount(
+      {
+        components: {
+          'veui-calendar': Calendar
+        },
+        data () {
+          return {
+            selected: null,
+            times: 0
+          }
+        },
+        template:
+          '<veui-calendar v-model="selected" multiple @select="handleSelect" />',
+        methods: {
+          handleSelect (selected) {
+            this.selected = selected
+            this.times += 1
+          }
         }
       },
-      template:
-        '<veui-calendar v-model="selected" multiple @select="handleSelect" />',
-      methods: {
-        handleSelect (selected) {
-          this.selected = selected
-          this.times += 1
-        }
+      {
+        attachToDocument: true
       }
-    })
+    )
 
     const days = wrapper.findAll('.veui-calendar-day button')
 
@@ -378,24 +428,29 @@ describe('components/Calendar', () => {
   })
 
   it('should handle selectstart.', async () => {
-    const wrapper = mount({
-      components: {
-        'veui-calendar': Calendar
-      },
-      data () {
-        return {
-          start: null,
-          times: 0
+    const wrapper = mount(
+      {
+        components: {
+          'veui-calendar': Calendar
+        },
+        data () {
+          return {
+            start: null,
+            times: 0
+          }
+        },
+        template: '<veui-calendar range @selectstart="handleSelectStart" />',
+        methods: {
+          handleSelectStart (start) {
+            this.start = start
+            this.times += 1
+          }
         }
       },
-      template: '<veui-calendar range @selectstart="handleSelectStart" />',
-      methods: {
-        handleSelectStart (start) {
-          this.start = start
-          this.times += 1
-        }
+      {
+        attachToDocument: true
       }
-    })
+    )
 
     const days = wrapper.findAll('.veui-calendar-day button')
     days.at(0).trigger('click')
@@ -409,23 +464,28 @@ describe('components/Calendar', () => {
   })
 
   it('should handle selectprogress when multiple is false.', async () => {
-    const wrapper = mount({
-      components: {
-        'veui-calendar': Calendar
-      },
-      data () {
-        return {
-          selectProgress: null
+    const wrapper = mount(
+      {
+        components: {
+          'veui-calendar': Calendar
+        },
+        data () {
+          return {
+            selectProgress: null
+          }
+        },
+        template:
+          '<veui-calendar range @selectprogress="handleSelectProgress" />',
+        methods: {
+          handleSelectProgress (selectProgress) {
+            this.selectProgress = selectProgress
+          }
         }
       },
-      template:
-        '<veui-calendar range @selectprogress="handleSelectProgress" />',
-      methods: {
-        handleSelectProgress (selectProgress) {
-          this.selectProgress = selectProgress
-        }
+      {
+        attachToDocument: true
       }
-    })
+    )
 
     const days = wrapper.findAll('.veui-calendar-day button')
     days.at(0).trigger('click')
@@ -441,24 +501,29 @@ describe('components/Calendar', () => {
   })
 
   it('should handle selectprogress when multiple is true.', async () => {
-    const wrapper = mount({
-      components: {
-        'veui-calendar': Calendar
-      },
-      data () {
-        return {
-          selected: null,
-          selectProgress: null
+    const wrapper = mount(
+      {
+        components: {
+          'veui-calendar': Calendar
+        },
+        data () {
+          return {
+            selected: null,
+            selectProgress: null
+          }
+        },
+        template:
+          '<veui-calendar multiple range v-model="selected" @selectprogress="handleSelectProgress" />',
+        methods: {
+          handleSelectProgress (selectProgress) {
+            this.selectProgress = selectProgress
+          }
         }
       },
-      template:
-        '<veui-calendar multiple range v-model="selected" @selectprogress="handleSelectProgress" />',
-      methods: {
-        handleSelectProgress (selectProgress) {
-          this.selectProgress = selectProgress
-        }
+      {
+        attachToDocument: true
       }
-    })
+    )
 
     const days = wrapper.findAll('.veui-calendar-day button')
     days.at(0).trigger('click')
@@ -481,24 +546,29 @@ describe('components/Calendar', () => {
   })
 
   it('should handle viewchange.', async () => {
-    const wrapper = mount({
-      components: {
-        'veui-calendar': Calendar
-      },
-      data () {
-        return {
-          year: null,
-          month: null
+    const wrapper = mount(
+      {
+        components: {
+          'veui-calendar': Calendar
+        },
+        data () {
+          return {
+            year: null,
+            month: null
+          }
+        },
+        template: '<veui-calendar @viewchange="handleViewChange" />',
+        methods: {
+          handleViewChange ({ year, month }) {
+            this.year = year
+            this.month = month
+          }
         }
       },
-      template: '<veui-calendar @viewchange="handleViewChange" />',
-      methods: {
-        handleViewChange ({ year, month }) {
-          this.year = year
-          this.month = month
-        }
+      {
+        attachToDocument: true
       }
-    })
+    )
 
     const date = new Date()
     let year = date.getFullYear()
@@ -525,7 +595,8 @@ describe('components/Calendar', () => {
         range: true,
         fillMonth: false,
         selected: [new Date(2019, 9, 1), new Date(2019, 11, 31)]
-      }
+      },
+      attachToDocument: true
     })
     const { vm } = wrapper
     let [p1, p2] = vm.panelData
@@ -550,7 +621,9 @@ describe('components/Calendar', () => {
   })
 
   it('should handle selected prop correctly on using as a uncontrolled component.', async () => {
-    const wrapper = mount(Calendar)
+    const wrapper = mount(Calendar, {
+      attachToDocument: true
+    })
     const { vm } = wrapper
     const today = wrapper.find('.veui-calendar-today button')
     today.trigger('click')
@@ -565,7 +638,8 @@ describe('components/Calendar', () => {
     const wrapper = mount(Calendar, {
       propsData: {
         type: 'year'
-      }
+      },
+      attachToDocument: true
     })
     const { vm } = wrapper
     function isVisible (container, target) {
@@ -593,17 +667,22 @@ describe('components/Calendar', () => {
   })
 
   it('should update panel date correctly on selecting next month.', async () => {
-    const wrapper = mount({
-      components: {
-        'veui-calendar': Calendar
+    const wrapper = mount(
+      {
+        components: {
+          'veui-calendar': Calendar
+        },
+        data () {
+          return {
+            selected: [new Date(2020, 6, 15)]
+          }
+        },
+        template: '<veui-calendar ref="calendar" multiple v-model="selected"/>'
       },
-      data () {
-        return {
-          selected: [new Date(2020, 6, 15)]
-        }
-      },
-      template: '<veui-calendar ref="calendar" multiple v-model="selected"/>'
-    })
+      {
+        attachToDocument: true
+      }
+    )
     const { vm } = wrapper
     let next = wrapper.find('.veui-calendar-day + .veui-calendar-aux button')
     next.trigger('click')


### PR DESCRIPTION
* bring the timing of the `afteropen` event for `Overlay` forward to immediately after its content is rendered to DOM
* add `getScrollContainerOffset` in `utils/dom` to calculate the relative position of an element against its scroll container
* make `scrollIntoView` and `scrollToAlign` insensitive to transforms
* fix test cases for `Calendar`

Closes #939