### PR TITLE
feat: improve alert/confirm/prompt-box events

### DIFF
--- a/packages/veui/src/components/AlertBox.vue
+++ b/packages/veui/src/components/AlertBox.vue
@@ -15,8 +15,7 @@
   :priority="priority"
   :before-close="beforeClose"
   role="alertdialog"
-  @ok="$emit('ok')"
-  @afterclose="$emit('afterclose')"
+  v-on="listeners"
 >
   <div :class="$c('alert-box-icon-wrapper')">
     <veui-icon
@@ -107,6 +106,9 @@ export default {
     }
   },
   computed: {
+    listeners () {
+      return pick(this.$listeners, ['ok', 'afteropen', 'afterclose'])
+    },
     realOkLabel () {
       return this.okLabel || this.t('ok')
     },

--- a/packages/veui/src/components/ConfirmBox.vue
+++ b/packages/veui/src/components/ConfirmBox.vue
@@ -12,9 +12,7 @@
   :ok-label="okLabel"
   :cancel-label="cancelLabel"
   role="alertdialog"
-  @ok="$emit('ok')"
-  @cancel="$emit('cancel')"
-  @afterclose="$emit('afterclose')"
+  v-on="listeners"
 >
   <template
     v-if="title || $slots.title"
@@ -81,6 +79,9 @@ export default {
     }
   },
   computed: {
+    listeners () {
+      return pick(this.$listeners, ['ok', 'cancel', 'afteropen', 'afterclose'])
+    },
     priority () {
       return this.config['confirmbox.priority']
     }

--- a/packages/veui/src/components/Dialog.vue
+++ b/packages/veui/src/components/Dialog.vue
@@ -16,8 +16,8 @@
   :inline="inline"
   :modal="modal"
   :priority="priority"
+  v-on="listeners"
   @mousedown="focusContent"
-  @afteropen="handleAfterOpen"
   @afterclose="handleAfterClose"
 >
   <div
@@ -96,6 +96,7 @@
 </template>
 
 <script>
+import { pick } from 'lodash'
 import Overlay from './Overlay'
 import Button from './Button'
 import prefix from '../mixins/prefix'
@@ -164,6 +165,9 @@ export default {
     cancelLabel: String
   },
   computed: {
+    listeners () {
+      return pick(this.$listeners, ['afteropen'])
+    },
     realOkLabel () {
       return this.okLabel || this.t('ok')
     },
@@ -252,9 +256,6 @@ export default {
     handleAfterClose () {
       this.closeModal()
       this.$emit('afterclose')
-    },
-    handleAfterOpen () {
-      this.$emit('afteropen')
     }
   }
 }

--- a/packages/veui/src/components/PromptBox.vue
+++ b/packages/veui/src/components/PromptBox.vue
@@ -13,9 +13,8 @@
   :ok-label="okLabel"
   :cancel-label="cancelLabel"
   role="alertdialog"
+  v-on="listeners"
   @ok="ok"
-  @cancel="cancel"
-  @afterclose="$emit('afterclose')"
 >
   <template slot="title">
     <slot name="title">{{ title }}</slot>
@@ -95,6 +94,9 @@ export default {
     invalid: Boolean
   },
   computed: {
+    listeners () {
+      return pick(this.$listeners, ['cancel', 'afteropen', 'afterclose'])
+    },
     priority () {
       return this.config['promptbox.priority']
     }
@@ -114,9 +116,6 @@ export default {
     },
     ok () {
       this.$emit('ok', this.realValue)
-    },
-    cancel () {
-      this.$emit('cancel', this.realValue)
     }
   }
 }

--- a/packages/veui/types/components/alert-box.d.ts
+++ b/packages/veui/types/components/alert-box.d.ts
@@ -18,6 +18,7 @@ type Props = {
 
 type Emits = {
   ok(): void
+  afteropen(): void
   afterclose(): void
 }
 

--- a/packages/veui/types/components/confirm-box.d.ts
+++ b/packages/veui/types/components/confirm-box.d.ts
@@ -20,6 +20,7 @@ type Props = Pick<
 type Emits = {
   ok(): void
   cancel(): void
+  afteropen(): void
   afterclose(): void
 }
 

--- a/packages/veui/types/components/dialog.d.ts
+++ b/packages/veui/types/components/dialog.d.ts
@@ -26,6 +26,7 @@ export type Props = {
 }
 
 export type Emits = {
+  afteropen(): void
   afterclose(): void
   ok(): void
   cancel(): void

--- a/packages/veui/types/components/prompt-box.d.ts
+++ b/packages/veui/types/components/prompt-box.d.ts
@@ -24,7 +24,8 @@ type Props = Pick<
 
 type Emits = {
   ok(value: string): void
-  cancel(value: string): void
+  cancel(): void
+  afteropen(): void
   afterclose(): void
 }
 


### PR DESCRIPTION
- pass down listeners instead of re-emit events
- add `afteropen` event
- fix `.d.ts`