### PR TITLE
feat: add useStrict

### DIFF
--- a/packages/veui/demo/cases/Autocomplete.vue
+++ b/packages/veui/demo/cases/Autocomplete.vue
@@ -46,11 +46,12 @@
     />
   </section>
   <section>
-    <h2>树型数据，focus 时下拉，最多展示4个</h2>
+    <h2>树型数据，focus 时下拉，最多展示4个，必须选搜索结果</h2>
     <veui-autocomplete
       v-model="treeValue"
       :datasource="coffees"
       placeholder="请输入"
+      :strict="{ select: true }"
       suggest-trigger="focus"
       :overlay-style="{
         '--dls-dropdown-max-display-items': 4

--- a/packages/veui/src/components/Autocomplete/Autocomplete.vue
+++ b/packages/veui/src/components/Autocomplete/Autocomplete.vue
@@ -26,10 +26,12 @@
         :readonly="realReadonly"
         :disabled="realDisabled"
         :invalid="realInvalid"
+        :strict="realStrict.maxlength"
         v-bind="inputProps"
         v-on="inputEvents"
         @blur="props.closeSuggestions"
         @keydown="props.handleKeydown"
+        @change="handleChange(props)"
         @input="handleTrigger($event, props, 'input')"
         @focus="handleTrigger($event, props, 'focus')"
       />
@@ -86,7 +88,6 @@ const SHARED_PROPS = [
   'clearable',
   'maxlength',
   'getLength',
-  'strict',
   'trim'
 ]
 
@@ -114,6 +115,7 @@ export default {
       default: 'options'
     },
     autofocus: Boolean,
+    strict: [Boolean, Object],
     ...pick(Input.props, SHARED_PROPS)
   },
   computed: {
@@ -122,7 +124,7 @@ export default {
     },
     baseProps () {
       return {
-        ...omit(this.$props, [...SHARED_PROPS, 'suggestTrigger']),
+        ...omit(this.$props, [...SHARED_PROPS, 'suggestTrigger', 'strict']),
         ...this.$attrs
       }
     },
@@ -137,10 +139,19 @@ export default {
     },
     // strict 且没有定制 getLength，选中建议也遵循 input 的 strict 的行为
     isLimitSimpleLength () {
-      return this.getLength == null && this.realMaxlength != null && this.strict
+      return (
+        this.getLength == null &&
+        this.realMaxlength != null &&
+        this.realStrict.maxlength
+      )
     },
     realMaxlength () {
       return normalizeInt(this.maxlength)
+    },
+    realStrict () {
+      return typeof this.strict === 'boolean'
+        ? { maxlength: this.strict }
+        : this.strict
     }
   },
   methods: {
@@ -163,6 +174,17 @@ export default {
       }
       if (eventName === 'input') {
         props.updateValue(val)
+      }
+    },
+    handleChange (props) {
+      if (this.realStrict.select) {
+        const { filteredDatasource, updateValue, value } = props
+        if (
+          filteredDatasource.length === 0 ||
+          filteredDatasource.every(({ label }) => label !== value)
+        ) {
+          updateValue('')
+        }
       }
     }
   }

--- a/packages/veui/src/components/Autocomplete/_AutocompleteBase.vue
+++ b/packages/veui/src/components/Autocomplete/_AutocompleteBase.vue
@@ -3,10 +3,11 @@
   <slot
     :open-suggestions="openSuggestions"
     :close-suggestions="closeSuggestions"
-    :handleKeydown="handleSuggestionKeydown"
+    :handle-keydown="handleSuggestionKeydown"
     :update-value="inputUpdateValue"
     :value="realValue"
     :datasource="realDatasource"
+    :filtered-datasource="filteredDatasource"
     name="input"
   />
   <veui-overlay

--- a/packages/veui/test/unit/specs/components/Autocomplete.spec.js
+++ b/packages/veui/test/unit/specs/components/Autocomplete.spec.js
@@ -59,7 +59,8 @@ let componentOptions = {
       readonly: false,
       disabled: false,
       filter: null,
-      match: null
+      match: null,
+      strict: true
     }
   }
 }
@@ -133,7 +134,7 @@ describe('components/Autocomplete', function () {
       {
         ...componentOptions,
         template:
-          '<veui-autocomplete v-model="value" strict maxlength="7" suggest-trigger="focus" :datasource="groupedDatasource"/>'
+          '<veui-autocomplete v-model="value" :strict="strict" :maxlength="7" suggest-trigger="focus" :datasource="groupedDatasource"/>'
       },
       debugInBrowser
     )
@@ -158,13 +159,42 @@ describe('components/Autocomplete', function () {
     options.at(options.length - 1).trigger('click')
     await vm.$nextTick()
     expect(vm.value).to.equal(FOUR.slice(0, 6))
+
+    await input('Just a random input...', true)
+    expect(vm.value).to.equal('Just a random input...')
+
+    vm.strict = { select: true }
+
+    await input('Just a random input...', true)
+    expect(vm.value).to.equal('')
+
+    vm.strict = { maxlength: false }
+
+    await input('')
+    options = wrapper.findAll(SUGGESTION_ITEM)
+    options.at(options.length - 1).trigger('click')
+    await vm.$nextTick()
+    expect(vm.value).to.equal(FOUR)
+
+    vm.strict = { maxlength: true }
+
+    await input('')
+    options = wrapper.findAll(SUGGESTION_ITEM)
+    options.at(options.length - 1).trigger('click')
+    await vm.$nextTick()
+    expect(vm.value).to.equal(FOUR.slice(0, 6))
+
     wrapper.destroy()
 
-    async function input (val) {
+    async function input (val, change = false) {
       let nativeInput = wrapper.find(NATIVE_INPUT)
       nativeInput.trigger('focus')
       nativeInput.element.value = val
       nativeInput.trigger('input')
+      await vm.$nextTick()
+      if (change) {
+        nativeInput.trigger('change')
+      }
       await vm.$nextTick()
     }
   })


### PR DESCRIPTION
`strict` prop should control all component built-in validation or related features. Take `TagInput` as an example:

We have both `max` for tag count and `maxlength` for tag text length. The `strict` attribute can be a `boolean` or `{ max?: boolean, maxlength?: boolean }`. When it is a `boolean`, it is equivalent to enabling strict mode for both rules at the same time. We use `useStrict` to enforce consistency across different components.