### PR TITLE
chore: update renovate github action

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@v40.1.10
+        uses: renovatebot/github-action@v46.1.13
         with:
           configurationFile: .github/renovate.json
           token: ${{ secrets.RENOVATE_TOKEN }}


### PR DESCRIPTION
Updates the self-hosted Renovate workflow from `renovatebot/github-action@v40.1.10` to `v46.1.13`.

This keeps the scheduled Renovate runner on the current GitHub Action wrapper while leaving the existing `.github/renovate.json` configuration and token wiring unchanged.