### PR TITLE
feat: support theme for imperatively created components

### DIFF
--- a/packages/veui-theme-dls/components/toast-list.less
+++ b/packages/veui-theme-dls/components/toast-list.less
@@ -6,18 +6,7 @@
   align-items: center;
   flex-flow: column;
 
-  .@{veui-prefix}-toast {
-    .veui-transition(opacity, top, transform);
-    transform: translateY(0);
+  & > div {
     margin-bottom: @dls-toast-spacing;
-
-    &-enter,
-    &-leave-to {
-      opacity: 0;
-    }
-
-    &-enter {
-      transform: translateY(-100%);
-    }
   }
 }

--- a/packages/veui-theme-dls/components/toast.less
+++ b/packages/veui-theme-dls/components/toast.less
@@ -10,6 +10,17 @@
   background-color: @dls-toast-background-color;
   color: @dls-toast-font-color;
   box-shadow: @dls-toast-shadow;
+  transform: translateY(0);
+  .veui-transition(opacity, top, transform);
+
+  &-enter,
+  &-leave-to {
+    opacity: 0;
+  }
+
+  &-enter {
+    transform: translateY(-100%);
+  }
 
   &-multiline {
     .padding(@dls-toast-padding-y, _);

--- a/packages/veui/demo/cases/Plugins.vue
+++ b/packages/veui/demo/cases/Plugins.vue
@@ -14,6 +14,10 @@
 </template>
 
 <script>
+import config from '@/managers/config'
+
+config.set({ theme: 'ai' })
+
 export default {
   name: 'plugins-demo',
   components: {},
@@ -25,7 +29,7 @@ export default {
   methods: {
     handleToast () {
       this.$toast.info('我是提示', {
-        theme: 'ai'
+        theme: Math.random() > 0.5 ? 'd20' : 'ai'
       })
     },
     async handleRemove () {
@@ -53,8 +57,7 @@ export default {
           })
         },
         okLabel: '恢复它',
-        cancelLabel: '不恢复它',
-        theme: 'ai'
+        cancelLabel: '不恢复它'
       })
     },
     async handlePromptInput () {

--- a/packages/veui/demo/cases/Plugins.vue
+++ b/packages/veui/demo/cases/Plugins.vue
@@ -5,8 +5,9 @@
     <code>this.$confirm()</code>
   </h2>
   <section>
-    <button v-if="!removed" @click="handleButtonClick">删除我</button>
-    <button @click="handleButton2Click">👈🏻恢复它</button>
+    <button @click="handleToast">toast提示</button>
+    <button v-if="!removed" @click="handleRemove">删除我</button>
+    <button @click="handleRestore">👈🏻恢复它</button>
     <button @click="handlePromptInput">prompt输入</button>
   </section>
 </article>
@@ -22,39 +23,50 @@ export default {
     }
   },
   methods: {
-    async handleButtonClick () {
+    handleToast () {
+      this.$toast.info('我是提示', {
+        theme: 'ai'
+      })
+    },
+    async handleRemove () {
       let ok = await this.$confirm('是否确定删除？', '删除确认', {
-        okLabel: '删除'
+        okLabel: '删除',
+        theme: 'ai'
       })
       if (!ok) {
         return
       }
       this.removed = true
     },
-    async handleButton2Click () {
+    async handleRestore () {
       await this.$confirm('是否确定恢复它？', '恢复确认', {
         ok: () => {
           let wait = new Promise((resolve) => setTimeout(resolve, 1000))
           return wait.then(() => {
             if (Math.random() > 0.7) {
-              this.$toast.error('恢复失败')
+              this.$toast.error('恢复失败', {
+                theme: 'ai'
+              })
               return false
             }
             this.removed = false
           })
         },
         okLabel: '恢复它',
-        cancelLabel: '不恢复它'
+        cancelLabel: '不恢复它',
+        theme: 'ai'
       })
     },
     async handlePromptInput () {
       let input = await this.$prompt('请输入！', 'PROMPT', {
         okLabel: '输入',
         cancelLabel: '不输入',
-        value: '初始值'
+        value: '初始值',
+        theme: 'ai'
       })
       this.$alert(`prompt输入内容为:${input}`, 'title', {
-        okLabel: '收到'
+        okLabel: '收到',
+        theme: 'ai'
       })
     }
   }

--- a/packages/veui/demo/cases/Table.vue
+++ b/packages/veui/demo/cases/Table.vue
@@ -834,9 +834,9 @@ export default {
     // for (let i = 0; i < 300; i++) {
     //   this.append()
     // }
-    this.tick = setInterval(() => {
-      this.count += 1
-    }, 1000)
+    // this.tick = setInterval(() => {
+    //   this.count += 1
+    // }, 1000)
   },
   beforeDestroy () {
     clearInterval(this.tick)

--- a/packages/veui/src/components/Toast.vue
+++ b/packages/veui/src/components/Toast.vue
@@ -1,5 +1,5 @@
 <template>
-<transition :name="$c('toast')" appear>
+<transition :name="$c('toast')" :appear="appear">
   <div
     v-if="realOpen"
     :ui="realUi"
@@ -90,7 +90,8 @@ export default {
     open: Boolean,
     duration: {
       type: Number
-    }
+    },
+    appear: Boolean
   },
   data () {
     return {

--- a/packages/veui/src/components/ToastList.vue
+++ b/packages/veui/src/components/ToastList.vue
@@ -78,6 +78,7 @@ export default {
             title={m.title}
             ui={m.ui}
             duration={m.duration}
+            theme={m.theme}
             style={`top: ${m.top}px`}
             onClose={() => this.remove(m)}
             onReady={(e) => this.updateHeight(m, e)}

--- a/packages/veui/src/components/ToastList.vue
+++ b/packages/veui/src/components/ToastList.vue
@@ -72,6 +72,7 @@ export default {
           <Toast
             key={m.__message_id__}
             open
+            appear
             status={m.status || m.type}
             message={typeof m.message === 'string' ? m.message : null}
             closable={m.closable}

--- a/packages/veui/src/directives/tooltip.js
+++ b/packages/veui/src/directives/tooltip.js
@@ -1,7 +1,8 @@
 import { normalize } from 'vue-directive-normalizer'
 import tooltip from '../managers/tooltip'
 import { flatMap, pick } from 'lodash'
-import { isOverflow } from '../utils/dom'
+import { isOverflow, getClosestComponent } from '../utils/dom'
+import { findAncestor } from '../utils/helper'
 
 const OPTIONS_SCHEMA = {
   value: 'content',
@@ -33,6 +34,22 @@ function refresh (el, binding) {
     }
 
     if (!options.overflow || isOverflow(el)) {
+      const component = findAncestor(
+        getClosestComponent(el),
+        (current) => {
+          return (current.$options.name || '').indexOf('veui-') === 0
+        },
+        true
+      )
+
+      const theme =
+        component &&
+        (component.theme ||
+          (component.themeConfig && component.themeConfig.theme))
+      if (theme) {
+        options.theme = theme
+      }
+
       tooltip.enter(this, options)
     }
   }

--- a/packages/veui/src/managers/alert.js
+++ b/packages/veui/src/managers/alert.js
@@ -23,7 +23,8 @@ export class AlertManager extends SimpleDialogManager {
                 'status',
                 'type',
                 'overlayClass',
-                'okLabel'
+                'okLabel',
+                'theme'
               ]),
               open: this.open,
               beforeClose: () => false

--- a/packages/veui/src/managers/confirm.js
+++ b/packages/veui/src/managers/confirm.js
@@ -23,7 +23,8 @@ export class ConfirmManager extends SimpleDialog {
                 'title',
                 'overlayClass',
                 'okLabel',
-                'cancelLabel'
+                'cancelLabel',
+                'theme'
               ]),
               open: this.open,
               loading: this.loading,

--- a/packages/veui/src/managers/prompt.js
+++ b/packages/veui/src/managers/prompt.js
@@ -25,7 +25,8 @@ export class PromptManager extends SimpleDialog {
                 'title',
                 'overlayClass',
                 'okLabel',
-                'cancelLabel'
+                'cancelLabel',
+                'theme'
               ]),
               value: this.value,
               open: this.open,

--- a/packages/veui/src/managers/simple-dialog.js
+++ b/packages/veui/src/managers/simple-dialog.js
@@ -1,5 +1,6 @@
 import Vue from 'vue'
 import { remove } from 'lodash'
+import config from './config'
 
 export default class SimpleDialog {
   components = []
@@ -12,7 +13,10 @@ export default class SimpleDialog {
   }
 
   create (data) {
-    const component = this.createComponent(data)
+    const component = this.createComponent({
+      theme: config.get('theme'),
+      ...data
+    })
     const el = document.createElement('div')
     document.body.appendChild(el)
     component.$mount(el)

--- a/packages/veui/src/managers/toast.js
+++ b/packages/veui/src/managers/toast.js
@@ -48,6 +48,7 @@ export class ToastManager {
   }
 
   show (message, status) {
+    console.log(status)
     let options = {}
     if (isObject(message)) {
       options = { ...message }

--- a/packages/veui/src/managers/toast.js
+++ b/packages/veui/src/managers/toast.js
@@ -2,6 +2,7 @@ import Vue from 'vue'
 import { isString, isObject, isNumber } from 'lodash'
 import ToastList from '../components/ToastList'
 import warn from '../utils/warn'
+import config from './config'
 
 let Container = Vue.extend(ToastList)
 
@@ -22,11 +23,13 @@ export class ToastManager {
       this.init()
     }
 
+    const theme = config.get('theme')
+
     let messages = []
     if (Array.isArray(option)) {
-      messages = option.map((item) => this.container.add(item))
+      messages = option.map((item) => this.container.add({ theme, ...item }))
     } else if (isObject(option)) {
-      messages = [this.container.add(option)]
+      messages = [this.container.add({ theme, ...option })]
     } else {
       warn('[toast-manager] Invalid arguments for Toasts.')
     }
@@ -48,7 +51,6 @@ export class ToastManager {
   }
 
   show (message, status) {
-    console.log(status)
     let options = {}
     if (isObject(message)) {
       options = { ...message }

--- a/packages/veui/src/managers/tooltip.js
+++ b/packages/veui/src/managers/tooltip.js
@@ -1,7 +1,6 @@
 import Vue from 'vue'
 import { assign } from 'lodash'
 import Tooltip from '../components/Tooltip'
-import { prefixify } from '../mixins/prefix'
 import config from './config'
 
 config.defaults(
@@ -12,11 +11,7 @@ config.defaults(
   'tooltip'
 )
 
-export function createTooltipManager ({
-  warmup,
-  cooldown = warmup,
-  themeVariant
-} = {}) {
+export function createTooltipManager ({ warmup, cooldown = warmup } = {}) {
   let component = null
   let timer = null
   let currentTarget = null
@@ -96,7 +91,7 @@ export function createTooltipManager ({
     }
   }
 
-  function open (target, { position, content }) {
+  function open (target, { position, content, theme }) {
     let useDefault = typeof content === 'undefined'
 
     if (!target || (!content && !useDefault)) {
@@ -104,7 +99,7 @@ export function createTooltipManager ({
     }
 
     if (!component) {
-      component = createComponent({ themeVariant })
+      component = createComponent({ theme })
     }
 
     assign(component, {
@@ -129,7 +124,7 @@ export function createTooltipManager ({
   }
 }
 
-function createComponent ({ themeVariant }) {
+function createComponent ({ theme }) {
   const el = document.createElement('div')
   document.body.appendChild(el)
 
@@ -139,7 +134,8 @@ function createComponent ({ themeVariant }) {
         open: false,
         target: null,
         content: null,
-        position: null
+        position: null,
+        theme
       }
     },
     render (h) {
@@ -150,8 +146,9 @@ function createComponent ({ themeVariant }) {
             open: this.open,
             target: this.target,
             position: this.position,
+            theme: this.theme,
             trigger: 'custom',
-            overlayClass: prefixify('global-tooltip', themeVariant)
+            overlayClass: 'veui-global-tooltip'
           }
         },
         [h('template', { slot: 'default' }, this.content)]

--- a/packages/veui/src/utils/dom.js
+++ b/packages/veui/src/utils/dom.js
@@ -862,6 +862,32 @@ export function getPortalEntry (element) {
   return null
 }
 
+/**
+ * 获取最接近的Vue组件
+ *
+ * @param {Element} element 起始的元素
+ * @returns {Vue} 返回最接近的 Vue 组件，如果找不到则返回 null
+ */
+export function getClosestComponent (element) {
+  let current = element
+
+  while (!current.__vue__) {
+    current = current.parentNode
+
+    if (!current) {
+      return null
+    }
+  }
+
+  let component = current.__vue__
+
+  while (component.$children.length === 1) {
+    component = component.$children[0]
+  }
+
+  return component
+}
+
 export function trigger (el, type) {
   let evt = document.createEvent('HTMLEvents')
   evt.initEvent(type, true, false)

--- a/packages/veui/src/utils/helper.js
+++ b/packages/veui/src/utils/helper.js
@@ -35,8 +35,8 @@ export function getTypedAncestor (component, type, direct) {
   return null
 }
 
-export function findAncestor (component, predicate) {
-  let current = component.$parent
+export function findAncestor (component, predicate, includesSelf = false) {
+  let current = includesSelf ? component : component.$parent
   while (current) {
     if (predicate(current)) {
       return current

--- a/packages/veui/test/unit/specs/directives/tooltip.spec.js
+++ b/packages/veui/test/unit/specs/directives/tooltip.spec.js
@@ -1,4 +1,5 @@
 import { expectTooltip, mount, wait } from '../../../utils'
+import Button from '@/components/Button'
 import tooltip from '@/directives/tooltip'
 import tooltipManager from '@/managers/tooltip'
 import config from '@/managers/config'
@@ -329,6 +330,37 @@ describe('directives/tooltip', function () {
     expectTooltip('Bye')
 
     tooltipManager.destroy()
+
+    wrapper.destroy()
+  })
+
+  it('should respect the theme of the closest component', async () => {
+    let warmup = config.get('tooltip.warmup')
+
+    let wrapper = mount(
+      {
+        directives: { tooltip },
+        components: {
+          'veui-button': Button
+        },
+        template: `
+          <veui-button theme="ai">
+            <span class="a" v-tooltip="'Hi'">A</span>
+          </veui-button>`
+      },
+      {
+        sync: false,
+        attachToDocument: true
+      }
+    )
+
+    let a = wrapper.find('.a')
+
+    a.trigger('mouseenter')
+    await wait(warmup + 50)
+    expectTooltip('Hi', (tooltip) => {
+      expect(tooltip.matches('.veui-ai-tooltip-box')).to.equal(true)
+    })
 
     wrapper.destroy()
   })

--- a/packages/veui/test/utils.js
+++ b/packages/veui/test/utils.js
@@ -58,8 +58,12 @@ export function expectTooltip (content, position) {
     expect(tooltip).to.not.equal(null)
     expect(tooltip.textContent.trim()).to.equal(content)
 
-    if (position) {
+    if (typeof position === 'string') {
       expect(tooltip.getAttribute('x-placement')).to.equal(position)
+    }
+
+    if (typeof position === 'function') {
+      position(tooltip)
     }
   }
 }


### PR DESCRIPTION
* plugins: `$alert` / `$confirm` / `$prompt` / `$toast`

  * respect `theme` global config by default
  * can be overridden with `theme` option

* directive: `tooltip`

  * automatically derived from the theme of the target element's closest component

Made some other necessary changes for the above feature.