### PR TITLE
refactor: add keyField prop to the iterable components

### DIFF
--- a/packages/veui/src/components/Anchor.vue
+++ b/packages/veui/src/components/Anchor.vue
@@ -17,6 +17,7 @@
       :class="$c('anchor-tree')"
       :datasource="items"
       :expanded="allAnchors"
+      :key-field="keyField"
     >
       <template
         slot="item"
@@ -137,7 +138,8 @@ export default {
       type: [String, Number],
       validator: offsetValidator,
       default: 0
-    }
+    },
+    keyField: String
   },
   data () {
     return {

--- a/packages/veui/src/components/ButtonGroup.vue
+++ b/packages/veui/src/components/ButtonGroup.vue
@@ -12,7 +12,7 @@
     <slot>
       <veui-button
         v-for="(item, index) in items"
-        :key="index"
+        :key="item[keyField || 'label']"
         :disabled="disabled || item.disabled"
         :aria-posinset="index + 1"
         :aria-setsize="items.length"
@@ -52,7 +52,8 @@ export default {
         return []
       }
     },
-    disabled: Boolean
+    disabled: Boolean,
+    keyField: String
   },
   methods: {
     handleClick (item, index, e) {

--- a/packages/veui/src/components/Carousel/Carousel.vue
+++ b/packages/veui/src/components/Carousel/Carousel.vue
@@ -35,6 +35,7 @@
           :slide-aspect-ratio="slideAspectRatio"
           :preload-range="preloadRange"
           :options="options"
+          :key-field="keyField"
           v-bind="isFade ? {} : slideProps"
         >
           <template
@@ -153,6 +154,7 @@ export default {
         return includes(['start', 'end'], value)
       }
     },
+    keyField: String,
     indicatorPosition: {
       type: String,
       default: 'inside',

--- a/packages/veui/src/components/Carousel/_Fade.vue
+++ b/packages/veui/src/components/Carousel/_Fade.vue
@@ -12,7 +12,7 @@
     v-for="(item, idx) in datasource"
     v-show="idx === index"
     ref="item"
-    :key="`item#${idx}`"
+    :key="keyField ? item[keyField] : `item#${idx}`"
     :class="{
       [$c('carousel-item')]: true,
       [$c('carousel-item-current')]: idx === index

--- a/packages/veui/src/components/Carousel/_Slide.vue
+++ b/packages/veui/src/components/Carousel/_Slide.vue
@@ -11,7 +11,7 @@
   <li
     v-for="(item, rdIndex) in realDatasource"
     ref="item"
-    :key="rdIndex"
+    :key="keyField ? item[keyField] : rdIndex"
     :class="{
       [$c('carousel-item')]: true,
       [$c('carousel-item-duplicate')]: item.duplicate,

--- a/packages/veui/src/components/Carousel/_mixin.js
+++ b/packages/veui/src/components/Carousel/_mixin.js
@@ -11,7 +11,8 @@ export default {
     options: Object,
     preloadRange: Array,
     datasource: Array,
-    index: Number
+    index: Number,
+    keyField: String
   },
   created () {
     // 过渡完成后重置视频时间

--- a/packages/veui/src/components/Cascader/Cascader.vue
+++ b/packages/veui/src/components/Cascader/Cascader.vue
@@ -114,6 +114,7 @@
           :select-mode="selectMode"
           :column-width="keyword ? null : columnWidth"
           :expanded="realExpanded"
+          :key-field="keyField"
           @update:expanded="handlePaneUpdateExpanded"
           @select="handlePaneSelect"
           @keydown.native="!searchable && handleCascaderKeydown($event)"
@@ -258,7 +259,8 @@ export default {
       }
     },
     inline: Boolean,
-    max: Number
+    max: Number,
+    keyField: String
   },
   data () {
     return {

--- a/packages/veui/src/components/Cascader/CascaderPane.vue
+++ b/packages/veui/src/components/Cascader/CascaderPane.vue
@@ -36,6 +36,7 @@
         :expand="expand"
         :class="$c('cascader-pane-tree')"
         :group-class="$c('cascader-pane-tree')"
+        :key-field="keyField"
       >
         <template
           slot="item"
@@ -204,7 +205,8 @@ export default {
       validator (val) {
         return ['leaf-only', 'any'].indexOf(val) >= 0
       }
-    }
+    },
+    keyField: String
   },
   computed: {
     isClickTrigger () {

--- a/packages/veui/src/components/CheckButtonGroup.vue
+++ b/packages/veui/src/components/CheckButtonGroup.vue
@@ -10,7 +10,7 @@
   <div :class="$c('check-button-group-items')">
     <veui-button
       v-for="(item, index) in items"
-      :key="`b-${item.value}`"
+      :key="item[keyField || 'value']"
       :ref="`b-${item.value}`"
       :ui="uiParts.button"
       :class="{
@@ -100,6 +100,7 @@ export default {
         return []
       }
     },
+    keyField: String,
     /* eslint-disable vue/require-prop-types */
     emptyValue: {}
     /* eslint-enable vue/require-prop-types */

--- a/packages/veui/src/components/CheckboxGroup.vue
+++ b/packages/veui/src/components/CheckboxGroup.vue
@@ -11,7 +11,7 @@
     <veui-checkbox
       :is="item.exclusive ? 'veui-radio' : 'veui-checkbox'"
       v-for="(item, index) in items"
-      :key="index"
+      :key="item[keyField || 'value']"
       :ref="`b-${item.value}`"
       :name="localName"
       :disabled="item.disabled || realDisabled || realReadonly"
@@ -92,6 +92,7 @@ export default {
         return []
       }
     },
+    keyField: String,
     /* eslint-disable vue/require-prop-types */
     emptyValue: {}
     /* eslint-enable vue/require-prop-types */

--- a/packages/veui/src/components/DatePicker.vue
+++ b/packages/veui/src/components/DatePicker.vue
@@ -96,8 +96,8 @@
         :class="$c('date-picker-shortcuts')"
       >
         <button
-          v-for="({ from, to, label }, index) in realShortcuts"
-          :key="index"
+          v-for="{ from, to, label } in realShortcuts"
+          :key="label"
           type="button"
           :class="$c('date-picker-shortcut')"
           @click="handleSelect([from, to])"

--- a/packages/veui/src/components/Lightbox.vue
+++ b/packages/veui/src/components/Lightbox.vue
@@ -71,7 +71,7 @@
             v-for="(item, i) in datasource"
             v-show="realIndex === i"
             ref="item"
-            :key="`${i}#${item.src}`"
+            :key="keyField ? item[keyField] : `${i}#${item.src}`"
             tabindex="0"
             data-autofocus
             :class="{
@@ -195,7 +195,8 @@ export default {
           }
         }
       }
-    }
+    },
+    keyField: String
   },
   computed: {
     attrs () {

--- a/packages/veui/src/components/Menu/Menu.vue
+++ b/packages/veui/src/components/Menu/Menu.vue
@@ -17,6 +17,7 @@
       }"
       :items="normalizedItems"
       :expanded="realExpanded"
+      :key-field="keyField"
     >
       <template
         slot="item"
@@ -115,6 +116,7 @@
               :ref="`dropdown-${link.name}`"
               :overlay-class="$c('menu-overlay')"
               :options="link.options"
+              :key-field="keyField"
               position="popup"
               trigger="hover"
               option-tag="div"

--- a/packages/veui/src/components/Menu/Nav.vue
+++ b/packages/veui/src/components/Menu/Nav.vue
@@ -10,7 +10,7 @@
   >
     <li
       v-for="item in realItems"
-      :key="item.name"
+      :key="item[keyField || 'name']"
       :ref="item.name"
       :class="{
         [$c('nav-more-hidden')]: isMoreBtn(item) && !restItems.length
@@ -102,7 +102,7 @@
           >
             <li
               v-for="cardItem in item.children"
-              :key="cardItem.name"
+              :key="cardItem[keyField || 'name']"
               :class="$c('nav-card-item')"
               @click="handleItemClick(cardItem)"
             >
@@ -147,7 +147,7 @@
               >
                 <li
                   v-for="subCardItem in cardItem.children"
-                  :key="subCardItem.name"
+                  :key="subCardItem[keyField || 'name']"
                   @click="handleItemClick(subCardItem)"
                 >
                   <slot

--- a/packages/veui/src/components/Menu/_mixin.js
+++ b/packages/veui/src/components/Menu/_mixin.js
@@ -34,7 +34,8 @@ export default {
       default (route, item) {
         return ensureSlash(route.path) === ensureSlash(item.path)
       }
-    }
+    },
+    keyField: String
   },
   computed: {
     normalizedItems () {

--- a/packages/veui/src/components/Pagination.vue
+++ b/packages/veui/src/components/Pagination.vue
@@ -56,8 +56,8 @@
       ]"
     >
       <li
-        v-for="(item, i) in pageIndicatorSeries"
-        :key="i"
+        v-for="item in pageIndicatorSeries"
+        :key="item.page"
         :class="{
           [$c('pagination-page')]: true,
           [$c('active')]: item.current

--- a/packages/veui/src/components/RadioButtonGroup.vue
+++ b/packages/veui/src/components/RadioButtonGroup.vue
@@ -12,7 +12,7 @@
     <veui-button
       v-for="(item, index) in items"
       :ref="`b-${item.value}`"
-      :key="index"
+      :key="item[keyField || 'value']"
       :ui="uiParts.button"
       :class="{
         [$c('button-selected')]: index === activeIndex
@@ -84,6 +84,7 @@ export default {
   },
   props: {
     items: Array,
+    keyField: String,
     /* eslint-disable vue/require-prop-types */
     value: {}
     /* eslint-enable vue/require-prop-types */

--- a/packages/veui/src/components/RadioGroup.vue
+++ b/packages/veui/src/components/RadioGroup.vue
@@ -10,7 +10,7 @@
     <veui-radio
       v-for="(item, index) in items"
       :ref="`b-${item.value}`"
-      :key="index"
+      :key="item[keyField || 'value']"
       :name="localName"
       :value="item.value"
       :model="realValue"
@@ -79,6 +79,7 @@ export default {
   },
   props: {
     items: Array,
+    keyField: String,
     /* eslint-disable vue/require-prop-types */
     value: {}
     /* eslint-enable vue/require-prop-types */

--- a/packages/veui/src/components/Select/OptionGroup.vue
+++ b/packages/veui/src/components/Select/OptionGroup.vue
@@ -69,6 +69,7 @@ const OptionGroup = {
     options: Array,
     disabled: Boolean,
     expanded: Boolean,
+    keyField: String,
     position: {
       type: String,
       default: 'inline',
@@ -281,7 +282,8 @@ const OptionGroup = {
             overlayStyle={this.overlayStyle}
             optionTag={this.optionTag}
             labelTag={this.labelTag}
-            key={i}
+            key={this.keyField ? option[this.keyField] : i}
+            keyField={this.keyField}
             trigger={option.trigger || this.trigger}
             option={option} // pass raw option
             scopedSlots={{
@@ -310,7 +312,7 @@ const OptionGroup = {
             hidden={option.hidden}
             disabled={this.disabled || option.disabled}
             tag={optionTag}
-            key={i}
+            key={this.keyField ? option[this.keyField] : i}
           >
             {this.$scopedSlots.option
               ? this.$scopedSlots.option(option)

--- a/packages/veui/src/components/Select/Select.vue
+++ b/packages/veui/src/components/Select/Select.vue
@@ -81,7 +81,8 @@ export default {
     searchable: Boolean,
     options: Array,
     multiple: Boolean,
-    max: Number
+    max: Number,
+    keyField: String
   },
   data () {
     return {
@@ -527,6 +528,7 @@ export default {
             key={key}
             v-show={!!options}
             hidden={!options}
+            keyField={this.keyField}
             aria-hidden={!options}
             ref="options"
             options={options}

--- a/packages/veui/src/components/Transfer/Transfer.vue
+++ b/packages/veui/src/components/Transfer/Transfer.vue
@@ -42,6 +42,7 @@ export default {
         return []
       }
     },
+    keyField: String,
     searchable: {
       type: Boolean,
       default: true
@@ -143,6 +144,7 @@ export default {
                 mergeChecked: this.mergeChecked,
                 includeIndeterminate: this.includeIndeterminate,
                 uiParts: this.uiParts,
+                keyField: this.keyField,
                 ui: this.realUi
               },
               on: {
@@ -174,6 +176,7 @@ export default {
                 title: this.selectedTitle,
                 isSelectable: this.isSelectable,
                 icons: this.icons,
+                keyField: this.keyField,
                 uiParts: this.uiParts,
                 ui: this.realUi
               },

--- a/packages/veui/src/components/Transfer/_CandidatePanel.vue
+++ b/packages/veui/src/components/Transfer/_CandidatePanel.vue
@@ -41,6 +41,7 @@
       :checked="realSelected"
       :ui="uiParts.tree"
       :disabled="!isSelectable"
+      :key-field="keyField || 'value'"
       @check="handleSelect"
     >
       <template
@@ -110,7 +111,8 @@ export default {
     selected: Array,
     ...useTree().props,
     uiParts: Object,
-    ui: String
+    ui: String,
+    keyField: String
   },
   data () {
     return {

--- a/packages/veui/src/components/Transfer/_SelectedPanel.vue
+++ b/packages/veui/src/components/Transfer/_SelectedPanel.vue
@@ -38,6 +38,7 @@
       :expanded.sync="expanded"
       :class="$c('transfer-selected-tree')"
       :disabled="!isSelectable"
+      :key-field="keyField || 'value'"
     >
       <template
         slot="item"
@@ -133,7 +134,8 @@ export default {
     isSelectable: Boolean,
     ui: String,
     icons: Object,
-    uiParts: Object
+    uiParts: Object,
+    keyField: String
   },
   data () {
     return {

--- a/packages/veui/src/components/Tree/Tree.vue
+++ b/packages/veui/src/components/Tree/Tree.vue
@@ -8,6 +8,7 @@
   :ui="realUi"
   :items="normalizedItems"
   :expanded="realExpanded"
+  :key-field="keyField || 'value'"
   @focusin.native="focused = true"
   @focusout.native="focused = false"
 >
@@ -146,7 +147,8 @@ export default {
     selected: {},
     /* eslint-ensable vue/require-prop-types */
     datasource: AbstractTree.props.items,
-    expanded: AbstractTree.props.expanded
+    expanded: AbstractTree.props.expanded,
+    keyField: String
   },
   data () {
     return {

--- a/packages/veui/src/components/Tree/_AbstractTree.vue
+++ b/packages/veui/src/components/Tree/_AbstractTree.vue
@@ -5,7 +5,7 @@
 >
   <li
     v-for="(item, index) in items"
-    :key="index"
+    :key="keyField ? item[keyField] : index"
     role="treeitem"
     :class="$c('abstract-tree-item-wrapper')"
   >
@@ -28,6 +28,7 @@
         :parents="[...parents, item]"
         :group-class="groupClass"
         :class="realGroupClass"
+        :key-field="keyField"
       >
         <template
           slot="item"
@@ -88,7 +89,8 @@ export default {
     expand: Function,
     groupClass: {
       type: [String, Object]
-    }
+    },
+    keyField: String
   },
   computed: {
     realGroupClass () {

--- a/packages/veui/test/unit/specs/components/Select/Select.spec.js
+++ b/packages/veui/test/unit/specs/components/Select/Select.spec.js
@@ -982,4 +982,40 @@ describe('components/Select/Select', () => {
 
     wrapper.destroy()
   })
+
+  it('should handle keyField prop correctly.', async () => {
+    const ds = [
+      { label: '1', value: '1' },
+      { label: '2', value: '2' }
+    ]
+    let wrapper = mount(Select, {
+      propsData: {
+        options: ds,
+        keyField: 'label',
+        expanded: true
+      },
+      sync: false,
+      attachToDocument: true
+    })
+    const { vm } = wrapper
+    await vm.$nextTick()
+    markDom()
+    wrapper.setProps({ options: [ds[1]] })
+    await vm.$nextTick()
+    checkDom(ds[1].label)
+
+    wrapper.destroy()
+
+    function markDom () {
+      let items = wrapper.findAll('.veui-option')
+      items.at(0).element.setAttribute('foo', vm.options[0].label)
+      items.at(1).element.setAttribute('foo', vm.options[1].label)
+    }
+
+    function checkDom (label) {
+      expect(wrapper.find('.veui-option').element.getAttribute('foo')).to.equal(
+        label
+      )
+    }
+  })
 })

--- a/packages/veui/test/unit/specs/components/Tree.spec.js
+++ b/packages/veui/test/unit/specs/components/Tree.spec.js
@@ -1222,6 +1222,43 @@ describe('components/Tree', () => {
         .trigger('change')
     }
   })
+
+  it('should handle keyField prop correctly.', async () => {
+    const ds = [
+      { label: '1', value: '1' },
+      { label: '2', value: '2' }
+    ]
+    let wrapper = mount(Tree, {
+      propsData: {
+        datasource: ds,
+        keyField: 'label'
+      },
+      sync: false,
+      attachToDocument: true
+    })
+    const { vm } = wrapper
+    await vm.$nextTick()
+    markDom()
+    wrapper.setProps({ datasource: [ds[1]] })
+    await vm.$nextTick()
+    checkDom(ds[1].label)
+
+    wrapper.destroy()
+
+    function markDom () {
+      let items = wrapper.findAll('.veui-abstract-tree-item-wrapper')
+      items.at(0).element.setAttribute('foo', vm.datasource[0].label)
+      items.at(1).element.setAttribute('foo', vm.datasource[1].label)
+    }
+
+    function checkDom (label) {
+      expect(
+        wrapper
+          .find('.veui-abstract-tree-item-wrapper')
+          .element.getAttribute('foo')
+      ).to.equal(label)
+    }
+  })
 })
 
 function unorderedEqual (a, b) {


### PR DESCRIPTION
把之前 keyField 的 commit 单独拿出来，可以定制类似 datasource 渲染时的 key