### PR TITLE
fix: babel plugin should match the whole identifier

### DIFF
--- a/packages/babel-plugin-veui/src/treeshake.js
+++ b/packages/babel-plugin-veui/src/treeshake.js
@@ -62,7 +62,7 @@ export default function ({ types: t }) {
   }
 }
 
-const VAR_PATTERN = /(?:V(?:eui)?)?([A-Z][a-zA-Z]*)/
+const VAR_PATTERN = /^(?:V(?:eui)?)?([A-Z][a-zA-Z]*)/
 
 function getComponentName (importedName) {
   let [, name] = importedName.match(VAR_PATTERN) || []

--- a/packages/babel-plugin-veui/test/fixtures/treeshake/expected.js
+++ b/packages/babel-plugin-veui/test/fixtures/treeshake/expected.js
@@ -1,6 +1,7 @@
 import Button from './Button'
 import { default as Select, foo } from './Select'
 import Input from 'veui/components/Input.vue'
+import { useTooltip } from 'veui'
 import Form from 'veui/components/Form/Form.vue'
 import Field from 'veui/components/Field.js'
 import VeuiIcon from 'veui/components/Icon.vue'

--- a/packages/babel-plugin-veui/test/fixtures/treeshake/source.js
+++ b/packages/babel-plugin-veui/test/fixtures/treeshake/source.js
@@ -1,6 +1,7 @@
 import Button from './Button'
 import { default as Select, foo } from './Select'
 import { Input } from 'veui'
+import { useTooltip } from 'veui'
 import { Form, Field, Icon as VeuiIcon, default as veui } from 'veui'
 import * as all from 'veui'
 import ui from 'veui-next'


### PR DESCRIPTION
...when looking for component names.