### PR TITLE
refactor: keep button transition when toggling disabled

### DIFF
--- a/packages/veui-theme-dls/components/button-group.less
+++ b/packages/veui-theme-dls/components/button-group.less
@@ -23,13 +23,16 @@
       .border-right-radius(inherit);
     }
 
-    &:hover,
-    &[data-focus-visible-added] {
+    &:hover {
       z-index: 2;
     }
 
     &.@{veui-prefix}-disabled {
       z-index: 0;
+    }
+
+    &[data-focus-visible-added] {
+      z-index: 2;
     }
   }
 

--- a/packages/veui-theme-dls/components/button.less
+++ b/packages/veui-theme-dls/components/button.less
@@ -3,15 +3,30 @@
 .@{veui-prefix}-button {
   position: relative;
   display: inline-flex;
-  justify-content: center;
-  align-items: center;
   user-select: none;
-  line-height: 2;
-  white-space: nowrap;
-  cursor: pointer;
   border: 1px solid;
+  line-height: 2;
+  cursor: pointer;
   .veui-button-transition();
-  .veui-stub();
+
+  &-native {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100%;
+    border: none;
+    white-space: nowrap;
+    background: none;
+    color: inherit;
+    font: inherit;
+    border-radius: inherit;
+    cursor: inherit;
+    .veui-stub();
+
+    &:disabled {
+      pointer-events: none;
+    }
+  }
 
   .make-metrics(@size) {
     @height: ~"dls-button-height-@{size}";
@@ -19,11 +34,14 @@
     @radius: ~"dls-button-border-radius-@{size}";
     @font-size: ~"dls-button-font-size-@{size}";
     height: @@height;
-    .padding(0, @@padding);
     border-radius: @@radius;
     font-size: @@font-size;
 
-    &[ui~="square"] {
+    .@{veui-prefix}-button-native {
+      .padding(0, @@padding);
+    }
+
+    &[ui~="square"] .@{veui-prefix}-button-native {
       width: @@height;
       padding: 0;
     }
@@ -71,7 +89,6 @@
   }
 
   &-loading {
-    pointer-events: none;
     cursor: default;
   }
 
@@ -85,7 +102,8 @@
       background-color: @dls-button-background-color-normal-hover;
     }
 
-    &:active {
+    &:active,
+    &.@{veui-prefix}-active {
       border-color: @dls-button-border-color-normal-active;
       background-color: @dls-button-background-color-normal-active;
     }
@@ -100,7 +118,7 @@
       color: @dls-button-font-color-normal-disabled;
     }
 
-    &&-loading {
+    &.@{veui-prefix}-button-loading {
       border-color: @dls-button-border-color-normal-active;
       background-color: @dls-button-background-color-normal-active;
     }
@@ -121,7 +139,8 @@
       background-color: @dls-button-background-color-basic-focus;
     }
 
-    &:active {
+    &:active,
+    &.@{veui-prefix}-active {
       border-color: @dls-button-border-color-basic-active;
       background-color: @dls-button-background-color-basic-active;
     }
@@ -152,7 +171,8 @@
       background-color: @dls-button-background-color-strong-focus;
     }
 
-    &:active {
+    &:active,
+    &.@{veui-prefix}-active {
       border-color: @dls-button-border-color-strong-active;
       background-color: @dls-button-background-color-strong-active;
     }
@@ -183,7 +203,8 @@
       background-color: @dls-button-background-color-primary-focus;
     }
 
-    &:active {
+    &:active,
+    &.@{veui-prefix}-active {
       border-color: @dls-button-border-color-primary-active;
       background-color: @dls-button-background-color-primary-active;
     }
@@ -214,7 +235,8 @@
       background-color: @dls-button-background-color-translucent-focus;
     }
 
-    &:active {
+    &:active,
+    &.@{veui-prefix}-active {
       border-color: @dls-button-border-color-translucent-active;
       background-color: @dls-button-background-color-translucent-active;
     }
@@ -234,15 +256,19 @@
   &[ui~="text"],
   &[ui~="icon"] {
     border: none;
-    padding: 0;
     height: auto;
     line-height: inherit;
     background-color: @dls-button-background-color-text;
     color: @dls-button-font-color-text;
 
+    .@{veui-prefix}-button-native {
+      padding: 0;
+    }
+
     &::after {
       content: "";
-      .absolute(_, -@dls-button-padding-text);
+      .absolute(50%, -@dls-button-padding-text, _);
+      transform: translateY(-50%);
       height: calc(1em + @dls-button-padding-text * 2);
       border: 1px solid transparent;
       border-radius: inherit;
@@ -269,7 +295,8 @@
       }
     }
 
-    &:active {
+    &:active,
+    &.@{veui-prefix}-active {
       background-color: @dls-button-background-color-text-active;
       color: @dls-button-font-color-text-active;
     }
@@ -290,7 +317,8 @@
         color: @dls-button-font-color-text-strong-focus;
       }
 
-      &:active {
+      &:active,
+      &.@{veui-prefix}-active {
         color: @dls-button-font-color-text-strong-active;
       }
 
@@ -310,7 +338,8 @@
         color: @dls-button-font-color-text-aux-focus;
       }
 
-      &:active {
+      &:active,
+      &.@{veui-prefix}-active {
         color: @dls-button-font-color-text-aux-active;
       }
 
@@ -322,7 +351,6 @@
 
   &[ui~="icon"] {
     &::after {
-      .absolute(auto);
       .size(calc(@dls-icon-size-normal + @dls-button-padding-text * 2));
     }
   }

--- a/packages/veui/demo/cases/Button.vue
+++ b/packages/veui/demo/cases/Button.vue
@@ -7,28 +7,38 @@
     <veui-button
       ui="xs"
       @click="handleClick"
+      @mouseenter="handleEnter"
     >保存</veui-button>
     <veui-button
       ui="s"
       @click="handleClick"
+      @mouseenter="handleEnter"
     >保存</veui-button>
-    <veui-button @click="handleClick">保存</veui-button>
+    <veui-button
+      @click="handleClick"
+      @mouseenter="handleEnter"
+    >保存</veui-button>
     <veui-button
       ui="l"
       @click="handleClick"
+      @mouseenter="handleEnter"
     >保存</veui-button>
     <veui-button
       ui="xl"
       @click="handleClick"
+      @mouseenter="handleEnter"
     >保存</veui-button>
     <veui-button
       v-tooltip="'点击保存'"
       disabled
       @click="handleClick"
+      @mouseenter="handleEnter"
     >保存</veui-button>
     <veui-button
+      v-tooltip="'正在保存'"
       loading
       @click="handleClick"
+      @mouseenter="handleEnter"
     >保存</veui-button>
   </section>
   <section>
@@ -516,6 +526,12 @@
     >编辑</veui-button>
     <veui-button @click="handleClick">保存</veui-button>
   </section>
+  <section>
+    <h4>表单内</h4>
+    <form @submit.prevent="handleSubmit">
+      <veui-button type="submit">Submit</veui-button>
+    </form>
+  </section>
 </article>
 </template>
 
@@ -545,11 +561,17 @@ export default {
   },
   methods: {
     handleClick (e) {
-      bus.$emit('log', e.currentTarget.getAttribute('ui'))
+      bus.$emit('log', ['click', e.currentTarget.getAttribute('ui')])
+    },
+    handleEnter (e) {
+      bus.$emit('log', ['mouseenter', e.currentTarget.getAttribute('ui')])
     },
     handleClickAndToggle (e) {
       this.handleClick(e)
       this.text = !this.text
+    },
+    handleSubmit () {
+      bus.$emit('log', 'submit')
     }
   }
 }

--- a/packages/veui/karma.conf.js
+++ b/packages/veui/karma.conf.js
@@ -2,9 +2,9 @@ const webpackConfig = require('@vue/cli-service/webpack.config.js')
 const devServer = require('./build/dev-server')
 
 let files = ['test/global.js']
-if (process.env.KARMA_TEST_FILES_ONLY) {
+if (process.env.TEST_FILES) {
   files = files.concat(
-    process.env.KARMA_TEST_FILES_ONLY.split(',')
+    process.env.TEST_FILES.split(',')
       .map(v => v.trim())
       .map(name => `test/unit/**/${name}.spec.js`)
   )
@@ -13,7 +13,7 @@ if (process.env.KARMA_TEST_FILES_ONLY) {
 }
 
 let browsers = []
-if (process.env.KARMA_TEST_WITH_UI) {
+if (process.env.TEST_UI) {
   browsers.push('Chrome')
 } else {
   browsers.push('ChromeHeadless')

--- a/packages/veui/src/components/Button.vue
+++ b/packages/veui/src/components/Button.vue
@@ -6,37 +6,56 @@ import ui from '../mixins/ui'
 import focusable from '../mixins/focusable'
 import '../common/global'
 
+const BUTTON_ATTRS = new Set([
+  'form',
+  'formaction',
+  'formenctype',
+  'formmethod',
+  'formnovalidate',
+  'formtarget',
+  'name',
+  'value'
+])
+
 export default {
   name: 'veui-button',
   components: {
     'veui-icon': Icon
   },
   mixins: [prefix, ui, focusable],
+  inheritAttrs: false,
   props: {
     disabled: Boolean,
-    name: String,
     type: {
       type: String,
       default: 'button'
     },
-    value: String,
     loading: Boolean
+  },
+  data () {
+    return {
+      active: false
+    }
   },
   computed: {
     activatable () {
       return !this.disabled && !this.loading
     },
     attrs () {
-      let { loading, disabled, type, ...props } = this.$props
+      const button = {}
+      const root = {}
+
+      Object.keys(this.$attrs).forEach(key => {
+        if (BUTTON_ATTRS.has(key)) {
+          button[key] = this.$attrs[key]
+        } else {
+          root[key] = this.$attrs[key]
+        }
+      })
 
       return {
-        tabindex: this.activatable ? null : '0',
-        role: this.activatable ? null : 'button',
-        ...props,
-        // 渲染成 div 的时候，type="button" 会导致在 Safari 上样式出现问题
-        type: this.activatable ? type : null,
-        'aria-disabled': this.disabled ? 'true' : null,
-        ui: this.realUi
+        button,
+        root
       }
     },
     listeners () {
@@ -51,40 +70,91 @@ export default {
   methods: {
     focus () {
       this.$el.focus()
+    },
+    handleKeydown (e) {
+      if (!this.activatable) {
+        return
+      }
+
+      if (e.key === ' ') {
+        this.active = true
+      }
+    },
+    handleKeyup (e) {
+      if (!this.activatable) {
+        return
+      }
+
+      if (this.active && e.key === ' ') {
+        this.$refs.button.click()
+        this.active = false
+      }
+    },
+    handleKeypress (e) {
+      if (this.activatable && e.key === 'Enter') {
+        this.$refs.button.click()
+      } else if (e.key === ' ') {
+        e.preventDefault() // prevent page scroll
+      }
+    },
+    handleBlur () {
+      this.active = false
     }
   },
   render () {
-    let Tag = this.activatable ? 'button' : 'div'
     return (
-      <Tag
+      <div
+        role="button"
+        tabindex="0"
         class={{
           [this.$c('button')]: true,
           [this.$c('button-loading')]: this.loading,
-          [this.$c('disabled')]: this.disabled
+          [this.$c('disabled')]: this.disabled,
+          [this.$c('active')]: this.active
         }}
+        aria-disabled={this.disabled ? 'true' : null}
+        ui={this.realUi}
+        onKeydown={this.handleKeydown}
+        onKeyup={this.handleKeyup}
+        onKeypress={this.handleKeypress}
+        onBlur={this.handleBlur}
         {...{
-          attrs: this.attrs,
+          attrs: this.attrs.root,
           on: this.listeners
         }}
       >
-        {this.loading ? (
-          this.icons.loading ? (
-            <Icon
-              class={this.$c('button-loading-icon')}
-              name={this.icons.loading}
-              spin
-            />
-          ) : (
-            <Loading class={this.$c('button-loading-icon')} loading />
-          )
-        ) : null}
-        {(this.$scopedSlots.default
-          ? this.$scopedSlots.default()
-          : this.$slots.default || []
-        ).map(vnode =>
-          !vnode.tag && (vnode.text || '').trim() ? <span>{vnode}</span> : vnode
-        )}
-      </Tag>
+        <button
+          ref="button"
+          class={this.$c('button-native')}
+          tabindex="-1"
+          role="presentation"
+          disabled={!this.activatable}
+          type={this.type}
+          {...{ attrs: this.attrs.button }}
+        >
+          {this.loading ? (
+            this.icons.loading ? (
+              <Icon
+                class={this.$c('button-loading-icon')}
+                name={this.icons.loading}
+                spin
+              />
+            ) : (
+              <Loading class={this.$c('button-loading-icon')} loading />
+            )
+          ) : null}
+          {(this.$scopedSlots.default
+            ? this.$scopedSlots.default()
+            : this.$slots.default || []
+          ).map(vnode =>
+            !vnode.tag && (vnode.text || '').trim() ? (
+              <span>{vnode}</span>
+            ) : (
+              vnode
+            )
+          )}
+        </button>
+      </div>
     )
   }
 }

--- a/packages/veui/test/unit/specs/components/AlertBox.spec.js
+++ b/packages/veui/test/unit/specs/components/AlertBox.spec.js
@@ -151,7 +151,7 @@ describe('components/AlertBox', function () {
     })
 
     let { vm } = wrapper
-    let btn = wrapper.find('.veui-dialog-content-foot button')
+    let btn = wrapper.find('.veui-dialog-content-foot .veui-button')
     expect(btn.classes('veui-disabled')).to.equal(false)
     expect(btn.classes('veui-button-loading')).to.equal(false)
 
@@ -185,7 +185,7 @@ describe('components/AlertBox', function () {
 
     await wrapper.vm.$nextTick()
 
-    let btn = wrapper.find('.veui-dialog-content-foot button')
+    let btn = wrapper.find('.veui-dialog-content-foot .veui-button')
     expect(btn.text()).to.equal('👍')
 
     wrapper.destroy()

--- a/packages/veui/test/unit/specs/components/Button.spec.js
+++ b/packages/veui/test/unit/specs/components/Button.spec.js
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils'
 import Button from '@/components/Button'
+import ui from '@/managers/ui'
 
 describe('components/Button', () => {
   it('should create a button component with `primary` ui', () => {
@@ -241,5 +242,21 @@ describe('components/Button', () => {
     wrapper.find('.veui-button').trigger('click')
     await wrapper.vm.$nextTick()
     expect(wrapper.vm.hasClick).to.equal(true)
+  })
+
+  it('should support icon config', () => {
+    ui.set('button.icons', {
+      loading: 'loading'
+    })
+
+    const wrapper = mount(Button, {
+      propsData: {
+        loading: true
+      }
+    })
+
+    expect(wrapper.find('.veui-icon').exists()).to.equal(true)
+
+    ui.set('button.icons', {})
   })
 })

--- a/packages/veui/test/unit/specs/components/ConfirmBox.spec.js
+++ b/packages/veui/test/unit/specs/components/ConfirmBox.spec.js
@@ -150,7 +150,7 @@ describe('components/ConfirmBox', function () {
     })
 
     let { vm } = wrapper
-    let btn = wrapper.find('.veui-dialog-content-foot button:first-child')
+    let btn = wrapper.find('.veui-dialog-content-foot .veui-button:first-child')
     expect(btn.classes('veui-disabled')).to.equal(false)
     expect(btn.classes('veui-button-loading')).to.equal(false)
 
@@ -184,7 +184,7 @@ describe('components/ConfirmBox', function () {
 
     await wrapper.vm.$nextTick()
 
-    let btns = wrapper.findAll('.veui-dialog-content-foot button')
+    let btns = wrapper.findAll('.veui-dialog-content-foot .veui-button')
     expect(btns.at(0).text()).to.equal('👍')
     expect(btns.at(1).text()).to.equal('👎')
 

--- a/packages/veui/test/unit/specs/components/Dialog.spec.js
+++ b/packages/veui/test/unit/specs/components/Dialog.spec.js
@@ -19,7 +19,7 @@ describe('components/Dialog', () => {
     let { vm } = wrapper
 
     wrapper
-      .find('.veui-dialog-content-foot button:first-child')
+      .find('.veui-dialog-content-foot .veui-button:first-child')
       .trigger('click')
 
     await vm.$nextTick()
@@ -28,7 +28,9 @@ describe('components/Dialog', () => {
     vm.open = true
 
     await vm.$nextTick()
-    wrapper.find('.veui-dialog-content-foot button:last-child').trigger('click')
+    wrapper
+      .find('.veui-dialog-content-foot .veui-button:last-child')
+      .trigger('click')
 
     await vm.$nextTick()
     expect(vm.open).to.equal(false)
@@ -77,7 +79,9 @@ describe('components/Dialog', () => {
     let { vm } = wrapper
 
     await vm.$nextTick()
-    wrapper.find('.veui-dialog-content-foot button:last-child').trigger('click')
+    wrapper
+      .find('.veui-dialog-content-foot .veui-button:last-child')
+      .trigger('click')
 
     await vm.$nextTick()
     expect(vm.open).to.equal(false)
@@ -86,7 +90,7 @@ describe('components/Dialog', () => {
 
     await vm.$nextTick()
     wrapper
-      .find('.veui-dialog-content-foot button:first-child')
+      .find('.veui-dialog-content-foot .veui-button:first-child')
       .trigger('click')
 
     await wait(100)
@@ -177,7 +181,7 @@ describe('components/Dialog', () => {
     await vm.$nextTick()
 
     wrapper
-      .find('.veui-dialog-content-foot button:first-child')
+      .find('.veui-dialog-content-foot .veui-button:first-child')
       .trigger('click')
 
     await vm.$nextTick()
@@ -186,7 +190,9 @@ describe('components/Dialog', () => {
 
     vm.open = true
     await vm.$nextTick()
-    wrapper.find('.veui-dialog-content-foot button:last-child').trigger('click')
+    wrapper
+      .find('.veui-dialog-content-foot .veui-button:last-child')
+      .trigger('click')
 
     await vm.$nextTick()
 
@@ -218,12 +224,14 @@ describe('components/Dialog', () => {
     })
 
     wrapper
-      .find('.veui-dialog-content-foot button:first-child')
+      .find('.veui-dialog-content-foot .veui-button:first-child')
       .trigger('click')
     await wrapper.vm.$nextTick()
     expect(wrapper.find('.veui-dialog-box').isVisible()).to.equal(true)
 
-    wrapper.find('.veui-dialog-content-foot button:last-child').trigger('click')
+    wrapper
+      .find('.veui-dialog-content-foot .veui-button:last-child')
+      .trigger('click')
     await wrapper.vm.$nextTick()
     expect(wrapper.find('.veui-dialog-box').isVisible()).to.equal(true)
 
@@ -245,7 +253,7 @@ describe('components/Dialog', () => {
     })
 
     let { vm } = wrapper
-    let btn = wrapper.find('.veui-dialog-content-foot button:first-child')
+    let btn = wrapper.find('.veui-dialog-content-foot .veui-button:first-child')
     expect(btn.classes('veui-disabled')).to.equal(false)
     expect(btn.classes('veui-button-loading')).to.equal(false)
 
@@ -279,7 +287,7 @@ describe('components/Dialog', () => {
 
     await wrapper.vm.$nextTick()
 
-    let btns = wrapper.findAll('.veui-dialog-content-foot button')
+    let btns = wrapper.findAll('.veui-dialog-content-foot .veui-button')
     expect(btns.at(0).text()).to.equal('👍')
     expect(btns.at(1).text()).to.equal('👎')
 

--- a/packages/veui/test/unit/specs/components/Drawer.spec.js
+++ b/packages/veui/test/unit/specs/components/Drawer.spec.js
@@ -146,7 +146,7 @@ describe('components/Drawer', () => {
     let { vm } = wrapper
 
     wrapper
-      .find('.veui-dialog-content-foot button:first-child')
+      .find('.veui-dialog-content-foot .veui-button:first-child')
       .trigger('click')
 
     await vm.$nextTick()
@@ -155,7 +155,9 @@ describe('components/Drawer', () => {
     vm.open = true
 
     await vm.$nextTick()
-    wrapper.find('.veui-dialog-content-foot button:last-child').trigger('click')
+    wrapper
+      .find('.veui-dialog-content-foot .veui-button:last-child')
+      .trigger('click')
 
     await vm.$nextTick()
     expect(vm.open).to.equal(false)
@@ -204,7 +206,9 @@ describe('components/Drawer', () => {
     let { vm } = wrapper
 
     await vm.$nextTick()
-    wrapper.find('.veui-dialog-content-foot button:last-child').trigger('click')
+    wrapper
+      .find('.veui-dialog-content-foot .veui-button:last-child')
+      .trigger('click')
 
     await vm.$nextTick()
     expect(vm.open).to.equal(false)
@@ -213,7 +217,7 @@ describe('components/Drawer', () => {
 
     await vm.$nextTick()
     wrapper
-      .find('.veui-dialog-content-foot button:first-child')
+      .find('.veui-dialog-content-foot .veui-button:first-child')
       .trigger('click')
 
     await wait(100)
@@ -302,7 +306,7 @@ describe('components/Drawer', () => {
     await vm.$nextTick()
 
     wrapper
-      .find('.veui-dialog-content-foot button:first-child')
+      .find('.veui-dialog-content-foot .veui-button:first-child')
       .trigger('click')
 
     await vm.$nextTick()
@@ -311,7 +315,9 @@ describe('components/Drawer', () => {
 
     vm.open = true
     await vm.$nextTick()
-    wrapper.find('.veui-dialog-content-foot button:last-child').trigger('click')
+    wrapper
+      .find('.veui-dialog-content-foot .veui-button:last-child')
+      .trigger('click')
 
     await vm.$nextTick()
 
@@ -343,12 +349,14 @@ describe('components/Drawer', () => {
     })
 
     wrapper
-      .find('.veui-dialog-content-foot button:first-child')
+      .find('.veui-dialog-content-foot .veui-button:first-child')
       .trigger('click')
     await wrapper.vm.$nextTick()
     expect(wrapper.find('.veui-drawer-box').isVisible()).to.equal(true)
 
-    wrapper.find('.veui-dialog-content-foot button:last-child').trigger('click')
+    wrapper
+      .find('.veui-dialog-content-foot .veui-button:last-child')
+      .trigger('click')
     await wrapper.vm.$nextTick()
     expect(wrapper.find('.veui-drawer-box').isVisible()).to.equal(true)
 
@@ -370,7 +378,7 @@ describe('components/Drawer', () => {
     })
 
     let { vm } = wrapper
-    let btn = wrapper.find('.veui-dialog-content-foot button:first-child')
+    let btn = wrapper.find('.veui-dialog-content-foot .veui-button:first-child')
     expect(btn.classes('veui-disabled')).to.equal(false)
     expect(btn.classes('veui-button-loading')).to.equal(false)
 
@@ -404,7 +412,7 @@ describe('components/Drawer', () => {
 
     await wrapper.vm.$nextTick()
 
-    let btns = wrapper.findAll('.veui-dialog-content-foot button')
+    let btns = wrapper.findAll('.veui-dialog-content-foot .veui-button')
     expect(btns.at(0).text()).to.equal('👍')
     expect(btns.at(1).text()).to.equal('👎')
 

--- a/packages/veui/test/unit/specs/components/Input.spec.js
+++ b/packages/veui/test/unit/specs/components/Input.spec.js
@@ -142,7 +142,7 @@ describe('components/Input', () => {
       }
     )
 
-    wrapper.find('button.veui-input-clear').trigger('click')
+    wrapper.find('.veui-input-clear').trigger('click')
   })
 
   it('should render before slot correctly', () => {

--- a/packages/veui/test/unit/specs/components/NumberInput.spec.js
+++ b/packages/veui/test/unit/specs/components/NumberInput.spec.js
@@ -136,7 +136,7 @@ describe('components/NumberInput', () => {
     )
 
     let input = wrapper.find('input.veui-input-input')
-    wrapper.find('button.veui-number-input-step-up').trigger('click')
+    wrapper.find('.veui-number-input-step-up').trigger('click')
     await wrapper.vm.$nextTick()
     expect(input.element.value).to.equal('3')
   })
@@ -172,7 +172,7 @@ describe('components/NumberInput', () => {
       done()
     })
 
-    wrapper.find('button.veui-number-input-step-up').trigger('click')
+    wrapper.find('.veui-number-input-step-up').trigger('click')
   })
 
   it('should make prop `value` fully controlled and violate `decimal-place` for respecting prop `value`', async () => {
@@ -211,7 +211,7 @@ describe('components/NumberInput', () => {
       }
     )
 
-    wrapper.find('button.veui-number-input-step-up').trigger('click')
+    wrapper.find('.veui-number-input-step-up').trigger('click')
     await wrapper.vm.$nextTick()
     expect(wrapper.vm.val).to.equal(1)
     wrapper.destroy()

--- a/packages/veui/test/unit/specs/components/PromptBox.spec.js
+++ b/packages/veui/test/unit/specs/components/PromptBox.spec.js
@@ -192,7 +192,7 @@ describe('components/PromptBox', function () {
     })
 
     let { vm } = wrapper
-    let btn = wrapper.find('.veui-dialog-content-foot button:first-child')
+    let btn = wrapper.find('.veui-dialog-content-foot .veui-button:first-child')
     expect(btn.classes('veui-disabled')).to.equal(false)
     expect(btn.classes('veui-button-loading')).to.equal(false)
 
@@ -226,7 +226,7 @@ describe('components/PromptBox', function () {
 
     await wrapper.vm.$nextTick()
 
-    let btns = wrapper.findAll('.veui-dialog-content-foot button')
+    let btns = wrapper.findAll('.veui-dialog-content-foot .veui-button')
     expect(btns.at(0).text()).to.equal('👍')
     expect(btns.at(1).text()).to.equal('👎')
 

--- a/packages/veui/test/unit/specs/components/SearchBox.spec.js
+++ b/packages/veui/test/unit/specs/components/SearchBox.spec.js
@@ -224,7 +224,7 @@ describe('components/SearchBox', () => {
     expect(wrapper.attributes('autofocus')).to.equal('autofocus')
     expect(wrapper.attributes('ui')).to.include('primary')
 
-    wrapper.find('button.veui-input-clear').trigger('click')
+    wrapper.find('.veui-input-clear').trigger('click')
     await wrapper.vm.$nextTick()
 
     expect(wrapper.find('input').element.value).to.equal('')
@@ -573,7 +573,7 @@ describe('components/SearchBox', () => {
       }
     })
 
-    wrapper.find('button.veui-input-clear').trigger('click')
+    wrapper.find('.veui-input-clear').trigger('click')
     await wrapper.vm.$nextTick()
     expect(wrapper.find('input').element.value).to.equal('ok')
 

--- a/packages/veui/test/unit/specs/components/Table.spec.js
+++ b/packages/veui/test/unit/specs/components/Table.spec.js
@@ -210,10 +210,10 @@ describe('components/Table', () => {
         template: `
           <veui-table :data="data" :expanded="expanded" expandable @update:expanded="updateExpanded">
             <veui-table-column field="field1" title="field1">
-              <template slot="sub-row" slot-scope="{ field3 }">{{ field3 }}</template>
+              <template #sub-row="{ field3 }">{{ field3 }}</template>
             </veui-table-column>
             <veui-table-column field="field2" title="field2">
-              <template slot="sub-row" slot-scope="{ field4 }">{{ field4 }}</template>
+              <template #sub-row="{ field4 }">{{ field4 }}</template>
             </veui-table-column>
           </veui-table>`
       },
@@ -225,7 +225,7 @@ describe('components/Table', () => {
     let { vm } = wrapper
     let rows = wrapper.findAll('tbody tr')
     expect(rows.length).to.equal(2)
-    let btn = wrapper.find('td button')
+    let btn = wrapper.find('td .veui-button')
     btn.trigger('click')
     await vm.$nextTick()
     let totalRows = wrapper.findAll('tbody tr')

--- a/packages/veui/test/unit/specs/components/Uploader.spec.js
+++ b/packages/veui/test/unit/specs/components/Uploader.spec.js
@@ -757,7 +757,7 @@ describe('components/Uploader', function () {
     ])
     items
       .at(1)
-      .find('button')
+      .find('.veui-button')
       .trigger('mouseenter')
     expect(dropdown.localExpanded).to.equal(true)
     dropdown.handleSelect('test11')
@@ -804,7 +804,7 @@ describe('components/Uploader', function () {
 
     let buttons = wrapper
       .find('.veui-uploader-entries-container')
-      .findAll('button')
+      .findAll('.veui-button')
 
     buttons.at(0).trigger('click')
     expect(wrapper.emitted('test')[0]).to.eql([])


### PR DESCRIPTION
目前 `Button` 组件为了在 `disabled` 状态下可以支持鼠标悬浮事件、接收焦点，实现方式是 `disabled` 状态下用 `<div>` 渲染。但这样在动态切换 `disabled` 时丢失了 transition 效果。所以这个 PR 将 `Button` 的实现统一为 `div > button` 的结构，并且尽可能保持原生的按钮功能：

- 支持点击 <kbd>enter</kbd> 触发 `click`
- 支持按下 <kbd>space</kbd> 触发 active 视觉效果，抬起时触发 `click`，点击完阻止默认的页面滚动
- 内部依然有一个原生 `<button>` 但不绑定任何事件，用来触发按钮的默认行为，比如 `type="submit"` 时触发外部表单提交等
- 普通 DOM attr 输出到 `<div>`，特殊属性输出到 `<button>`
- 用 `role="button"` 标注 ARIA 语义信息