### PR TITLE
feat: add input mask for NumberInput, DatePicker and TimePicker

### DIFF
--- a/packages/veui/demo/cases/Input.vue
+++ b/packages/veui/demo/cases/Input.vue
@@ -216,6 +216,11 @@
       <veui-input placeholder="end" trim="end"/>
     </section>
   </section>
+
+  <section>
+    <h3>Input mask</h3>
+    <veui-input mask="####-##-##" placeholder="YYYY-MM-DD" @input="log"/>
+  </section>
 </article>
 </template>
 

--- a/packages/veui/package.json
+++ b/packages/veui/package.json
@@ -31,6 +31,7 @@
     "date-fns": "^2.28.0",
     "dls-graphics": "^1.3.2",
     "lodash": "^4.17.21",
+    "@justfork/maska": "^2.0.0",
     "popper.js": "^1.16.1",
     "resize-detector": "^0.1.10",
     "vue-awesome": "^4.5.0",

--- a/packages/veui/src/components/DatePicker.vue
+++ b/packages/veui/src/components/DatePicker.vue
@@ -129,6 +129,7 @@
               :value="realInputValue[0]"
               :ui="uiParts.input"
               :autofocus="activateByEnd ? null : ''"
+              :mask="mask"
               @input="handleInput(0, $event)"
               @focus="handleInputFocus"
             />
@@ -139,6 +140,7 @@
                 :value="realInputValue[1]"
                 :ui="uiParts.input"
                 :autofocus="activateByEnd ? '' : null"
+                :mask="mask"
                 @input="handleInput(1, $event)"
                 @focus="handleInputFocus"
               />
@@ -227,6 +229,10 @@ const RANGE_PLACEHOLDER_KEY_MAP = {
 }
 
 const DEFAULT_DATE_SEP = '[/.-]'
+
+function dateFormatToMask (format) {
+  return format.replace(/[yMd]/g, '#')
+}
 
 export default {
   name: 'veui-date-picker',
@@ -348,6 +354,13 @@ export default {
           to
         }
       })
+    },
+    mask () {
+      let format =
+        typeof this.format === 'string'
+          ? this.format
+          : TYPE_FORMAT_MAP[this.type]
+      return dateFormatToMask(format)
     }
   },
   watch: {

--- a/packages/veui/src/components/NumberInput.vue
+++ b/packages/veui/src/components/NumberInput.vue
@@ -13,6 +13,7 @@
     [$c('number-input')]: true,
     [$c('number-input-controls-focus')]: spinnerFocused
   }"
+  :mask="mask"
   v-on="listeners"
   @change="handleChange"
   @input="handleInput"
@@ -97,7 +98,7 @@ import Icon from './Icon'
 import { sign, add, round } from '../utils/math'
 import warn from '../utils/warn'
 import { VALUE_EVENTS } from '../utils/dom'
-import { isInteger, isNaN, get, find, omit, isFunction } from 'lodash'
+import { isInteger, isNaN, get, find, omit, isFunction, repeat } from 'lodash'
 import nudge from '../directives/nudge'
 import longpress from '../directives/longpress'
 import useControllable from '../mixins/controllable'
@@ -131,7 +132,7 @@ export default {
   inheritAttrs: false,
   props: {
     ui: String,
-    value: Number,
+    value: [Number, String],
     step: {
       type: Number,
       default: 1
@@ -228,12 +229,22 @@ export default {
         min: this.realMin,
         value: this.value
       }
+    },
+    mask () {
+      let { realMax, realMin, decimalPlace } = this
+      let prefix = realMax < 0 ? '-' : realMin >= 0 ? '' : '-?'
+      let mask =
+        decimalPlace === -1
+          ? '#*.#*'
+          : `#*${decimalPlace === 0 ? '' : '.'}${repeat('#', decimalPlace)}`
+
+      return `${prefix}${mask}`
     }
   },
   watch: {
     // 输入过程中，外部 value 发生变化，那么重置输入
     // 这个逻辑是为了统一：当无法完全受控，那么 prop 变化时如何处理？目前逻辑是 prop 覆盖 local
-    value (val) {
+    value () {
       if (this.parsedInputValue != null) {
         // 没有 local 状态了，就是 realValue 生效了，见 realInputValue
         this.parsedInputValue = null

--- a/packages/veui/src/components/TimePicker/TimePicker.vue
+++ b/packages/veui/src/components/TimePicker/TimePicker.vue
@@ -18,8 +18,10 @@
     v-model="realInputValue"
     v-bind="inputProps"
     autocomplete="off"
+    :mask="mask"
     @focus="openDropdown"
     @click="openDropdown"
+    @keydown.enter="closeDropdown"
   >
     <div slot="after" :class="$c('time-picker-icon')">
       <veui-button
@@ -153,6 +155,11 @@ const HOURS = range(24)
 const MINUTES = range(60)
 const SECONDS = MINUTES
 const MODES = ['hour', 'minute', 'second']
+const MASKS = {
+  hour: '##:00',
+  minute: '##:##',
+  second: '##:##:##'
+}
 
 config.defaults(
   {
@@ -312,6 +319,9 @@ export default {
         this.realValue = val
         this.scrollSelectedToCenter()
       }
+    },
+    mask () {
+      return MASKS[this.mode]
     }
   },
   watch: {

--- a/packages/veui/src/utils/bom.js
+++ b/packages/veui/src/utils/bom.js
@@ -1,14 +1,14 @@
-function getNavigator (key) {
-  // 为了支持 ssr，需要判断下有没有 bom
-  return typeof navigator === 'undefined' ? undefined : navigator[key]
-}
-
-// 目前需求比较简单，简单实现下。如果需要完备实现可以引入 detect-brower
+// 目前需求比较简单，简单实现下。如果需要完备实现可以引入 detect-browser
 export function isFirefox () {
-  let ua = getNavigator('userAgent')
-  return ua ? ua.toLowerCase().indexOf('firefox') > -1 : false
+  if (process.env.VUE_ENV === 'server') {
+    return false
+  }
+  return navigator.userAgent.toLowerCase().indexOf('firefox') > -1
 }
 
 export function isSafari () {
-  return /apple/i.test(getNavigator('vendor'))
+  if (process.env.VUE_ENV === 'server') {
+    return false
+  }
+  return /apple/i.test(navigator.vendor)
 }

--- a/packages/veui/test/unit/specs/components/DatePicker.spec.js
+++ b/packages/veui/test/unit/specs/components/DatePicker.spec.js
@@ -504,4 +504,38 @@ describe('components/DatePicker', function () {
     })
     wrapper.destroy()
   })
+
+  it('should mask input correctly', async () => {
+    let wrapper = mount(
+      {
+        components: {
+          'veui-date-picker': DatePicker
+        },
+        data () {
+          return {
+            type: 'date'
+          }
+        },
+        template: `<veui-date-picker :type="type" expanded/>`
+      },
+      {
+        sync: false,
+        attachToDocument: true
+      }
+    )
+
+    let { vm } = wrapper
+    let input = wrapper.find(DatePicker).vm.$refs.start
+    expect(input.mask).to.equal('####/##/##')
+
+    vm.type = 'month'
+    await vm.$nextTick()
+    expect(input.mask).to.equal('####/##')
+
+    vm.type = 'year'
+    await vm.$nextTick()
+    expect(input.mask).to.equal('####')
+
+    wrapper.destroy()
+  })
 })

--- a/packages/veui/test/unit/specs/components/NumberInput.spec.js
+++ b/packages/veui/test/unit/specs/components/NumberInput.spec.js
@@ -345,4 +345,49 @@ describe('components/NumberInput', function () {
       await vm.$nextTick()
     }
   })
+
+  it('should mask input correctly', async () => {
+    let wrapper = mount(
+      {
+        components: {
+          'veui-number-input': NumberInput
+        },
+        data () {
+          return {
+            decimalPlace: 0,
+            max: undefined,
+            min: undefined
+          }
+        },
+        template: `<veui-number-input :decimal-place="decimalPlace" :max="max" :min="min"/>`
+      },
+      {
+        sync: false,
+        attachToDocument: true
+      }
+    )
+
+    let { vm } = wrapper
+    let input = wrapper.find(NumberInput).vm
+    expect(input.mask).to.equal('-?#*')
+
+    vm.decimalPlace = 2
+    vm.max = -10
+    await vm.$nextTick()
+    expect(input.mask).to.equal('-#*.##')
+
+    vm.decimalPlace = 4
+    vm.max = 10
+    vm.min = -10
+    await vm.$nextTick()
+    expect(input.mask).to.equal('-?#*.####')
+
+    vm.decimalPlace = -1
+    vm.max = undefined
+    vm.min = 10
+    await vm.$nextTick()
+    expect(input.mask).to.equal('#*.#*')
+
+    wrapper.destroy()
+  })
 })

--- a/packages/veui/test/unit/specs/components/TimePicker/TimePicker.spec.js
+++ b/packages/veui/test/unit/specs/components/TimePicker/TimePicker.spec.js
@@ -121,4 +121,38 @@ describe('components/TimePicker', function () {
     expect(isEqual(vm.value0, '12:30:30')).to.equal(true)
     wrapper.destroy()
   })
+
+  it('should mask input correctly', async () => {
+    let wrapper = mount(
+      {
+        components: {
+          'veui-time-picker': TimePicker
+        },
+        data () {
+          return {
+            mode: 'second'
+          }
+        },
+        template: `<veui-time-picker :mode="mode"/>`
+      },
+      {
+        sync: false,
+        attachToDocument: true
+      }
+    )
+
+    let { vm } = wrapper
+    let input = wrapper.find(TimePicker).vm.$refs.input
+    expect(input.mask).to.equal('##:##:##')
+
+    vm.mode = 'minute'
+    await vm.$nextTick()
+    expect(input.mask).to.equal('##:##')
+
+    vm.mode = 'hour'
+    await vm.$nextTick()
+    expect(input.mask).to.equal('##:00')
+
+    wrapper.destroy()
+  })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,7 @@ importers:
     specifiers:
       '@babel/core': ^7.17.10
       '@babel/runtime': ^7.17.9
+      '@justfork/maska': ^2.0.0
       '@rollup/plugin-alias': ^3.1.9
       '@rollup/plugin-babel': ^5.3.1
       '@rollup/plugin-commonjs': ^19.0.2
@@ -143,6 +144,7 @@ importers:
       vue-template-compiler: ^2.6.14
       webpack: ^4.46.0
     dependencies:
+      '@justfork/maska': 2.0.0
       bytes: 3.1.2
       clone-element: 0.1.0
       core-js: 3.22.4
@@ -1629,6 +1631,10 @@ packages:
       string-argv: 0.3.1
       type-detect: 4.0.8
     dev: true
+
+  /@justfork/maska/2.0.0:
+    resolution: {integrity: sha512-0kug/g3AXzhe0NbkvD5R/BGEGz8GBEZBzgmsMpAoPU19OHtls85vjBi77PyitnzdV9ZVBLBM3AXRA50wdNiZCw==}
+    dev: false
 
   /@mrmlnc/readdir-enhanced/2.2.1:
     resolution: {integrity: sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==}


### PR DESCRIPTION
- Added a `mask` prop to `Input` but let's keep it internal for now, as we may switch to other low-level implementations in the future and we tend to prevent vendor lock-in ATM.
- Used a forked version of [`maska`](https://github.com/beholdr/maska) as it doesn't support optional token yet and the author seems to be inactive (I made a PR anyway https://github.com/beholdr/maska/pull/87).
- Disabled in Firefox as the order of `input` event handlers and microtasks in it is different from others, which makes it very tricky to coordinate our controlled input and `maska`'s DOM manipulation in Firefox.
- Technically the masks can be stricter but it would be rather complicated.

---

Update: `maska@2` will come with an optional token so we'll move to it later.