### PR TITLE
docs: Add Cloud IDE preview link

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Packages included in this repo are:
 * [`veui-theme-dls`](./packages/veui-theme-dls)
 * [`veui-theme-dls-icons`](./packages/veui-theme-dls-icons)
 
+## Start On Cloud IDE
+
+[https://idegithub.com/ecomfe/veui](https://idegithub.com/ecomfe/veui)
+
 ## Contribution
 
 To develop `veui` locally you need to clone this repo and run the following in `veui`'s root directory (VEUI uses pnpm as the package manager):

--- a/preview.yml
+++ b/preview.yml
@@ -1,0 +1,11 @@
+# preview.yml
+autoOpen: true # 打开工作空间时是否自动开启所有应用的预览
+apps:
+  - port: 3000 # 应用的端口
+    run: pnpm install && pnpm dev # 应用的启动命令
+    command: # 使用此命令启动服务，且不执行run
+    preview: # 预览文件(文件路径),且不执行run和command命令
+    root: ./ # 应用的启动目录
+    name: VEUI # 应用名称
+    description: Enterprise UI components for Vue.js. # 应用描述
+    autoOpen: true # 打开工作空间时是否自动开启预览（优先级高于根级 autoOpen)


### PR DESCRIPTION
写了一个脚本 `preview.yml`，可以直接在云 IDE 中自动拉取 VEUI 的代码、自动安装依赖、自动打开预览，可以实时调试代码查看 demo，方便在线预览。